### PR TITLE
SimilarityTransforms added.

### DIFF
--- a/examples/pybug.transform.affine.ipynb
+++ b/examples/pybug.transform.affine.ipynb
@@ -26,6 +26,7 @@
       "                     [-0.80,  0.60,  0.00],\n",
       "                     [ 0.48,  0.64,  0.60]])\n",
       "scale = np.array([7,3, 15])\n",
+      "scale2 = np.ones(3)*-3.52\n",
       "translation = np.array([-1,20,3])"
      ],
      "language": "python",
@@ -37,7 +38,8 @@
      "collapsed": false,
      "input": [
       "r = Rotation(rotation)\n",
-      "s = Scale(scale)\n",
+      "nus = Scale(scale)  # NonUniformScale (Affine)\n",
+      "us = Scale(2, n_dim=3)  # UniformScale (Similarity)\n",
       "t = Translation(translation)"
      ],
      "language": "python",
@@ -65,7 +67,7 @@
      "cell_type": "code",
      "collapsed": false,
      "input": [
-      "print s"
+      "print nus"
      ],
      "language": "python",
      "metadata": {},
@@ -85,6 +87,24 @@
      "cell_type": "markdown",
      "metadata": {},
      "source": [
+      "All these are instances of `DiscreteAffineTransform`. That means we can ask any of these to invert themselves"
+     ]
+    },
+    {
+     "cell_type": "code",
+     "collapsed": false,
+     "input": [
+      "print us\n",
+      "print us.inverse"
+     ],
+     "language": "python",
+     "metadata": {},
+     "outputs": []
+    },
+    {
+     "cell_type": "markdown",
+     "metadata": {},
+     "source": [
       "All affine transforms can be chained together using the `chain(another_affine_transform)` method. This produces a new `AffineTransform`. Note that printing a general affine transform describes an equalivilent set of discrete affine transforms (that is, a sequence of discrete `Rotation`, `Translation` and `Scale` operations) that perform the same transform"
      ]
     },
@@ -92,7 +112,7 @@
      "cell_type": "code",
      "collapsed": false,
      "input": [
-      "rotation_followed_by_scale = r.chain(s)\n",
+      "rotation_followed_by_scale = r.chain(nus)\n",
       "print rotation_followed_by_scale"
      ],
      "language": "python",
@@ -115,6 +135,23 @@
       "result_of_chain = reduce(lambda x, y: x.chain(y), decomposed)\n",
       "print result_of_chain\n",
       "print 'Does chaining the decomposition do the same as the original? %s' % (result_of_chain == rotation_followed_by_scale)"
+     ],
+     "language": "python",
+     "metadata": {},
+     "outputs": []
+    },
+    {
+     "cell_type": "markdown",
+     "metadata": {},
+     "source": [
+      "Note that chaining `SimilarityTransform` objects together yields a `SimilarityTransform` instead."
+     ]
+    },
+    {
+     "cell_type": "code",
+     "collapsed": false,
+     "input": [
+      "print t.chain(us)"
      ],
      "language": "python",
      "metadata": {},


### PR DESCRIPTION
This adds numerous minor fixes (mainly to documentation) in the
transform.affine module, and introduces the concept of a
SimilarityTransform (ST). Chaining ST's together yields a new ST, so we
can easily confirm that rigid alignment algorithms yield ST's as end
products. To support this, Scale has been broken in two:
- UniformScale (SimilarityTransform, and hence AffineTransform)
- NonUniformScale (AffineTransform)

a new Scale factory has been made which intellegently returns the right
form of Scale based on the arguments provided.

Finally, the affine notebook has been updated to highlight these
changes.
