### PR TITLE
ignore ipython autosave

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,5 @@ pybug.egg-info/*
 .idea/*
 #we don't want to track cython generated cpp files
 #*.cpp
+# ignore IPython notebook autosave files
+.ipynb_checkpoints


### PR DESCRIPTION
IPython 1.0 has autosave, which is implemented using a hidden `.ipynb_checkpoint` folder in the directory the notebook is in. Never add these to git.
