### PR TITLE
trimesh and pointcloud tests

### DIFF
--- a/pybug/shape/mesh/trimish_test.py
+++ b/pybug/shape/mesh/trimish_test.py
@@ -1,0 +1,45 @@
+import numpy as np
+from pybug.shape import TriMesh
+
+
+def test_trimesh_creation():
+    points = np.array([[0, 0, 0],
+                       [1, 0, 0],
+                       [1, 1, 0],
+                       [0, 1, 0]])
+    trilist = np.array([[0, 1, 3],
+                        [1, 2, 3]])
+    TriMesh(points, trilist)
+
+
+def test_trimesh_n_dims():
+    points = np.array([[0, 0, 0],
+                       [1, 0, 0],
+                       [1, 1, 0],
+                       [0, 1, 0]])
+    trilist = np.array([[0, 1, 3],
+                        [1, 2, 3]])
+    trimesh = TriMesh(points, trilist)
+    assert(trimesh.n_dims == 3)
+
+
+def test_trimesh_n_points():
+    points = np.array([[0, 0, 0],
+                       [1, 0, 0],
+                       [1, 1, 0],
+                       [0, 1, 0]])
+    trilist = np.array([[0, 1, 3],
+                        [1, 2, 3]])
+    trimesh = TriMesh(points, trilist)
+    assert(trimesh.n_points == 4)
+
+
+def test_trimesh_n_tris():
+    points = np.array([[0, 0, 0],
+                       [1, 0, 0],
+                       [1, 1, 0],
+                       [0, 1, 0]])
+    trilist = np.array([[0, 1, 3],
+                        [1, 2, 3]])
+    trimesh = TriMesh(points, trilist)
+    assert(trimesh.n_tris == 2)

--- a/pybug/shape/pointcloud_test.py
+++ b/pybug/shape/pointcloud_test.py
@@ -1,0 +1,22 @@
+import numpy as np
+from pybug.shape import PointCloud
+
+
+def test_pointcloud_creation():
+    points = np.array([[1, 2, 3],
+                       [1, 1, 1]])
+    PointCloud(points)
+
+
+def test_pointcloud_n_dims():
+    points = np.array([[1, 2, 3],
+                       [1, 1, 1]])
+    pc = PointCloud(points)
+    assert(pc.n_dims == 3)
+
+
+def test_pointcloud_n_points():
+    points = np.array([[1, 2, 3],
+                       [1, 1, 1]])
+    pc = PointCloud(points)
+    assert(pc.n_points == 2)


### PR DESCRIPTION
Adds some tests for the basic creation of `PointCloud` and `TriMesh` instances. For now the tests rest in the main pybug package, alongside the modules that are tested (as is already done with `pybug.transform` tests)
