### PR TITLE
pybug.data_path_to(data_item)

### DIFF
--- a/examples/Basic Lucas-Kanade.ipynb
+++ b/examples/Basic Lucas-Kanade.ipynb
@@ -27,9 +27,11 @@
      "collapsed": false,
      "input": [
       "from pybug.io import auto_import\n",
+      "from pybug import data_path_to\n",
       "import numpy as np\n",
       "\n",
-      "takeo = auto_import('../data/takeo.ppm')[0]\n",
+      "takeo_path = data_path_to('takeo.ppm')\n",
+      "takeo = auto_import(takeo_path)[0]\n",
       "takeo.view()"
      ],
      "language": "python",

--- a/examples/pybug.model.linear.PCAModel.ipynb
+++ b/examples/pybug.model.linear.PCAModel.ipynb
@@ -20,8 +20,8 @@
      "input": [
       "import scipy.io as sio\n",
       "from pybug.image import Image\n",
-      "import os.path\n",
-      "im_db = sio.loadmat(os.path.abspath('../data/alignedbwfaces.mat'))\n",
+      "from pybug import data_path_to\n",
+      "im_db = sio.loadmat(data_path_to('alignedbwfaces.mat'))\n",
       "imagedata = im_db['images']\n",
       "mask = im_db['mask']\n",
       "images = []\n",

--- a/pybug/__init__.py
+++ b/pybug/__init__.py
@@ -1,0 +1,13 @@
+import os.path
+
+
+def pybug_src_dir_path():
+    return os.path.split(os.path.abspath(__file__))[0][:-5]
+
+
+def data_dir_path():
+    return os.path.join(pybug_src_dir_path(), 'data')
+
+
+def data_path_to(data):
+    return os.path.join(data_dir_path(), data)

--- a/pybug/io/io_test.py
+++ b/pybug/io/io_test.py
@@ -1,9 +1,9 @@
-#from pybug.io.mesh import AssimpImporter
 from pybug.io import auto_import
 from pybug.shape import TriMesh
+from pybug import data_path_to
 
 
 def test_assimp_obj_import():
-    meshes = auto_import('./data/bunny.obj')
+    meshes = auto_import(data_path_to('bunny.obj'))
     mesh = meshes[0]
     assert(isinstance(mesh, TriMesh))


### PR DESCRIPTION
Adds a method to the top level of the pybug package that returns the full path to the data folder.

Note that this will only work for development environments which are `pip install -e`'d, but means we can write tests that use data in the data folder without worrying about where the python interpreter running `nosetests` is launched from.
