### PR TITLE
Sort filepaths when autoimporting

### DIFF
--- a/pybug/io/base.py
+++ b/pybug/io/base.py
@@ -70,7 +70,8 @@ def _multi_import(filepaths, extensions_map, keep_importers=False):
     object_count = len(filepaths)
     importers = []
 
-    for i, (f, ext) in enumerate(filepaths):
+    # Loop over the sorted filepaths (keeps logical filepath order)
+    for i, (f, ext) in enumerate(sorted(filepaths)):
         importer_type = extensions_map.get(ext)
         importers.append(importer_type(f))
         # Cheeky carriage return so we print on the same line


### PR DESCRIPTION
Makes it much easier to process a list of objects according to
the filepath ordering. For example, importing images and their
landmarks manually means you can import them both as lists
and zip them together sensibly.
