### PR TITLE
method to provide tcoords like Image landmarks

### DIFF
--- a/pybug/shape/mesh/textured.py
+++ b/pybug/shape/mesh/textured.py
@@ -31,17 +31,35 @@ class TexturedTriMesh(TriMesh):
 
     def tcoords_pixel_scaled(self):
         r"""
-        Returns a PointCloud that is scaled to be suitable for directly
+        Returns a PointCloud that is modified to be suitable for directly
         indexing into the pixels of the texture (e.g. for manual mapping
-        operations).
+        operations). The resulting tcoords behave just like image landmarks
+        do:
+
+         >>> texture = texturedtrimesh.texture
+         >>> tc_ps = texturedtrimesh.tcoords_pixel_scaled()
+         >>> pixel_values_at_tcs = texture[tc_ps[: ,0], tc_ps[:, 1]]
+
+        The operations that are performed are:
+
+        - Flipping the origin from bottom-left to top-left
+        - Scaling the tcoords by the image shape (denormalising them)
+        - Permuting the axis so that
 
         Returns
         -------
         tcoords_scaled : :class:`pybug.shape.PointCloud`
-            A scaled version of the tcoords.
+            A copy of the tcoords that behave like Image landmarks
         """
         scale = Scale(np.array(self.texture.shape)[::-1])
-        return PointCloud(scale.apply(self.tcoords.points))
+        tcoords = self.tcoords.points.copy()
+        # flip the 'y' st 1 -> 0 and 0 -> 1, moving the axis to upper left
+        tcoords[:, 1] = 1 - tcoords[:, 1]
+        # apply the scale to get the units correct
+        tcoords = scale.apply(tcoords)
+        # flip axis 0 and axis 1 so indexing is as expected
+        tcoords = tcoords[:, ::-1]
+        return PointCloud(tcoords)
 
     def _view(self, figure_id=None, new_figure=False, textured=True, **kwargs):
         r"""


### PR DESCRIPTION
Sometimes it is desirable to manipulate texture coords on a `TexturedTriMesh` as if they were landmarks on an `Image` class. We currently (and consistently) ensure that Image landmarks are converted from whatever scheme the landmark files uses to our own standard, which makes most sense for mapping into image pixels:

```
image = Image(...)
lm = image.landmarks['SOMEKEY'].all_landmarks()
pixel_values_at_landmark_positions = image.pixels[lm[:, 0], lm[:, 1]]
```

This makes a lot of sense, and removes lots of the head scratching that is encountered when dealing with image landmarks (are they `(x,y)` or `(y,x)`? Is the `y` dimension actually axis 0? Are they normalized to 0-1?...)

Unfortunately, tcoords are always in a consistent format which is different to the one outlined above. In particular:
1. They are normalised
2. The lower-left corner of the image is considered the origin
3. They are given as `[axis_1, axis_0]`

This is the format demanded by OpenGL, so we probably don't want to change the actual state of the `tcoords` property on `TexturedTriMesh`. Saying all that, there are occasisions when you want to be able to treat the texture coords just like any other image landmark. This PR adds the `tcoords_pixel_scaled()` method on `TexturedTriMesh`. The `PointCloud` that it generates is simply the tcoords reinterpreted as if they were image landmarks, so they fit in nicely with the scheme above.
