### PR TITLE
Convenience method for point-wise distance between two PointClouds

### DIFF
--- a/pybug/shape/pointcloud.py
+++ b/pybug/shape/pointcloud.py
@@ -131,6 +131,6 @@ class PointCloud(Shape):
             PointCloud.
         """
         if self.n_dims != pointcloud.n_dims:
-            raise Exception("The two PointClouds must be of the same "
-                            "dimensionality.")
+            raise ValueError("The two PointClouds must be of the same "
+                             "dimensionality.")
         return cdist(self.points, pointcloud.points, **kwargs)


### PR DESCRIPTION
A thin wrapper around `scipy.spatial.distance.cdist` for `PointCloud`.

Adding methods like this provide a convenient way to do basic geometric operations on our types without having to strip out the raw data (`.points`) all the time.
