### PR TITLE
added boundary methods to PointCloud

### DIFF
--- a/pybug/shape/pointcloud.py
+++ b/pybug/shape/pointcloud.py
@@ -58,9 +58,9 @@ class PointCloud(Shape):
 
     def from_vector(self, flattened):
         r"""
-        Builds a new pointcoloud given then ``flattened`` vector. This allows
-        rebuilding pointclouds with the correct number of dimensions from a
-        vector.
+        Builds a new :class:`PointCloud` given then ``flattened`` vector.
+        This allows rebuilding pointclouds with the correct number of
+        dimensions from a vector.
 
         Parameters
         ----------
@@ -89,9 +89,9 @@ class PointCloud(Shape):
 
     def max_min_bounds(self, boundary=0):
         r"""
-        The maximum and minimum extent of the `pybug
-        .shape.pointcloud.PointCloud`. An optional boundary argument can be
-        provided to expand the bounds by a constant margin.
+        The maximum and minimum extent of the :class:`PointCloud`.
+        An optional boundary argument can be provided to expand the bounds
+        by a constant margin.
 
         Parameters
         ----------
@@ -103,12 +103,12 @@ class PointCloud(Shape):
         Returns
         --------
         max_b : (D,) ndarray
-            The maximum extent of the PointCloud and boundary along each
-            dimension
+            The maximum extent of the :class:`PointCloud` and boundary along
+            each dimension
 
         min_b : (D,) ndarray
-            The minimum extent of the PointCloud and boundary along each
-            dimension
+            The minimum extent of the :class:`PointCloud` and boundary along
+            each dimension
         """
         max_b = np.max(self.points, axis=0) + boundary
         min_b = np.min(self.points, axis=0) - boundary
@@ -116,12 +116,12 @@ class PointCloud(Shape):
 
     def range_bounds(self):
         r"""
-        The range of the extent of the `pybug.shape.pointcloud.PointCloud`.
+        The range of the extent of the :class:`PointCloud`.
 
         Returns
         --------
         range_b : (D,) ndarray
-            The range of the PointCloud's extent in each dimension.
+            The range of the :class:`PointCloud`s extent in each dimension.
         """
         max_b, min_b = self.max_min_bounds()
         return max_b - min_b


### PR DESCRIPTION
Two new methods on `PointCloud` for computing the range of the `PointCloud`s extent in each dimension, and the max and min values of the `PointCloud` in each dimension.
