### PR TITLE
adds max_images and max_meshes to auto_import

### DIFF
--- a/pybug/io/base.py
+++ b/pybug/io/base.py
@@ -5,7 +5,8 @@ import sys
 
 
 def auto_import(pattern, meshes=True, images=True,
-                include_texture_images=False):
+                include_texture_images=False,
+                max_meshes=None, max_images=None):
     r"""
     Smart data importer. Will match all files found on the glob pattern
     passed in, build the relevant importers, and then call ``build()`` on them
@@ -33,6 +34,16 @@ def auto_import(pattern, meshes=True, images=True,
         If this is the case, it won't import these images separately.
 
         Default: ``False``
+    max_meshes: positive integer, optional
+        If not ``None``, only import the first max_mesh meshes found. Else,
+        import all.
+
+        Default: ``None``
+    max_images: positive integer, optional
+        If not ``None``, only import the first max_images found. Else,
+        import all.
+
+        Default: ``None``
 
     Examples
     --------
@@ -54,10 +65,14 @@ def auto_import(pattern, meshes=True, images=True,
     mesh_objects, image_objects = [], []
     if meshes:
         mesh_paths = _glob_matching_extension(pattern, mesh_types)
+        if max_meshes:
+            mesh_paths = mesh_paths[:max_meshes]
         mesh_objects, mesh_importers = _multi_mesh_import(mesh_paths,
                                                           keep_importers=True)
     if images:
         image_files = _glob_matching_extension(pattern, image_types)
+        if max_images:
+            image_files = image_files[:max_images]
         if meshes and not include_texture_images:
             texture_paths = [m.texture_path for m in mesh_importers
                              if m.texture_path is not None]


### PR DESCRIPTION
sometimes you have a folder which is a large bag of data, but for testing purposes you just want to import maybe 10 instances for now. You could

a. Copy some of the data into a different folder so it's easy to glob - PITA
b. Wait to auto_import everything in the folder then just strip off 10 - expensive

Now, just use the `max_images` and `max_meshes` kwargs.

```
no_more_than_10_meshes = auto_import('./datafolder/*, max_meshes=10)
```

Note this only sets a maximum, if `auto_import` finds only 8 instances that's fine - you'll just get 8 instances back.
