### PR TITLE
Multiple channel LSIntensity Residual

### DIFF
--- a/pybug/align/lucaskanade/residual.py
+++ b/pybug/align/lucaskanade/residual.py
@@ -179,11 +179,11 @@ class LSIntensity(Residual):
 
         # reshape gradient
         # gradient:  n_pixels  x  n_channels  x  n_dims
-        gradient = np.reshape(gradient, (gradient.shape[0], -1, 2))
+        gradient = np.reshape(gradient, (gradient.shape[0], -1, image.n_dims))
 
         # compute steepest descent images
-        # gradient:  n_pixels  x  n_channels  x      _     x  n_dims
-        # dW_dp:     n_pixels  x       _      x  n_params  x  n_dims
+        # gradient:  n_pixels  x  n_channels  x            x  n_dims
+        # dW_dp:     n_pixels  x              x  n_params  x  n_dims
         # sdi:       n_pixels  x  n_channels  x  n_params
         sdi = np.sum(dW_dp[:, None, :, :] * gradient[:, :, None, :], axis=3)
 


### PR DESCRIPTION
Adapts the computation of the `steepest descent images` in the `LSIntensity` subclass so that it effectively deals with images containing multiple channels.

Note that all other `Residual` subclasses will also need to account for this in a near future.
