### PR TITLE
makes trilist optional to pwa, default to Delaunay

### DIFF
--- a/examples/pybug.transform.piecewiseaffine.ipynb
+++ b/examples/pybug.transform.piecewiseaffine.ipynb
@@ -36,14 +36,22 @@
       "              [-1.0, -0.01], [1.0, -0.4], [0.8, -1.6]])\n",
       "tl = np.array([[0,2,1], [1,3,2]])\n",
       "\n",
-      "slow_pwa = DiscreteAffinePWATransform(a,b,tl)\n",
-      "fast_pwa = CachedPWATransform(a,b,tl)\n",
+      "slow_pwa = DiscreteAffinePWATransform(a, b,tl)\n",
+      "fast_pwa = CachedPWATransform(a, b, tl)\n",
       "# pwa is just a CachedPWATransform alias\n",
-      "pwa = PiecewiseAffineTransform(a,b,tl)"
+      "# no trilist results in Delaunay being used.\n",
+      "pwa = PiecewiseAffineTransform(a, b)"
      ],
      "language": "python",
      "metadata": {},
      "outputs": []
+    },
+    {
+     "cell_type": "markdown",
+     "metadata": {},
+     "source": [
+      "Note that if the trilist is omitted, a Delaunay triangulation of the source points is used instead."
+     ]
     },
     {
      "cell_type": "markdown",

--- a/pybug/transform/piecewiseaffine.py
+++ b/pybug/transform/piecewiseaffine.py
@@ -1,5 +1,6 @@
 import abc
 import numpy as np
+from scipy.spatial import Delaunay
 from pybug.exceptions import DimensionalityError
 from pybug.shape import TriMesh
 from pybug.transform import AffineTransform, Transform
@@ -36,8 +37,10 @@ class AbstractPWATransform(Transform):
         The source points.
     target : (N, 2) ndarray
         The target points.
-    trilist : (M, 3) ndarray
+    trilist : (M, 3) ndarray, optional
         A common triangulation for the ``source`` and ``target``.
+
+        Default: Delaunay triangulation of the source
 
     Raises
     ------
@@ -51,7 +54,9 @@ class AbstractPWATransform(Transform):
 
     __metaclass__ = abc.ABCMeta
 
-    def __init__(self, source, target, trilist):
+    def __init__(self, source, target, trilist=None):
+        if trilist is None:
+            trilist = Delaunay(source).simplices
         self.source = TriMesh(source, trilist)
         self.target = TriMesh(target, trilist)
         self.n_dims = self.source.n_dims
@@ -248,8 +253,10 @@ class DiscreteAffinePWATransform(AbstractPWATransform):
         The source points.
     target : (N, 2) ndarray
         The target points.
-    trilist : (M, 3) ndarray
+    trilist : (M, 3) ndarray, optional
         A common triangulation for the ``source`` and ``target``.
+
+        Default: Delaunay triangulation of the source
 
     Raises
     ------
@@ -259,7 +266,7 @@ class DiscreteAffinePWATransform(AbstractPWATransform):
         Source and target must be 2D.
     """
 
-    def __init__(self, source, target, trilist):
+    def __init__(self, source, target, trilist=None):
         super(DiscreteAffinePWATransform, self).__init__(
             source, target, trilist)
         self._produce_affine_transforms_per_tri()
@@ -469,9 +476,10 @@ class CachedPWATransform(AbstractPWATransform):
         The source points.
     target : (N, 2) ndarray
         The target points.
-    trilist : (M, 3) ndarray
+    trilist : (M, 3) ndarray, optional
         A common triangulation for the ``source`` and ``target``.
 
+        Default: Delaunay triangulation of the source
     Raises
     ------
     DimensionalityError
@@ -480,17 +488,18 @@ class CachedPWATransform(AbstractPWATransform):
         Source and target must be 2D.
     """
 
-    def __init__(self, source, target, trilist):
+    def __init__(self, source, target, trilist=None):
         super(CachedPWATransform, self).__init__(source, target,
                                                  trilist)
-        t = target[trilist]
+        t = target[self.trilist]
         # get vectors ij ik for the target
         self.tij, self.tik = t[:, 1] - t[:, 0], t[:, 2] - t[:, 0]
         # target i'th vertex positions
         self.ti = t[:, 0]
         # make sure the source and target satisfy the c requirements
         source_c = np.require(source, dtype=np.float64, requirements=['C'])
-        trilist_c = np.require(trilist, dtype=np.uint32, requirements=['C'])
+        trilist_c = np.require(self.trilist, dtype=np.uint32,
+                               requirements=['C'])
         # build the cython wrapped C object and store it locally
         self._fastpwa = CLookupPWA(source_c, trilist_c)
 


### PR DESCRIPTION
Quite often when calculating Piecewise Affine, the triangulation is calculated from Delaunay. Now, `trilist` is an optional argument to PWA - if it's not passed, a Delaunay triangluation of the source is used for the trilist.
