### PR TITLE
lazy instantiation of all viewers

### DIFF
--- a/pybug/visualize/viewmatplotlib.py
+++ b/pybug/visualize/viewmatplotlib.py
@@ -1,5 +1,3 @@
-import matplotlib.pyplot as plt
-import matplotlib.cm as cm
 import numpy as np
 import abc
 from pybug.visualize.base import Renderer
@@ -35,6 +33,7 @@ class MatplotlibRenderer(Renderer):
         figure : Matplotlib figure object
             The figure we will be rendering on.
         """
+        import matplotlib.pyplot as plt
         if self.new_figure or self.figure_id is not None:
             self.figure = plt.figure(self.figure_id)
         else:
@@ -52,6 +51,8 @@ class MatplotlibImageViewer2d(MatplotlibRenderer):
         self.image = image
 
     def _render(self, **kwargs):
+        import matplotlib.pyplot as plt
+        import matplotlib.cm as cm
         if len(self.image.shape) == 2 or self.image.shape[2] == 1:
             im = self.image
             im = im if len(im.shape) == 2 else im[..., 0]
@@ -71,6 +72,7 @@ class MatplotlibPointCloudViewer2d(MatplotlibRenderer):
 
     def _render(self, image_view=False, cmap=None,
                       colour_array='b', label=None, **kwargs):
+        import matplotlib.pyplot as plt
         # Flip x and y for viewing if points are tied to an image
         points = self.points[:, ::-1] if image_view else self.points
         plt.scatter(points[:, 0], points[:, 1], cmap=cmap,
@@ -86,6 +88,7 @@ class MatplotlibTriMeshViewer2d(MatplotlibRenderer):
         self.trilist = trilist
 
     def _render(self, image_view=False, label=None, **kwargs):
+        import matplotlib.pyplot as plt
         # Flip x and y for viewing if points are tied to an image
         points = self.points[:, ::-1] if image_view else self.points
         plt.triplot(points[:, 0], points[:, 1], self.trilist,
@@ -102,6 +105,8 @@ class MatplotlibLandmarkViewer2d(MatplotlibRenderer):
         self.landmark_dict = landmark_dict
 
     def _plot_landmarks(self, include_labels, image_view, **kwargs):
+        import matplotlib.pyplot as plt
+        import matplotlib.cm as cm
         colours = kwargs.get('colours',
                              np.random.random([3, len(self.landmark_dict)]))
         halign = kwargs.get('halign', 'center')

--- a/pybug/visualize/viewmayavi.py
+++ b/pybug/visualize/viewmayavi.py
@@ -1,7 +1,5 @@
-from mayavi import mlab
-from tvtk.api import tvtk
-import numpy as np
 import abc
+import numpy as np
 from pybug.visualize.base import Renderer
 
 
@@ -35,6 +33,7 @@ class MayaviViewer(Renderer):
         figure : Mayavi figure object
             The figure we will be rendering on.
         """
+        from mayavi import mlab
         if self.new_figure or self.figure_id is not None:
             self.figure = mlab.figure(self.figure_id)
         else:
@@ -52,6 +51,7 @@ class MayaviPointCloudViewer3d(MayaviViewer):
         self.points = points
 
     def _render(self, **kwargs):
+        from mayavi import mlab
         mlab.points3d(
             self.points[:, 0], self.points[:, 1], self.points[:, 2],
             figure=self.figure, scale_factor=1)
@@ -66,6 +66,7 @@ class MayaviLandmarkViewer3d(MayaviViewer):
         self.landmark_dict = landmark_dict
 
     def _render(self, **kwargs):
+        from mayavi import mlab
         # disabling the rendering greatly speeds up this for loop
         self.figure.scene.disable_render = True
         positions = []
@@ -73,7 +74,8 @@ class MayaviLandmarkViewer3d(MayaviViewer):
             for i, p in enumerate(pcloud.points):
                 positions.append(p)
                 l = '%s_%d' % (label, i)
-                # TODO: This is due to a bug in mayavi that won't allow rendering text to an empty figure
+                # TODO: This is due to a bug in mayavi that won't allow
+                # rendering text to an empty figure
                 mlab.points3d(p[0], p[1], p[2])
                 mlab.text3d(p[0], p[1], p[2], l, figure=self.figure)
         positions = np.array(positions)
@@ -94,6 +96,7 @@ class MayaviTriMeshViewer3d(MayaviViewer):
         self.trilist = trilist
 
     def _render(self, normals=None, **kwargs):
+        from mayavi import mlab
         if normals is not None:
             MayaviVectorViewer3d(self.figure_id, False,
                                  self.points, normals)._render(**kwargs)
@@ -118,6 +121,7 @@ class MayaviTexturedTriMeshViewer3d(MayaviViewer):
         self.tcoords_per_point = tcoords_per_point
 
     def _render(self, normals=None, **kwargs):
+        from tvtk.api import tvtk
         if normals is not None:
             MayaviVectorViewer3d(self.figure_id, False,
                                  self.points, normals)._render(**kwargs)
@@ -150,6 +154,7 @@ class MayaviVectorViewer3d(MayaviViewer):
         self.vectors = vectors
 
     def _render(self, **kwargs):
+        from mayavi import mlab
         # Only get every nth vector. 1 means get every vector.
         mask_points = kwargs.get('mask_points', 1)
         mlab.quiver3d(self.points[:, 0],


### PR DESCRIPTION
All imports of visualisation modules has been pushed down into the methods on the viewers that are called only when a view of data is requested. This means that importing are own package doesn't lead to chain importing of the whole of `tvtk`, `mayavi`, and `matplotlib`. This shaves a good amount of time off our initial `pybug` import time, and means that `pybug` can be easily run on platforms that don't have viewing support in a more headless mode.
