### PR TITLE
MDTransform fixes and additions

### DIFF
--- a/pybug/model/base.py
+++ b/pybug/model/base.py
@@ -1,29 +1,26 @@
 import abc
 
 
-# TODO: this class seems a bit bare? Needs to be documented better.
 class StatisticalModel(object):
     r"""
-    Abstract base class representing a statistical model.
+    Abstract interface for a model that is constructed from a set of sample
+    data
     """
 
     __metaclass__ = abc.ABCMeta
-    samples = None
+
+    def __init__(self, samples):
+        self.samples = samples
 
     @property
-    def sample_data_class(self):
-        r"""
-        The class of the sample data
-
-        :type: class type
-        """
-        return self.template_sample.__class__
-
-    @property
-    def template_sample(self):
+    def template_instance(self):
         r"""
         The first sample.
 
-        :type: ``self.sample_data_class``
+        :type: ``self.instance_class``
         """
         return self.samples[0]
+
+    @property
+    def n_samples(self):
+        return len(self.samples)

--- a/pybug/transform/modeldriven.py
+++ b/pybug/transform/modeldriven.py
@@ -537,7 +537,7 @@ class GlobalMDTransform(ModelDrivenTransform):
         # by application of the chain rule dX_db is the Jacobian of the
         # model transformed by the linear component of the global transform
         dS_db = model_jacobian
-        dX_dS = self._global_transform_jacobian_points(
+        dX_dS = self.global_transform.jacobian_points(
             self.model.mean.points)
         dX_db = np.einsum('ilj, idj -> idj', dX_dS, dS_db)
         # dS_db:  n_points  x     n_weights     x  n_dims
@@ -556,9 +556,6 @@ class GlobalMDTransform(ModelDrivenTransform):
 
     def _global_transform_jacobian(self, points):
         return self.global_transform.jacobian(points)
-
-    def _global_transform_jacobian_points(self, points):
-        return self.global_transform.jacobian_points(points)
 
     def as_vector(self):
         r"""


### PR DESCRIPTION
- Adds the concept of a `SimilarityModel`. An equivalent parametrization of a similarity transform around a specific set of points.
- Adds a subclass of `GlobalMDTransform`, called `OrthoMDTransform`, which internally builds `SimilarityTransform` objects using a `SimilarityModel`.
