### PR TITLE
copy data on building images

### DIFF
--- a/pybug/image/base.py
+++ b/pybug/image/base.py
@@ -61,7 +61,7 @@ class AbstractNDImage(Vectorizable, Landmarkable, Viewable):
             raise ValueError("Abstract Images have to build from at least 3D"
                              " image data arrays (2D + n_channels) - a {} "
                              "dim array was provided".format(image_data.ndim))
-        self.pixels = image_data
+        self.pixels = image_data.copy()
 
     @classmethod
     def _init_with_channel(cls, image_data_with_channel):


### PR DESCRIPTION
As it currently stands, Images don't copy their data on construction, which sounds pretty dangerous.

I think a copy here on assignment might be a good idea especially after the recent maintaining-references - bugs thoughts?
