### PR TITLE
transfer lms on image.from_vector()

### DIFF
--- a/pybug/image/boolean.py
+++ b/pybug/image/boolean.py
@@ -152,7 +152,7 @@ class BooleanNDImage(AbstractNDImage):
         rebuilding a boolean image **itself** from boolean values. The mask
         is in no way interpreted in performing the operation, in contrast to
         MaskedNDImage, where only the masked region is used in from_vector()
-        and as_vector().
+        and as_vector(). Any image landmarks are transferred in the process.
 
         Parameters
         ----------
@@ -164,7 +164,9 @@ class BooleanNDImage(AbstractNDImage):
         image : :class:`BooleanNDImage`
             New BooleanImage of same shape as this image
         """
-        return BooleanNDImage(flattened.reshape(self.shape))
+        mask = BooleanNDImage(flattened.reshape(self.shape))
+        mask.landmarks = self.landmarks
+        return mask
 
     def invert(self):
         r"""

--- a/pybug/image/masked.py
+++ b/pybug/image/masked.py
@@ -186,6 +186,8 @@ class MaskedNDImage(AbstractNDImage):
         channel to an image but maintain the shape. For example, when
         calculating the gradient.
 
+        Note that landmarks are transferred in the process.
+
         Parameters
         ----------
         flattened : (``n_pixels``,)


### PR DESCRIPTION
Hotfix so that rebuilding images `from_vector()` keeps the image's landmarks.
