### PR TITLE
Allow for Similarity without rotation alignment between source and target

### DIFF
--- a/pybug/transform/affine.py
+++ b/pybug/transform/affine.py
@@ -526,7 +526,7 @@ class SimilarityTransform(AffineTransform):
             The target pointcloud instance used in the alignment
 
         rotation: boolean, optional
-            If False, the rotation part of the similarity transform is not
+            If False, the rotation component of the similarity transform is not
             inferred.
 
             Default: True


### PR DESCRIPTION
This pull request introduces a `kwarg` `rotation` in the methods `_align` and `_procrustes_alignment` of the `SimilarityTransform` class so that it is possible to recover the `SimilarityTransform` that perfectly aligns `source`  and `target` without its `rotation` component
