### PR TITLE
tojson()

### DIFF
--- a/pybug/shape/mesh/base.py
+++ b/pybug/shape/mesh/base.py
@@ -34,18 +34,17 @@ class TriMesh(PointCloud):
         return '{}, n_tris: {}'.format(PointCloud.__str__(self),
                                        self.n_tris)
 
-    def toJSON(self):
+    def tojson(self):
         r"""
         Convert this TriMesh to a dictionary JSON representation.
 
         Returns
         -------
-        dictionary with 'points' and 'trilist' lists suitable for use in the
-        by the json standard library.
+        dictionary with 'points' and 'trilist' keys. Both are lists suitable
+        for use in the by the `json` standard library package.
         """
-        json_dict = {'points': self.points.tolist(),
-                     'trilist': self.trilist.tolist()}
-        return json_dict
+        return {'points': self.points.tolist(),
+                'trilist': self.trilist.tolist()}
 
     def from_vector(self, flattened):
         r"""


### PR DESCRIPTION
Adds a method on `TriMesh` that returns a simple dictionary representation of the `TriMesh`. This is needed for the Landmarker and more generally the PyBug web API going forwards.
