### PR TITLE
tojson on PointCloud and TriMesh

### DIFF
--- a/pybug/shape/mesh/base.py
+++ b/pybug/shape/mesh/base.py
@@ -36,15 +36,16 @@ class TriMesh(PointCloud):
 
     def tojson(self):
         r"""
-        Convert this TriMesh to a dictionary JSON representation.
+        Convert this `TriMesh` to a dictionary JSON representation.
 
         Returns
         -------
         dictionary with 'points' and 'trilist' keys. Both are lists suitable
         for use in the by the `json` standard library package.
         """
-        return {'points': self.points.tolist(),
-                'trilist': self.trilist.tolist()}
+        json_dict = PointCloud.tojson(self)
+        json_dict['trilist'] = self.trilist.tolist()
+        return json_dict
 
     def from_vector(self, flattened):
         r"""

--- a/pybug/shape/pointcloud.py
+++ b/pybug/shape/pointcloud.py
@@ -64,6 +64,17 @@ class PointCloud(Shape):
         """
         return self.points.flatten()
 
+    def tojson(self):
+        r"""
+        Convert this `PointCloud` to a dictionary JSON representation.
+
+        Returns
+        -------
+        dict with a 'points' key, the value of which is a list suitable
+        for use in the by the `json` standard library package.
+        """
+        return {'points': self.points.tolist()}
+
     def from_vector_inplace(self, vector):
         r"""
         Updates this PointCloud in-place with a new vector of parameters


### PR DESCRIPTION
Adds a method on `PointCloud` and `TriMesh` that returns a simple dictionary representation of the shape. This is needed for the Landmarker and more generally the PyBug web API going forwards.
