### PR TITLE
Fixes important LK bug introduced by aambuilder

### DIFF
--- a/pybug/lucaskanade/appearance/adaptive.py
+++ b/pybug/lucaskanade/appearance/adaptive.py
@@ -73,7 +73,7 @@ class AdaptiveForwardAdditive(AppearanceLucasKanade):
             n_iters += 1
 
         lk_fitting.fitted = True
-        return self.transform
+        return lk_fitting
 
 
 class AdaptiveForwardCompositional(AppearanceLucasKanade):
@@ -144,7 +144,7 @@ class AdaptiveForwardCompositional(AppearanceLucasKanade):
             n_iters += 1
 
         lk_fitting.fitted = True
-        return self.transform
+        return lk_fitting
 
 
 class AdaptiveInverseCompositional(AppearanceLucasKanade):
@@ -219,4 +219,4 @@ class AdaptiveInverseCompositional(AppearanceLucasKanade):
             n_iters += 1
 
         lk_fitting.fitted = True
-        return self.transform
+        return lk_fitting

--- a/pybug/lucaskanade/appearance/probabilistic.py
+++ b/pybug/lucaskanade/appearance/probabilistic.py
@@ -52,7 +52,7 @@ class ProbabilisticForwardAdditive(AppearanceLucasKanade):
             n_iters += 1
 
         lk_fitting.fitted = True
-        return self.transform
+        return lk_fitting
 
 
 class ProbabilisticForwardCompositional(AppearanceLucasKanade):
@@ -102,7 +102,7 @@ class ProbabilisticForwardCompositional(AppearanceLucasKanade):
             n_iters += 1
 
         lk_fitting.fitted = True
-        return self.transform
+        return lk_fitting
 
 
 class ProbabilisticInverseCompositional(AppearanceLucasKanade):
@@ -154,4 +154,4 @@ class ProbabilisticInverseCompositional(AppearanceLucasKanade):
             n_iters += 1
 
         lk_fitting.fitted = True
-        return self.transform
+        return lk_fitting

--- a/pybug/lucaskanade/appearance/projectout.py
+++ b/pybug/lucaskanade/appearance/projectout.py
@@ -51,7 +51,7 @@ class ProjectOutForwardAdditive(AppearanceLucasKanade):
             n_iters += 1
 
         lk_fitting.fitted = True
-        return self.transform
+        return lk_fitting
 
 
 class ProjectOutForwardCompositional(AppearanceLucasKanade):
@@ -100,7 +100,7 @@ class ProjectOutForwardCompositional(AppearanceLucasKanade):
             n_iters += 1
 
         lk_fitting.fitted = True
-        return self.transform
+        return lk_fitting
 
 
 class ProjectOutInverseCompositional(AppearanceLucasKanade):
@@ -153,4 +153,4 @@ class ProjectOutInverseCompositional(AppearanceLucasKanade):
             n_iters += 1
 
         lk_fitting.fitted = True
-        return self.transform
+        return lk_fitting

--- a/pybug/lucaskanade/appearance/simultaneous.py
+++ b/pybug/lucaskanade/appearance/simultaneous.py
@@ -77,7 +77,7 @@ class SimultaneousForwardAdditive(AppearanceLucasKanade):
             n_iters += 1
 
         lk_fitting.fitted = True
-        return self.transform
+        return lk_fitting
 
 
 class SimultaneousForwardCompositional(AppearanceLucasKanade):
@@ -152,7 +152,7 @@ class SimultaneousForwardCompositional(AppearanceLucasKanade):
             n_iters += 1
 
         lk_fitting.fitted = True
-        return self.transform
+        return lk_fitting
 
 
 class SimultaneousInverseCompositional(AppearanceLucasKanade):
@@ -228,4 +228,4 @@ class SimultaneousInverseCompositional(AppearanceLucasKanade):
             n_iters += 1
 
         lk_fitting.fitted = True
-        return self.transform
+        return lk_fitting


### PR DESCRIPTION
Makes all `_fit` methods in `LK` objects return `Fitting` objects instead of `Transforms` . 

This was OK for the commonly used `Alternating...` but wrong in all other `LK` objects.
