### PR TITLE
bump Cython version above Mavericks bug

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -48,7 +48,7 @@ setup(name='menpo',
       install_requires=[# Core
                         'numpy>=1.8.0',
                         'scipy>=0.12.0',
-                        'Cython>=0.18',
+                        'Cython>=0.20.1', # req on OS X Mavericks
 
                         # Image
                         'Pillow>=2.0.0',


### PR DESCRIPTION
This fixes the isspace issue present on Mavericks
