### PR TITLE
Fixes project_out_vectors method.

### DIFF
--- a/menpo/model/linear.py
+++ b/menpo/model/linear.py
@@ -230,7 +230,7 @@ class LinearModel(object):
                         trans_a=True)
         return (vectors -
                 dgemm(alpha=1.0, a=weights.T, b=self.components.T,
-                      trans_a=True, trans_b=False))
+                      trans_a=True, trans_b=True))
 
     def orthonormalize_inplace(self):
         r"""

--- a/menpo/model/pca.py
+++ b/menpo/model/pca.py
@@ -119,8 +119,8 @@ class PCAModel(MeanInstanceLinearModel):
     @property
     def jacobian(self):
         """
-        Returns the Jacobian of the PCA model. In this case, simply the
-        components of the model reshaped to have the standard Jacobian shape:
+        Returns the Jacobian of the PCA model reshaped to have the standard
+        Jacobian shape:
 
             n_points    x  n_params      x  n_dims
             n_features  x  n_components  x  n_dims
@@ -130,9 +130,21 @@ class PCAModel(MeanInstanceLinearModel):
         jacobian : (n_features, n_components, n_dims) ndarray
             The Jacobian of the model in the standard Jacobian shape.
         """
-        jacobian = self.components.reshape(self.n_active_components, -1,
-                                           self.template_instance.n_dims)
+        jacobian = self._jacobian.reshape(self.n_active_components, -1,
+                                          self.template_instance.n_dims)
         return jacobian.swapaxes(0, 1)
+
+    @property
+    def _jacobian(self):
+        """
+        Returns the Jacobian of the PCA model with respect to the weights.
+
+        Returns
+        -------
+        jacobian : (n_components, n_features) ndarray
+            The Jacobian with respect to the weights
+        """
+        return self.components
 
     def component_vector(self, index, with_mean=True, scale=1.0):
         r"""


### PR DESCRIPTION
- It also adds a convenient property `_jacobian` to be used by the `Simultaneous` family of `LK` algorithms for fitting `AAMs`.

In `Simultaneous` algorithms we require the following appearance `Jacobian`:

```
appearance_jacobian = self.appearance_model._jacobian.T
```

and we require `appearance_jacobian` to be:

```
(n_features x n_dims) x n_components
```

instead of the usual Menpo `Jacobian` shape:

```
n_features  x  n_components  x  n_dims
```

For the time being, `_jacobian` is equal `components` on `PCAModel`. This is most probably a temporary thing due to the fact that all data used so far is real. If complex data is used, the same `PCAModel` class (or a subclass) could be used to perform `ComplexPCA` (Circular) but, in that case, the `Jacobian` would have a different form that would not be equal to the `components`.
