### PR TITLE
Hotfix: fixes scipy 0.14 indexing complaints for PCAModel

### DIFF
--- a/menpo/model/pca.py
+++ b/menpo/model/pca.py
@@ -64,7 +64,7 @@ class PCAModel(MeanInstanceLinearModel):
 
     @n_active_components.setter
     def n_active_components(self, value):
-        value = round(value)
+        value = int(round(value))
         if 0 < value <= self.n_components:
             self._n_components = value
         else:


### PR DESCRIPTION
Continues the work of #284 and extends it so that `scipy`'s complain is removed when slicing a `PCAModel`.
