### PR TITLE
import menpo now exposes all menpo functionality

### DIFF
--- a/menpo/__init__.py
+++ b/menpo/__init__.py
@@ -1,4 +1,16 @@
-from base import menpo_src_dir_path
+from base import menpo_src_dir_path, Vectorizable, Targetable
+
+import fit
+import fitmultilevel
+import image
+import io
+import landmark
+import math
+import model
+import rasterize
+import shape
+import transform
+import visualize
 
 from ._version import get_versions
 __version__ = get_versions()['version']


### PR DESCRIPTION
This is a tiny change, but I'm making it a PR because it could change how we use menpo.

With this change, all of the public API of Menpo (i.e. everything that users will see in the public facing documentation) is now available with a single import. Some examples to clarify:

``` python
import menpo
pc = menpo.shape.PointCloud(...)
scale = menpo.transform.UniformScale(...)
img = menpo.image.MaskedImage(...)
```

While this is a little verbose and I suggest in notebooks we continue to manually import things that will be used a lot throughout a given notebook, it is nice that we can now just write this once at the top of a notebook and tab-complete our way to any part of menpo without having to issue another import command.
