### PR TITLE
Remove DimensionalityError 

### DIFF
--- a/menpo/base.py
+++ b/menpo/base.py
@@ -171,3 +171,10 @@ class Targetable(object):
 
 def menpo_src_dir_path():
     return os.path.split(os.path.abspath(__file__))[0]
+
+
+class DimensionalityError(ValueError):
+    """
+    Raised when the number of dimensions do not match what was expected.
+    """
+    pass

--- a/menpo/exception.py
+++ b/menpo/exception.py
@@ -1,5 +1,0 @@
-class DimensionalityError(ValueError):
-    """
-    Raised when the number of dimensions do not match what was expected.
-    """
-    pass

--- a/menpo/io/base.py
+++ b/menpo/io/base.py
@@ -3,7 +3,6 @@ from copy import deepcopy
 import os
 from glob import glob
 from menpo import menpo_src_dir_path
-from menpo.exception import DimensionalityError
 
 
 def data_dir_path():
@@ -452,7 +451,7 @@ def _import(filepath, extensions_map, keep_importer=False,
                 for x in built_objects:
                     try:
                         x.landmarks[lms.group_label] = deepcopy(lms)
-                    except DimensionalityError:
+                    except ValueError:
                         pass
         else:
             for x in built_objects:

--- a/menpo/landmark/base.py
+++ b/menpo/landmark/base.py
@@ -90,8 +90,7 @@ class LandmarkManager(Transformable, Viewable):
         from menpo.shape import PointCloud
         # firstly, make sure the dim is correct
         if value.n_dims != self._target.n_dims:
-            from menpo.exception import DimensionalityError
-            raise DimensionalityError(
+            raise ValueError(
                 "Trying to set {}D landmarks on a "
                 "{}D shape".format(value.n_dims, self._target.n_dims))
         if isinstance(value, PointCloud):

--- a/menpo/shape/mesh/base.py
+++ b/menpo/shape/mesh/base.py
@@ -4,7 +4,6 @@ from scipy.spatial import Delaunay
 from menpo.shape import PointCloud
 from menpo.shape.mesh.normals import compute_normals
 from menpo.visualize import TriMeshViewer
-from menpo.exception import DimensionalityError
 
 
 class TriMesh(PointCloud):
@@ -82,7 +81,7 @@ class TriMesh(PointCloud):
             If mesh is not 3D
         """
         if self.n_dims != 3:
-            raise DimensionalityError("Normals are only valid for 3D meshes")
+            raise ValueError("Normals are only valid for 3D meshes")
         return compute_normals(self.points, self.trilist)[0]
 
     @property
@@ -101,7 +100,7 @@ class TriMesh(PointCloud):
             If mesh is not 3D
         """
         if self.n_dims != 3:
-            raise DimensionalityError("Normals are only valid for 3D meshes")
+            raise ValueError("Normals are only valid for 3D meshes")
         return compute_normals(self.points, self.trilist)[1]
 
     @property

--- a/menpo/shape/mesh/coloured.py
+++ b/menpo/shape/mesh/coloured.py
@@ -1,6 +1,5 @@
 import numpy as np
 
-from menpo.exception import DimensionalityError
 from menpo.rasterize import Rasterizable
 from menpo.rasterize.base import ColourRasterInfo
 from menpo.visualize.base import ColouredTriMeshViewer3d
@@ -64,8 +63,8 @@ class ColouredTriMesh(TriMesh, Rasterizable):
                     figure_id, new_figure, self.points,
                     self.trilist, self.colours).render(**kwargs)
             else:
-                raise DimensionalityError("Only viewing of 3D coloured meshes"
-                                          "is currently supported.")
+                raise ValueError("Only viewing of 3D coloured meshes "
+                                 "is currently supported.")
         else:
             return super(ColouredTriMesh, self)._view(figure_id=figure_id,
                                                       new_figure=new_figure,

--- a/menpo/shape/mesh/textured.py
+++ b/menpo/shape/mesh/textured.py
@@ -6,7 +6,6 @@ from menpo.shape import PointCloud
 from menpo.visualize import TexturedTriMeshViewer3d
 from menpo.transform import Scale
 from menpo.rasterize import Rasterizable
-from menpo.exception import DimensionalityError
 
 from .base import TriMesh
 
@@ -114,8 +113,8 @@ class TexturedTriMesh(TriMesh, Rasterizable):
                     self.trilist, self.texture,
                     self.tcoords.points).render(**kwargs)
             else:
-                raise DimensionalityError("Only viewing of 3D textured meshes"
-                                          "is currently supported.")
+                raise ValueError("Only viewing of 3D textured meshes"
+                                 "is currently supported.")
         else:
             return super(TexturedTriMesh, self)._view(figure_id=figure_id,
                                                       new_figure=new_figure,

--- a/menpo/transform/homogeneous/affine.py
+++ b/menpo/transform/homogeneous/affine.py
@@ -2,8 +2,6 @@ import abc
 import copy
 import numpy as np
 
-from menpo.exception import DimensionalityError
-
 from .base import Homogeneous, HomogFamilyAlignment
 
 
@@ -46,10 +44,10 @@ class Affine(Homogeneous):
         if self.h_matrix is not None:
             # already have a matrix set! The update better be the same size
             if self.n_dims != shape[0] - 1:
-                raise DimensionalityError("Trying to update the homogeneous "
-                                          "matrix to a different dimension")
+                raise ValueError("Trying to update the homogeneous "
+                                 "matrix to a different dimension")
         if shape[0] - 1 not in [2, 3]:
-            raise DimensionalityError("Affine Transforms can only be 2D or 3D")
+            raise ValueError("Affine Transforms can only be 2D or 3D")
         if not (np.allclose(value[-1, :-1], 0) and
                 np.allclose(value[-1, -1], 1)):
             raise ValueError("Bottom row must be [0 0 0 1] or [0, 0, 1]")
@@ -241,7 +239,7 @@ class Affine(Homogeneous):
         """
         n_points, points_n_dim = points.shape
         if points_n_dim != self.n_dims:
-            raise DimensionalityError(
+            raise ValueError(
                 "Trying to sample jacobian in incorrect dimensions "
                 "(transform is {0}D, sampling at {1}D)".format(
                     self.n_dims, points_n_dim))

--- a/menpo/transform/homogeneous/rotation.py
+++ b/menpo/transform/homogeneous/rotation.py
@@ -1,8 +1,6 @@
 import abc
 import numpy as np
 
-from menpo.exception import DimensionalityError
-
 from .base import HomogFamilyAlignment
 from .affine import DiscreteAffine
 from .similarity import Similarity
@@ -72,8 +70,8 @@ class Rotation(DiscreteAffine, Similarity):
             raise ValueError("You need to provide a square rotation matrix")
         # The update better be the same size
         elif self.n_dims != shape[0]:
-            raise DimensionalityError("Trying to update the rotation "
-                                      "matrix to a different dimension")
+            raise ValueError("Trying to update the rotation "
+                             "matrix to a different dimension")
         # TODO actually check I am a valid rotation
         # TODO slightly dodgey here accessing _h_matrix
         self._h_matrix[:-1, :-1] = value

--- a/menpo/transform/homogeneous/similarity.py
+++ b/menpo/transform/homogeneous/similarity.py
@@ -1,7 +1,5 @@
 import numpy as np
 
-from menpo.exception import DimensionalityError
-
 from .base import HomogFamilyAlignment
 from .affine import Affine
 
@@ -101,8 +99,8 @@ class Similarity(Affine):
             raise NotImplementedError("3D similarity transforms cannot be "
                                       "vectorized yet.")
         else:
-            raise DimensionalityError("Only 2D and 3D Similarity transforms "
-                                      "are currently supported.")
+            raise ValueError("Only 2D and 3D Similarity transforms "
+                             "are currently supported.")
 
     def from_vector_inplace(self, p):
         r"""
@@ -137,8 +135,8 @@ class Similarity(Affine):
             raise NotImplementedError("3D similarity transforms cannot be "
                                       "vectorized yet.")
         else:
-            raise DimensionalityError("Only 2D and 3D Similarity transforms "
-                                      "are currently supported.")
+            raise ValueError("Only 2D and 3D Similarity transforms "
+                             "are currently supported.")
 
     def _build_pseudoinverse(self):
         return Similarity(np.linalg.inv(self.h_matrix))
@@ -175,14 +173,13 @@ class Similarity(Affine):
         """
         n_points, points_n_dim = points.shape
         if points_n_dim != self.n_dims:
-            raise DimensionalityError('Trying to sample jacobian in incorrect '
-                                      'dimensions (transform is {0}D, '
-                                      'sampling at {1}D)'.format(self.n_dims,
-                                                                 points_n_dim))
+            raise ValueError('Trying to sample jacobian in incorrect '
+                             'dimensions (transform is {0}D, sampling '
+                             'at {1}D)'.format(self.n_dims, points_n_dim))
         elif self.n_dims != 2:
             # TODO: implement 3D Jacobian
-            raise DimensionalityError("Only the Jacobian of a 2D similarity "
-                                      "transform is currently supported.")
+            raise ValueError("Only the Jacobian of a 2D similarity "
+                             "transform is currently supported.")
 
         # prealloc the jacobian
         jac = np.zeros((n_points, self.n_parameters, self.n_dims))

--- a/menpo/transform/test/homogeneous/homogeneous_test.py
+++ b/menpo/transform/test/homogeneous/homogeneous_test.py
@@ -1,20 +1,16 @@
 import numpy as np
 from numpy.testing import assert_allclose, assert_equal
-from menpo.transform import (Affine,
-                             Similarity,
-                             Rotation,
-                             Scale, NonUniformScale, UniformScale,
-                             Translation)
-from menpo.exception import DimensionalityError
+from menpo.transform import (Affine, Similarity, Rotation, Scale,
+                             NonUniformScale, UniformScale, Translation)
 from nose.tools import raises
 
-@raises(DimensionalityError)
+@raises(ValueError)
 def test_1d_translation():
     t_vec = np.array([1])
     Translation(t_vec)
 
 
-@raises(DimensionalityError)
+@raises(ValueError)
 def test_5d_translation():
     t_vec = np.ones(5)
     Translation(t_vec)
@@ -422,13 +418,13 @@ def test_similarity_jacobian_2d():
     assert_equal(dW_dp, sim_jac_solution2d)
 
 
-@raises(DimensionalityError)
+@raises(ValueError)
 def test_similarity_jacobian_3d_raises_dimensionalityerror():
     t = Similarity(np.eye(4))
     t.jacobian(np.ones([2, 3]))
 
 
-@raises(DimensionalityError)
+@raises(ValueError)
 def test_similarity_2d_points_raises_dimensionalityerror():
     params = np.ones(4)
     t = Similarity.identity(2).from_vector(params)
@@ -578,7 +574,7 @@ def test_uniformscale_build_3d():
     assert_equal(tr.h_matrix, homo)
 
 
-@raises(DimensionalityError)
+@raises(ValueError)
 def test_uniformscale_build_4d_raise_dimensionalityerror():
     UniformScale(1, 4)
 

--- a/menpo/visualize/base.py
+++ b/menpo/visualize/base.py
@@ -1,10 +1,6 @@
 # This has to go above the default importers to prevent cyclical importing
 import abc
 
-import numpy as np
-from scipy.misc import imrotate
-
-from menpo.exception import DimensionalityError
 from collections import Iterable
 
 
@@ -283,8 +279,8 @@ class LandmarkViewer(object):
                                     self.group_label, self.pointcloud,
                                     self.labels_to_masks).render(**kwargs)
         else:
-            raise DimensionalityError("Only 2D and 3D landmarks are "
-                                      "currently supported")
+            raise ValueError("Only 2D and 3D landmarks are "
+                             "currently supported")
 
 
 class PointCloudViewer(object):
@@ -334,8 +330,8 @@ class PointCloudViewer(object):
             return PointCloudViewer3d(self.figure_id, self.new_figure,
                                       self.points).render(**kwargs)
         else:
-            raise DimensionalityError("Only 2D and 3D pointclouds are "
-                                      "currently supported")
+            raise ValueError("Only 2D and 3D pointclouds are "
+                             "currently supported")
 
 
 class ImageViewer(object):
@@ -458,7 +454,7 @@ class ImageViewer(object):
                 return ImageViewer2d(self.figure_id, self.new_figure,
                                      self.pixels).render(**kwargs)
         else:
-            raise DimensionalityError("Only 2D images are currently supported")
+            raise ValueError("Only 2D images are currently supported")
 
 
 class TriMeshViewer(object):
@@ -512,8 +508,8 @@ class TriMeshViewer(object):
             return TriMeshViewer3d(self.figure_id, self.new_figure,
                                    self.points, self.trilist).render(**kwargs)
         else:
-            raise DimensionalityError("Only 2D and 3D TriMeshes are "
-                                      "currently supported")
+            raise ValueError("Only 2D and 3D TriMeshes "
+                             "are currently supported")
 
 
 class MultipleImageViewer(ImageViewer):
@@ -537,7 +533,7 @@ class MultipleImageViewer(ImageViewer):
                 return MultiImageViewer2d(self.figure_id, self.new_figure,
                                           self.pixels_list).render(**kwargs)
         else:
-            raise DimensionalityError("Only 2D images are currently supported")
+            raise ValueError("Only 2D images are currently supported")
 
 
 class FittingViewer(ImageViewer):
@@ -560,4 +556,4 @@ class FittingViewer(ImageViewer):
                     self.figure_id, self.new_figure, self.pixels,
                     self.target_list).render(**kwargs)
         else:
-            raise DimensionalityError("Only 2D images are currently supported")
+            raise ValueError("Only 2D images are currently supported")


### PR DESCRIPTION
We haven't been 100% consistent in using `DimensionalityError` in Menpo. We certainly never rely on it for catching errors, and with it not being used consistently it's not terribly useful.

This PR replaces all occurrences of `DimensionalityError` with `ValueError` (it's superclass). In the future we may wish to revisit adding Exceptions to Menpo but for now simplicity of sticking with builtin errors trumps verbosity.
