### PR TITLE
fix interp ordering and docs

### DIFF
--- a/menpo/image/base.py
+++ b/menpo/image/base.py
@@ -689,7 +689,7 @@ class Image(Vectorizable, Landmarkable, Viewable):
                 "(they must match)".format(self.n_dims, transform.n_dims))
 
         template_points = template_mask.true_indices
-        points_to_sample = transform.apply(template_points).T
+        points_to_sample = transform.apply(template_points)
         # we want to sample each channel in turn, returning a vector of sampled
         # pixels. Store those in a (n_pixels, n_channels) array.
         sampled_pixel_values = _interpolator(self.pixels, points_to_sample,

--- a/menpo/image/interpolation.py
+++ b/menpo/image/interpolation.py
@@ -4,14 +4,14 @@ from scipy.ndimage import map_coordinates
 
 def scipy_interpolation(pixels, points_to_sample, mode='constant', order=1):
     r"""
-    C-based interpolator that was designed to be identical when
-    used in both Python and Matlab.
+    Interpolation utilizing SciPy's map_coordinates function.
 
     Parameters
     ----------
-    ndimage : (M, N, ..., C) ndarray
-        The image that is to be sampled from. The final axis channels.
-    points_to_sample: (K, n_points) ndarray
+    pixels : (M, N, ..., n_channels) ndarray
+        The image to be sampled from, the final axis containing channel
+        information.
+    points_to_sample : (n_points, n_dims) ndarray
         The points which should be sampled from pixels
     mode : {'constant', 'nearest', 'reflect', 'wrap'}, optional
         Points outside the boundaries of the input are filled according to the
@@ -31,9 +31,12 @@ def scipy_interpolation(pixels, points_to_sample, mode='constant', order=1):
     """
     sampled_pixel_values = []
     # Loop over every channel in image - we know last axis is always channels
+    # Note that map_coordinates uses the opposite (dims, points) convention
+    # to us so we transpose
+    points_to_sample_t = points_to_sample.T
     for i in xrange(pixels.shape[-1]):
         sampled_pixel_values.append(map_coordinates(pixels[..., i],
-                                                    points_to_sample,
+                                                    points_to_sample_t,
                                                     mode=mode,
                                                     order=order))
     sampled_pixel_values = [v.reshape([-1, 1]) for v in sampled_pixel_values]


### PR DESCRIPTION
interpolation now uses our standard `(points, dims)` convention, transpose for scipy happens within.
