### PR TITLE
Tidy the __str__ methods in homogeneous

### DIFF
--- a/menpo/transform/homogeneous/affine.py
+++ b/menpo/transform/homogeneous/affine.py
@@ -97,12 +97,6 @@ class Affine(Homogeneous):
     def __eq__(self, other):
         return np.allclose(self.h_matrix, other.h_matrix)
 
-    def __str__(self):
-        rep = repr(self) + '\n'
-        rep += str(self.h_matrix) + '\n'
-        rep += self._transform_str()
-        return rep
-
     def _transform_str(self):
         r"""
         A string representation explaining what this affine transform does.
@@ -113,8 +107,9 @@ class Affine(Homogeneous):
         str : string
             String representation of transform.
         """
+        header = 'Affine decomposing into:'
         list_str = [t._transform_str() for t in self.decompose()]
-        return reduce(lambda x, y: x + '\n' + y, list_str)
+        return header + reduce(lambda x, y: x + '\n' + '  ' + y, list_str, '  ')
 
     def _apply(self, x, **kwargs):
         r"""

--- a/menpo/transform/homogeneous/base.py
+++ b/menpo/transform/homogeneous/base.py
@@ -37,6 +37,23 @@ class Homogeneous(ComposableTransform, Vectorizable, VComposable, VInvertible):
     def __init__(self, h_matrix):
         self._h_matrix = h_matrix.copy()
 
+    def __str__(self):
+        rep = self._transform_str() + '\n'
+        rep += str(self.h_matrix)
+        return rep
+
+    def _transform_str(self):
+        r"""
+        A string representation explaining what this homogeneous transform does.
+        Has to be implemented by base classes.
+
+        Returns
+        -------
+        str : string
+            String representation of transform.
+        """
+        return 'Homogeneous'
+
     @classmethod
     def identity(cls, n_dims):
         return Homogeneous(np.eye(n_dims + 1))

--- a/menpo/transform/homogeneous/rotation.py
+++ b/menpo/transform/homogeneous/rotation.py
@@ -81,7 +81,8 @@ class Rotation(DiscreteAffine, Similarity):
         if axis is None:
             return "NO OP"
         angle_of_rot = (rad_angle_of_rotation * 180.0) / np.pi
-        message = 'CCW Rotation of %d degrees about %s' % (angle_of_rot, axis)
+        message = ('CCW Rotation of {:.1f} degrees '
+                   'about {}'.format(angle_of_rot,axis))
         return message
 
     def axis_and_angle_of_rotation(self):

--- a/menpo/transform/homogeneous/scale.py
+++ b/menpo/transform/homogeneous/scale.py
@@ -91,7 +91,7 @@ class NonUniformScale(DiscreteAffine, Affine):
         return self.h_matrix.diagonal()[:-1]
 
     def _transform_str(self):
-        message = 'NonUniformScale by %s ' % self.scale
+        message = 'NonUniformScale by {}'.format(self.scale)
         return message
 
     @property
@@ -184,7 +184,7 @@ class UniformScale(DiscreteAffine, Similarity):
         return self.h_matrix[0, 0]
 
     def _transform_str(self):
-        message = 'UniformScale by %f ' % self.scale
+        message = 'UniformScale by {}'.format(self.scale)
         return message
 
     @property

--- a/menpo/transform/homogeneous/similarity.py
+++ b/menpo/transform/homogeneous/similarity.py
@@ -19,6 +19,19 @@ class Similarity(Affine):
         Affine.__init__(self, h_matrix)
         #TODO check that I am a similarity transform
 
+    def _transform_str(self):
+        r"""
+        A string representation explaining what this similarity transform does.
+
+        Returns
+        -------
+        str : string
+            String representation of transform.
+        """
+        header = 'Similarity decomposing into:'
+        list_str = [t._transform_str() for t in self.decompose()]
+        return header + reduce(lambda x, y: x + '\n' + '  ' + y, list_str, '  ')
+
     @classmethod
     def identity(cls, n_dims):
         return Similarity(np.eye(n_dims + 1))

--- a/menpo/transform/homogeneous/translation.py
+++ b/menpo/transform/homogeneous/translation.py
@@ -26,7 +26,7 @@ class Translation(DiscreteAffine, Similarity):
         return Translation(np.zeros(n_dims))
 
     def _transform_str(self):
-        message = 'Translate by %s ' % self.translation_component
+        message = 'Translation by {}'.format(self.translation_component)
         return message
 
     @property


### PR DESCRIPTION
This just makes the printing of the homogenous transform family a little tidier.
