### PR TITLE
Fixes orthonormalize_against method edge case.

### DIFF
--- a/menpo/model/pca.py
+++ b/menpo/model/pca.py
@@ -510,15 +510,15 @@ class PCAModel(MeanInstanceLinearModel):
             # oh dear, we've lost some components from the end of our model.
             if self.n_active_components < n_available_components:
                 # save the current number of active components
-                n_components = self.n_active_components
+                n_active_components = self.n_active_components
             else:
                 # save the current number of available components
-                n_components = n_available_components
+                n_active_components = n_available_components
             # call trim_components to update our state.
             self.trim_components(n_components=n_available_components)
-            if n_components < n_available_components:
+            if n_active_components < n_available_components:
                 # reset the number of active components
-                self.n_active_components = n_components
+                self.n_active_components = n_active_components
 
         # now we can set our own components with the updated orthogonal ones
         self.components = Q[linear_model.n_components:, :]

--- a/menpo/model/test_model.py
+++ b/menpo/model/test_model.py
@@ -180,9 +180,21 @@ def test_pca_orthogonalize_against():
     pca_model = PCAModel(pca_samples)
     lm_samples = np.asarray([np.random.randn(10) for _ in range(4)])
     lm_model = LinearModel(np.asarray(lm_samples))
+    # orthogonalize
+    pca_model.orthonormalize_against_inplace(lm_model)
+    # number of active components must remain the same
+    assert_equal(pca_model.n_active_components, 6)
+
+
+def test_pca_orthogonalize_against_with_less_active_components():
+    pca_samples = [PointCloud(np.random.randn(10)) for _ in range(10)]
+    pca_model = PCAModel(pca_samples)
+    lm_samples = np.asarray([np.random.randn(10) for _ in range(4)])
+    lm_model = LinearModel(np.asarray(lm_samples))
     # set number of active components
     pca_model.n_active_components = 5
     # orthogonalize
     pca_model.orthonormalize_against_inplace(lm_model)
     # number of active components must remain the same
     assert_equal(pca_model.n_active_components, 5)
+


### PR DESCRIPTION
Fixes edge case that was breaking `PCA` when using its method `orthonormalize_againts`
