### PR TITLE
BUG fixed: block element not reset if norm=0

### DIFF
--- a/menpo/image/feature/cpp/HOG.cpp
+++ b/menpo/image/feature/cpp/HOG.cpp
@@ -426,6 +426,9 @@ void DalalTriggsHOGdescriptor(double *inputImage,
                             block[i][j][k] = h[y+i][x+j][k] / blockNorm;
                             if (block[i][j][k] > l2normClipping)
                                 block[i][j][k] = l2normClipping;
+                        } 
+                        else {
+                            block[i][j][k] = 0;
                         }
                     }
                 }


### PR DESCRIPTION
In HOGS we calculate a norm per block and then use this norm to normalize the block itself.

We currently fail to deal with the case where the norm is 0. As the underlying memory is dirty, this leads to possible bugs.

We can imagine that for a given value of `(x, y)`, `block[i][j][k]` is modified at line 426
But that for another value (after) `(x', y')`, `block[i][j][k]` is not modified (no else statement)
That means that the value of `block[i][j][k]` will not be the one corresponding to this `(x', y')` (and not 0.) but will still be taken into account for the remaining part of the process.

Credit to @dubzzz for finding and fixing this!
