### PR TITLE
add OS X travis build (WIP)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,10 @@
-language: python
-python:
-  - 2.7
+#language: python
+#python:
+#  - 2.7
+os:
+  - linux
+  - osx
+
 notifications:
   email: false
   flowdock: 769202b66114a5ce0e61df484dfeb177


### PR DESCRIPTION
Adds support for OS X builds on Travis, closing #414.

TODOs:
- [ ] Download the approprate version of miniconda by checking the [travis OS environment variable](http://docs.travis-ci.com/user/multi-os/#TRAVIS_OS_NAME-environment-variable).
- [ ] Maybe move to using accelerate (storing our auth token in a [travis encryption key](http://docs.travis-ci.com/user/encryption-keys/). Standardise tests on there.
