### PR TITLE
White background (non-mask pixels)

### DIFF
--- a/menpo/visualize/base.py
+++ b/menpo/visualize/base.py
@@ -482,7 +482,7 @@ class ImageViewer(object):
             returned.
         """
         if mask is not None:
-            pixels[~mask] = min(pixels.min(), 0)
+            pixels[~mask] = max(pixels.max(), 0)
         return pixels
 
     def render(self, **kwargs):


### PR DESCRIPTION
This PR sets a white background (i.e. the non-masked pixels of a masked image) instead of black that we had till now. This is done by setting the values of the non-mask pixels equal to the maximum value of the masked pixels.
