### PR TITLE
Adds HDF5able serialization support to Menpo

### DIFF
--- a/conda/meta.yaml
+++ b/conda/meta.yaml
@@ -29,6 +29,7 @@ requirements:
     - mock
     - pathlib  # [not py3k]
     - pip
+    - hdf5able
     - wrapt
 
 test:

--- a/menpo/base.py
+++ b/menpo/base.py
@@ -1,6 +1,8 @@
 import abc
 import os.path
 
+from hdf5able import HDF5able
+
 # To debug the Copyable interface, simply uncomment lines 11-23 below and the
 # four lines in the copy() method.
 # Then you can call print_copyable_log() to see exactly what types have been
@@ -21,7 +23,7 @@ import os.path
 #         print('  {:15}|  {}'.format(k, ', '.join(v)))
 
 
-class Copyable(object):
+class Copyable(HDF5able):
     """
     Efficient copying of classes containing numpy arrays.
 

--- a/menpo/fitmultilevel/aam/builder.py
+++ b/menpo/fitmultilevel/aam/builder.py
@@ -1,5 +1,6 @@
 from __future__ import division
 import numpy as np
+from hdf5able import HDF5able, SerializableCallable
 
 from menpo.shape import TriMesh
 from menpo.image import MaskedImage
@@ -648,7 +649,7 @@ class PatchBasedAAMBuilder(AAMBuilder):
                              self.pyramid_on_features, self.interpolator)
 
 
-class AAM(object):
+class AAM(HDF5able):
     r"""
     Active Appearance Model class.
 
@@ -742,6 +743,23 @@ class AAM(object):
         self.scaled_shape_models = scaled_shape_models
         self.pyramid_on_features = pyramid_on_features
         self.interpolator = interpolator
+
+    def h5_dict_to_serializable_dict(self):
+        import menpo.transform
+        d = self.__dict__.copy()
+        transform = d.pop('transform')
+        d['transform'] = SerializableCallable(transform, [menpo.transform])
+
+        features = d.pop('feature_type')
+        d['features'] = [SerializableCallable(f, [menpo.feature])
+                         for f in features]
+        return d
+
+    @classmethod
+    def h5_dict_from_serialized_dict(cls, d, version):
+        # anticipating https://github.com/menpo/menpo/pull/426
+        d['feature_type'] = d.pop('features')
+        return d
 
     @property
     def n_levels(self):

--- a/menpo/io/__init__.py
+++ b/menpo/io/__init__.py
@@ -1,7 +1,7 @@
-from .input import (import_image, import_images,
+from .input import (load, import_image, import_images,
                     import_mesh, import_meshes, import_builtin_asset,
                     import_landmark_file, import_landmark_files,
                     data_path_to, data_dir_path, ls_builtin_assets,
                     mesh_paths, image_paths, landmark_file_paths)
-from .output import (export_image, export_landmark_file, export_mesh,
+from .output import (save, export_image, export_landmark_file, export_mesh,
                      export_textured_mesh)

--- a/menpo/io/input/__init__.py
+++ b/menpo/io/input/__init__.py
@@ -1,4 +1,4 @@
-from .base import (import_image, import_images,
+from .base import (load, import_image, import_images,
                    import_mesh, import_meshes, import_builtin_asset,
                    import_landmark_file, import_landmark_files,
                    data_path_to, data_dir_path, ls_builtin_assets,

--- a/menpo/io/input/base.py
+++ b/menpo/io/input/base.py
@@ -3,10 +3,29 @@ import os
 from glob import glob
 
 from pathlib import Path
+import hdf5able
 
 from ..utils import _norm_path
 from menpo import menpo_src_dir_path
 from menpo.visualize import progress_bar_str, print_dynamic
+
+
+def load(path):
+    r"""
+    Load a given HDF5 file of serialized Menpo objects or base types.
+
+    Parameters
+    ----------
+    path : `str`
+        A path to a HDF5 file that conforms to the hdf5able specification.
+
+    Returns
+    -------
+    hdf5able :
+        Any collection of HDF5able objects.
+
+    """
+    return hdf5able.load(path)
 
 
 def data_dir_path():
@@ -784,7 +803,7 @@ from menpo.io.input.extensions import (mesh_types, all_image_types,
                                        all_landmark_types)
 
 
-class IOInfo(object):
+class IOInfo(hdf5able.HDF5able):
     r"""
     Simple state object for recording IO information.
     """

--- a/menpo/io/output/__init__.py
+++ b/menpo/io/output/__init__.py
@@ -1,2 +1,2 @@
-from .base import (export_landmark_file, export_image, export_mesh,
+from .base import (save, export_landmark_file, export_image, export_mesh,
                    export_textured_mesh)

--- a/menpo/io/output/base.py
+++ b/menpo/io/output/base.py
@@ -1,7 +1,26 @@
 from pathlib import Path
+from hdf5able import save as h5_save
 
 from .extensions import landmark_types, image_types, mesh_types
 from ..utils import _norm_path
+
+
+def save(path, hdf5able):
+    r"""
+    Serialized a collection of Menpo objects and base types to disk in a
+    HDF5 file container.
+
+    Parameters
+    ----------
+    path : `str`
+        A path to a HDF5 file that conforms to the hdf5able specification.
+
+    hdf5able : `HDF5able` or base types
+        Any collection of base types (dict, list, str, etc) along with any
+        HDG5able Menpo type.
+
+    """
+    h5_save(path, hdf5able)
 
 
 def export_landmark_file(fp, landmark_group, extension=None,


### PR DESCRIPTION
Serialization of Menpo datatypes has long been on our wishlist (#164, see there for detailed discussion). This PR adds solid serialization support to Menpo in a fundamental way.

The actual meat of this solution is a separate package called [hdf5able](https://github.com/menpo/hdf5able). This package defines a standardized approach for serializing and de-serializing basic Python types to and from HDF5 files. It also provides a class called `HDF5able`. Any custom subclass of `HDF5able` can also be safely serialized to disk. This PR:
1. Adds `HDF5able` as a superclass of `Copyable`, making most Menpo types serializable, with no extra effort.
2. Classes that hold callables as variables (most notably feature functions in the `fit` package) need to specialize a few methods of `HDF5able` to be serializable. Support is added for `AAM` serialization in this PR. Future small PR's in Menpo can add support to classes as we go.
3. Adds `menpo.io.load(path)` and `menpo.io.save(path, objects)`. These are the new API for saving Menpo objects.

Note that because HDF5 is an open standard, any files saved out from Menpo can be easily inspected by any number of tools. Matlab also supports HDF5, so immediately Menpo data can be read into Matlab (we may right a small Matlab function to make this easier to encourage support). 
