### PR TITLE
import_builtin_asset.ASSET_NAME

### DIFF
--- a/menpo/io/input/base.py
+++ b/menpo/io/input/base.py
@@ -360,7 +360,9 @@ def import_builtin(x):
 
 
 class BuiltinAssets(object):
-    pass
+
+    def __call__(self, asset_name):
+        return _import_builtin_asset(asset_name)
 
 import_builtin_asset = BuiltinAssets()
 
@@ -393,6 +395,7 @@ def landmark_file_paths(pattern):
 def _import_glob_generator(pattern, extension_map, max_assets=None,
                            has_landmarks=False, landmark_resolver=same_name,
                            importer_kwargs=None, verbose=False):
+    pattern = _norm_path(pattern)
     filepaths = list(glob_with_suffix(pattern, extension_map))
     if max_assets:
         filepaths = filepaths[:max_assets]


### PR DESCRIPTION
Adds direct namespacing of builtin assets. With this PR the following two calls are equivalent:

``` python
menpo.io.import_builtin_asset.breakingbad_jpg()
menpo.io.import_builtin_asset('breakingbad_jpg')
```

benefit being the top variant is tab-completable. The string variant is still allowed, just adds an alternative for use in notebook sessions. Note that all periods in built-in assets are replaced with underscores for the method-variant (as can be seen with the breaking bad example above).
