### PR TITLE
pathlib.Path can no be used in menpo.io

### DIFF
--- a/menpo/io/input/base.py
+++ b/menpo/io/input/base.py
@@ -25,7 +25,7 @@ def load(path):
         Any collection of HDF5able objects.
 
     """
-    return hdf5able.load(path)
+    return hdf5able.load(_norm_path(path))
 
 
 def data_dir_path():
@@ -395,7 +395,6 @@ def landmark_file_paths(pattern):
 def _import_glob_generator(pattern, extension_map, max_assets=None,
                            has_landmarks=False, landmark_resolver=same_name,
                            importer_kwargs=None, verbose=False):
-    pattern = _norm_path(pattern)
     filepaths = list(glob_with_suffix(pattern, extension_map))
     if max_assets:
         filepaths = filepaths[:max_assets]
@@ -581,6 +580,7 @@ def _pathlib_glob_for_pattern(pattern):
     ValueError
         If the pattern doesn't contain a '*' wildcard and is not a directory
     """
+    pattern = _norm_path(pattern)
     gsplit = pattern.split('*', 1)
     if len(gsplit) == 1:
         # no glob provided. Is the provided pattern a dir?

--- a/menpo/io/output/base.py
+++ b/menpo/io/output/base.py
@@ -20,7 +20,7 @@ def save(path, hdf5able):
         HDG5able Menpo type.
 
     """
-    h5_save(path, hdf5able)
+    h5_save(_norm_path(path), hdf5able)
 
 
 def export_landmark_file(fp, landmark_group, extension=None,

--- a/menpo/io/utils.py
+++ b/menpo/io/utils.py
@@ -6,4 +6,4 @@ def _norm_path(filepath):
     Uses all the tricks in the book to expand a path out to an absolute one.
     """
     return os.path.abspath(os.path.normpath(
-        os.path.expandvars(os.path.expanduser(filepath))))
+        os.path.expandvars(os.path.expanduser(str(filepath)))))


### PR DESCRIPTION
Adds support for passing pathlib `Path` objects directly into Menpo's IO module.
