### PR TITLE
make mayavi an optional dependency

### DIFF
--- a/conda/meta.yaml
+++ b/conda/meta.yaml
@@ -19,7 +19,6 @@ requirements:
     - matplotlib 1.4.0
     - scikit-learn 0.15.2
     - pillow  2.5.1
-    - mayavi  4.3.1 # [not py3k]
 
     # Menpo Project
     - hdf5able 0.3.3

--- a/menpo/visualize/viewmayavi.py
+++ b/menpo/visualize/viewmayavi.py
@@ -19,6 +19,11 @@ class MayaviViewer(Renderer):
     __metaclass__ = abc.ABCMeta
 
     def __init__(self, figure_id, new_figure):
+        try:
+            import mayavi
+        except ImportError:
+            raise ImportError("mayavi is required for viewing 3D objects "
+                              "(consider 'conda/pip install mayavi')")
         super(MayaviViewer, self).__init__(figure_id, new_figure)
 
     def get_figure(self):

--- a/setup.py
+++ b/setup.py
@@ -44,8 +44,7 @@ else:
                         'hdf5able==0.3.3',
 
                         # Visualization
-                        'matplotlib==1.4.0',
-                        'mayavi==4.3.1']
+                        'matplotlib==1.4.0']
 
     if sys.version_info.major == 2:
         install_requires.append('pathlib==1.0')


### PR DESCRIPTION
Mayavi is not available on Python 3 and is a large cumbersome dependency. Whilst it is great to have for 3D work, it is not used at all whilst working with images in Menpo.

This PR removes mayavi from Menpo as a hard dependency. If a user who doesn't have mayavi installed tries to view a 3D object an `ImportError` is raised that prints the following error:

```
mayavi is required for viewing 3D objects (consider 'conda/pip install mayavi')
```
