### PR TITLE
Normalize norm and std of Image object

### DIFF
--- a/menpo/image/test/image_test.py
+++ b/menpo/image/test/image_test.py
@@ -420,21 +420,21 @@ def test_2d_crop_with_mask():
     assert (np.alltrue(cropped_im.shape))
 
 
-def test_normalize_std_default():
+def test_normalize_std_image():
     pixels = np.ones((120, 120, 3))
     pixels[..., 0] = 0.5
     pixels[..., 1] = 0.2345
-    image = MaskedImage(pixels)
+    image = Image(pixels)
     image.normalize_std_inplace()
     assert_allclose(np.mean(image.pixels), 0, atol=1e-10)
     assert_allclose(np.std(image.pixels), 1)
 
 
-def test_normalize_norm_default():
+def test_normalize_norm_image():
     pixels = np.ones((120, 120, 3))
     pixels[..., 0] = 0.5
     pixels[..., 1] = 0.2345
-    image = MaskedImage(pixels)
+    image = Image(pixels)
     image.normalize_norm_inplace()
     assert_allclose(np.mean(image.pixels), 0, atol=1e-10)
     assert_allclose(np.linalg.norm(image.pixels), 1)
@@ -456,7 +456,7 @@ def test_normalize_norm_zero_norm_exception():
     image.normalize_norm_inplace(mode='per_channel')
 
 
-def test_normalize_std_per_channel():
+def test_normalize_std_masked_per_channel():
     pixels = np.random.randn(120, 120, 3)
     pixels[..., 1] *= 7
     pixels[..., 0] += -14
@@ -469,7 +469,33 @@ def test_normalize_std_per_channel():
         np.std(image.as_vector(keep_channels=True), axis=0), 1)
 
 
-def test_normalize_norm_per_channel():
+def test_normalize_std_image_per_channel():
+    pixels = np.random.randn(120, 120, 3)
+    pixels[..., 1] *= 9
+    pixels[..., 0] += -3
+    pixels[..., 2] /= 140
+    image = Image(pixels)
+    image.normalize_std_inplace(mode='per_channel')
+    assert_allclose(
+        np.mean(image.as_vector(keep_channels=True), axis=0), 0, atol=1e-10)
+    assert_allclose(
+        np.std(image.as_vector(keep_channels=True), axis=0), 1)
+
+
+def test_normalize_norm_image_per_channel():
+    pixels = np.random.randn(120, 120, 3)
+    pixels[..., 1] *= 17
+    pixels[..., 0] += -114
+    pixels[..., 2] /= 30
+    image = Image(pixels)
+    image.normalize_norm_inplace(mode='per_channel')
+    assert_allclose(
+        np.mean(image.as_vector(keep_channels=True), axis=0), 0, atol=1e-10)
+    assert_allclose(
+        np.linalg.norm(image.as_vector(keep_channels=True), axis=0), 1)
+
+
+def test_normalize_norm_masked_per_channel():
     pixels = np.random.randn(120, 120, 3)
     pixels[..., 1] *= 7
     pixels[..., 0] += -14


### PR DESCRIPTION
The methods `normalize_norm_inplace()` and `normalize_std_inplace()` were only defined in the `MaskedImage` class. This PR also adds them in the `Image` class and also updates the tests.
