### PR TITLE
Widgets fixes

### DIFF
--- a/menpo/visualize/widgets/base.py
+++ b/menpo/visualize/widgets/base.py
@@ -1302,6 +1302,9 @@ def visualize_fitting_results(fitting_results, figure_size=(7, 7), popup=False,
     if not isinstance(fitting_results, list):
         fitting_results = [fitting_results]
 
+    # check if all fitting_results have gt_shape in order to show the ced button
+    show_ced = all(not f.gt_shape is None for f in fitting_results)
+
     # find number of fitting_results
     n_fitting_results = len(fitting_results)
 
@@ -1494,13 +1497,18 @@ def visualize_fitting_results(fitting_results, figure_size=(7, 7), popup=False,
             im = image_number_wid.selected_index
 
         # create output str
-        info_txt = r"""
-            Initial error: {:.4f}
-            Final error: {:.4f}
-            {} iterations
-        """.format(fitting_results[im].initial_error(error_type=value),
-                   fitting_results[im].final_error(error_type=value),
-                   fitting_results[im].n_iters)
+        if fitting_results[im].gt_shape is not None:
+            info_txt = r"""
+                Initial error: {:.4f}
+                Final error: {:.4f}
+                {} iterations
+            """.format(fitting_results[im].initial_error(error_type=value),
+                       fitting_results[im].final_error(error_type=value),
+                       fitting_results[im].n_iters)
+        else:
+            info_txt = r"""
+                {} iterations
+            """.format(fitting_results[im].n_iters)
         if hasattr(fitting_results[im], 'n_levels'):  # Multilevel result
             info_txt += r"""
                 {} levels with downscale of {:.1f}
@@ -1557,7 +1565,7 @@ def visualize_fitting_results(fitting_results, figure_size=(7, 7), popup=False,
                                         value='me_norm',
                                         description='Error type')
     error_type_wid.on_trait_change(update_info, 'value')
-    plot_ced_but = ButtonWidget(description='Plot CED')
+    plot_ced_but = ButtonWidget(description='Plot CED', visible=show_ced)
     error_wid = ContainerWidget(children=[error_type_wid, plot_ced_but])
 
     # define function that updates options' widgets state
@@ -1618,7 +1626,11 @@ def visualize_fitting_results(fitting_results, figure_size=(7, 7), popup=False,
                                       error_wid, save_figure_wid])
         tab_wid.on_trait_change(save_fig_tab_fun, 'selected_index')
         wid = ContainerWidget(children=[image_number_wid, tab_wid])
-        tab_titles = ['Info', 'Result', 'Options', 'CED', 'Save figure']
+        if show_ced:
+            tab_titles = ['Info', 'Result', 'Options', 'CED', 'Save figure']
+        else:
+            tab_titles = ['Info', 'Result', 'Options', 'Error type',
+                          'Save figure']
         button_title = 'Fitting Results Menu'
     else:
         # do not show the plot ced button

--- a/menpo/visualize/widgets/helpers.py
+++ b/menpo/visualize/widgets/helpers.py
@@ -893,7 +893,7 @@ def landmark_options(group_keys, labels_keys, plot_function=None,
     landmarks = CheckboxWidget(description='Show landmarks',
                                value=landmarks_default)
     legend = CheckboxWidget(description='Show legend', value=legend_default)
-    numbering = CheckboxWidget(description='Show Numbering',
+    numbering = CheckboxWidget(description='Show numbering',
                                value=numbering_default)
     group = DropdownWidget(values=group_keys, description='Group')
     labels_toggles = [[ToggleButtonWidget(description=k, value=True)
@@ -1704,7 +1704,7 @@ def final_result_options(group_keys, plot_function=None, title='Final Result',
     mode.value = subplots_enabled_default
     show_legend = CheckboxWidget(description='Show legend',
                                  value=legend_default)
-    show_numbering = CheckboxWidget(description='Show Numbering',
+    show_numbering = CheckboxWidget(description='Show numbering',
                                     value=numbering_default)
 
     # Group widgets
@@ -2039,7 +2039,7 @@ def iterations_result_options(n_iters, image_has_gt_shape, n_points,
     plot_mode.value = subplots_enabled_default
     show_legend = CheckboxWidget(description='Show legend',
                                  value=legend_default)
-    show_numbering = CheckboxWidget(description='Show Numbering',
+    show_numbering = CheckboxWidget(description='Show numbering',
                                     value=numbering_default)
     # if just one iteration, disable multiple options
     if n_iters == 1:
@@ -2174,12 +2174,8 @@ def iterations_result_options(n_iters, image_has_gt_shape, n_points,
         show_image.visible = value
         show_legend.visible = value
         show_numbering.visible = value
-        if image_has_gt_shape and value:
-            plot_errors_button.visible = True
-            plot_displacements.visible = True
-        else:
-            plot_errors_button.visible = False
-            plot_displacements.visible = False
+        plot_errors_button.visible = image_has_gt_shape and value
+        plot_displacements.visible = value
         if value:
             if iterations_mode.value == 0:
                 animation_wid.visible = True
@@ -2339,7 +2335,7 @@ def update_iterations_result_options(iterations_result_wid, n_iters,
         iterations_result_wid.children[2].children[4].visible = \
             iterations_result_wid.children[0].value and image_has_gt_shape
         iterations_result_wid.children[2].children[5].visible = \
-            iterations_result_wid.children[0].value and image_has_gt_shape
+            iterations_result_wid.children[0].value
         # store the flag
         iterations_result_wid.image_has_gt_shape = image_has_gt_shape
 


### PR DESCRIPTION
This PR solves two bugs in widgets:
1. `visualize_images` now supports images without landmarks. The user can also pass a mixed list of landmarked, non-landmarked, masked and multichannel images.
2. `visualize_fitting_results` now visualizes results that do not have a groundtruth shape (`gt_shape` is `None`). The user can pass a list of mixed fitting result objects that either have or not a gt shape.
