### PR TITLE
Some fixes for PIL image importing

### DIFF
--- a/menpo/image/base.py
+++ b/menpo/image/base.py
@@ -1350,7 +1350,7 @@ class Image(Vectorizable, LandmarkableViewable):
         if self.n_dims != 2 or self.n_channels not in [1, 3]:
             raise ValueError('Can only convert greyscale or RGB 2D images. '
                              'Received a {} channel {}D image.'.format(
-                self.n_channels, self.ndims))
+                self.n_channels, self.n_dims))
         # Slice off the channel for greyscale images
         pixels = self.pixels[..., 0] if self.n_channels == 1 else self.pixels
         return PILImage.fromarray((pixels * 255).astype(np.uint8))

--- a/menpo/io/input/base.py
+++ b/menpo/io/input/base.py
@@ -59,35 +59,36 @@ def same_name(asset):
             for p in landmark_file_paths(pattern)}
 
 
-def import_image(filepath, landmark_resolver=same_name):
-    r"""Single image (and associated landmarks) importer.
+def import_image(filepath, landmark_resolver=same_name, normalise=True):
+    r"""
+    Single image (and associated landmarks) importer.
 
-    Iff an image file is found at `filepath`, returns a :class:`menpo.image
-    .MaskedImage` representing it. Landmark files sharing the same filename
+    Iff an image file is found at `filepath`, returns a :map:`Image` or subclass
+    representing it. Landmark files sharing the same filename
     will be imported and attached too. If the image defines a mask,
     this mask will be imported.
-
-    This method is valid for both traditional images and spatial image types.
 
     Parameters
     ----------
     filepath : `str`
         A relative or absolute filepath to an image file.
-
     landmark_resolver : `function`, optional
         This function will be used to find landmarks for the
         image. The function should take one argument (the image itself) and
         return a dictionary of the form ``{'group_name': 'landmark_filepath'}``
         Default finds landmarks with the same name as the image file.
+    normalise : `bool`, optional
+        If ``True``, normalise the image pixels between 0 and 1 and convert
+        to floating point.
 
     Returns
     -------
-    :map:`Image`
-        An instantiated :map:`Image` or subclass thereof
-
+    images : :map:`Image` or list of
+        An instantiated :map:`Image` or subclass thereof or a list of images.
     """
+    kwargs = {'normalise': normalise}
     return _import(filepath, image_types, has_landmarks=True,
-                   landmark_resolver=landmark_resolver)
+                   landmark_resolver=landmark_resolver, importer_kwargs=kwargs)
 
 
 def import_landmark_file(filepath, asset=None):
@@ -112,8 +113,9 @@ def import_landmark_file(filepath, asset=None):
 
 
 def import_images(pattern, max_images=None, landmark_resolver=same_name,
-                  verbose=False):
-    r"""Multiple image import generator.
+                  normalise=True, verbose=False):
+    r"""
+    Multiple image import generator.
 
     Makes it's best effort to import and attach relevant related
     information such as landmarks. It searches the directory for files that
@@ -123,22 +125,21 @@ def import_images(pattern, max_images=None, landmark_resolver=same_name,
     of data to take place as data is imported (e.g. cropping images to
     landmarks as they are imported for memory efficiency).
 
-
     Parameters
     ----------
     pattern : `str`
         The glob path pattern to search for images.
-
     max_images : positive `int`, optional
         If not ``None``, only import the first ``max_images`` found. Else,
         import all.
-
     landmark_resolver : `function`, optional
         This function will be used to find landmarks for the
         image. The function should take one argument (the image itself) and
         return a dictionary of the form ``{'group_name': 'landmark_filepath'}``
         Default finds landmarks with the same name as the image file.
-
+    normalise : `bool`, optional
+        If ``True``, normalise the images between 0.0 and 1.0 and convert
+        to ``np.float``.
     verbose : `bool`, optional
         If ``True`` progress of the importing will be dynamically reported.
 
@@ -161,11 +162,13 @@ def import_images(pattern, max_images=None, landmark_resolver=same_name,
         >>>    im.crop_inplace((0, 0), (100, 100))  # crop to a sensible size as we go
         >>>    images.append(im)
     """
+    kwargs = {'normalise': normalise}
     for asset in _import_glob_generator(pattern, image_types,
                                         max_assets=max_images,
                                         has_landmarks=True,
                                         landmark_resolver=landmark_resolver,
-                                        verbose=verbose):
+                                        verbose=verbose,
+                                        importer_kwargs=kwargs):
         yield asset
 
 

--- a/menpo/io/input/extensions.py
+++ b/menpo/io/input/extensions.py
@@ -1,6 +1,6 @@
 # A list of extensions that different importers support.
 from .landmark import LM2Importer, LJSONImporter
-from .image import PILImporter
+from .image import PILImporter, PILGIFImporter
 from .landmark_image import ImageASFImporter, ImagePTSImporter
 
 
@@ -9,9 +9,11 @@ image_types = {'.bmp': PILImporter,
                '.dcx': PILImporter,
                '.eps': PILImporter,
                '.ps': PILImporter,
-               '.gif': PILImporter,
+               '.gif': PILGIFImporter,
                '.im': PILImporter,
                '.jpg': PILImporter,
+               '.jpg2': PILImporter,
+               '.jpx': PILImporter,
                '.jpe': PILImporter,
                '.jpeg': PILImporter,
                '.pcd': PILImporter,
@@ -32,4 +34,3 @@ image_landmark_types = {'.asf': ImageASFImporter,
                         '.pts': ImagePTSImporter,
                         '.ptsx': ImagePTSImporter,
                         '.ljson': LJSONImporter}
-

--- a/menpo/io/input/image.py
+++ b/menpo/io/input/image.py
@@ -1,28 +1,119 @@
 import numpy as np
 import PIL.Image as PILImage
 from .base import Importer
-from menpo.image import Image
+from menpo.image import Image, MaskedImage, BooleanImage
 
 
 class PILImporter(Importer):
     r"""
-    Imports an image using PIL
+    Imports an image using PIL.
+
+    Different image modes cause different importing strategies.
+
+    RGB, L, I:
+        Imported as either `float` of `uint8` depending on normalisation flag.
+    RGBA:
+        Imported as :map:`MaskedImage` if normalise is ``True`` else imported
+        as a 4 channel `uint8` image.
+    1:
+        Imported as a :map:`BooleanImage`. Normalisation is ignored.
 
     Parameters
     ----------
     filepath : string
         Absolute filepath of image
+    normalise : `bool`, optional
+        If ``True``, normalise between 0.0 and 1.0 and convert to float. If
+        ``False`` just pass whatever PIL imports back (according
+        to types rules outlined in constructor).
     """
-
-    def __init__(self, filepath):
+    def __init__(self, filepath, normalise=True):
         super(PILImporter, self).__init__(filepath)
+        self._pil_image = None
+        self.normalise = normalise
 
     def build(self):
         r"""
-        Read the image using PIL and then use the
-        :class:`menpo.image.base.MaskedImage` constructor to create a class.
-        Normalise between 0 and 1.0
+        Read the image using PIL and then use the :map:`Image` constructor to
+        create a class.
         """
         self._pil_image = PILImage.open(self.filepath)
-        image_pixels = np.array(self._pil_image, dtype=np.float) / 255.0
-        return Image(image_pixels)
+        mode = self._pil_image.mode
+        if mode == 'RGBA':
+            # RGB with Alpha Channel
+            # If we normalise it then we convert to floating point
+            # and set the alpha channel to the mask
+            if self.normalise:
+                alpha = np.array(self._pil_image)[..., 3].astype(np.bool)
+                image_pixels = self._pil_to_numpy(True,
+                                                  convert='RGB')
+                image = MaskedImage(image_pixels, mask=alpha)
+            else:
+                # With no normalisation we just return the pixels
+                image = Image(self._pil_to_numpy(False))
+        elif mode in ['L', 'I', 'RGB']:
+            # Greyscale, Integer and RGB images
+            image = Image(self._pil_to_numpy(self.normalise))
+        elif mode == '1':
+            # Can't normalise a binary image
+            image = BooleanImage(self._pil_to_numpy(False))
+        elif mode == 'P':
+            # Convert pallete images to RGB
+            image = Image(self._pil_to_numpy(self.normalise, convert='RGB'))
+        else:
+            raise ValueError('Unexpected mode for PIL: {}'.format(mode))
+        return image
+
+    def _pil_to_numpy(self, normalise, convert=None):
+        dtype = np.float if normalise else None
+        p = self._pil_image.convert(convert) if convert else self._pil_image
+        np_pixels = np.array(p, dtype=dtype, copy=True)
+        return np_pixels / 255.0 if normalise else np_pixels
+
+
+class PILGIFImporter(PILImporter):
+    r"""
+    Imports a GIF using PIL. Correctly encodes the pallete
+    (`P` for `RGB` (Pallete mode).
+
+    For multi-frame GIF animations, will return a list of images containing
+    each frame.
+
+    Parameters
+    ----------
+    filepath : string
+        Absolute filepath of image
+    normalise : `bool`, optional
+        If ``True``, normalise between 0.0 and 1.0 and convert to float. If
+        ``False`` just pass whatever PIL imports back (according
+        to types rules outlined in constructor).
+    """
+
+    def __init__(self, filepath, normalise=True):
+        super(PILGIFImporter, self).__init__(filepath, normalise=normalise)
+
+    def build(self):
+        r"""
+        Read the image using PIL and then use the :map:`Image` constructor to
+        create a class.
+        """
+        self._pil_image = PILImage.open(self.filepath)
+        # By default GIFs use a
+        if self._pil_image.mode == 'P':
+            # Do we need this duration information for playback?
+            # duration = self._pil_image.info['duration']
+            images = []
+            try:
+                while 1:  # Keep looping until we hit the end of the GIF
+                    np_pixels = self._pil_to_numpy(self.normalise,
+                                                   convert='RGB')
+                    images.append(Image(np_pixels))
+                    # Seek to the next frame
+                    self._pil_image.seek(self._pil_image.tell() + 1)
+            except EOFError:
+                pass  # Exhausted GIF
+        else:
+            raise ValueError('Unknown mode for GIF: {}'.format(
+                self._pil_image.mode))
+
+        return images

--- a/menpo/io/test/io_import_test.py
+++ b/menpo/io/test/io_import_test.py
@@ -1,5 +1,8 @@
 import os
+import numpy as np
+from mock import patch
 from nose.tools import raises
+from PIL import Image as PILImage
 import menpo.io as mio
 
 
@@ -49,7 +52,15 @@ def test_path():
 
 def test_import_image():
     img_path = os.path.join(mio.data_dir_path(), 'einstein.jpg')
-    mio.import_image(img_path)
+    im = mio.import_image(img_path)
+    assert im.pixels.dtype == np.float
+    assert im.n_channels == 1
+
+
+def test_import_image_no_norm():
+    img_path = os.path.join(mio.data_dir_path(), 'einstein.jpg')
+    im = mio.import_image(img_path, normalise=False)
+    assert im.pixels.dtype == np.uint8
 
 
 def test_import_landmark_file():
@@ -87,3 +98,166 @@ def test_import_images_wrong_path_raises_value_error():
 @raises(ValueError)
 def test_import_landmark_files_wrong_path_raises_value_error():
     list(mio.import_landmark_files('asldfjalkgjlaknglkajlekjaltknlaekstjlakj'))
+
+
+@patch('menpo.io.input.image.PILImage.open')
+@patch('menpo.io.input.base.Path.is_file')
+def test_importing_RGBA_no_normalise(is_file, mock_image):
+    mock_image.return_value = PILImage.new('RGBA', (10, 10))
+    is_file.return_value = True
+
+    im = mio.import_image('fake_image_being_mocked.jpg', normalise=False)
+    assert im.shape == (10, 10)
+    assert im.n_channels == 4
+    assert im.pixels.dtype == np.uint8
+
+
+@patch('menpo.io.input.image.PILImage.open')
+@patch('menpo.io.input.base.Path.is_file')
+def test_importing_RGBA_normalise(is_file, mock_image):
+    from menpo.image import MaskedImage
+
+    mock_image.return_value = PILImage.new('RGBA', (10, 10))
+    is_file.return_value = True
+
+    im = mio.import_image('fake_image_being_mocked.jpg', normalise=True)
+    assert im.shape == (10, 10)
+    assert im.n_channels == 3
+    assert im.pixels.dtype == np.float
+    assert type(im) == MaskedImage
+
+
+@patch('menpo.io.input.image.PILImage.open')
+@patch('menpo.io.input.base.Path.is_file')
+def test_importing_L_no_normalise(is_file, mock_image):
+    mock_image.return_value = PILImage.new('L', (10, 10))
+    is_file.return_value = True
+
+    im = mio.import_image('fake_image_being_mocked.jpg', normalise=False)
+    assert im.shape == (10, 10)
+    assert im.n_channels == 1
+    assert im.pixels.dtype == np.uint8
+
+
+@patch('menpo.io.input.image.PILImage.open')
+@patch('menpo.io.input.base.Path.is_file')
+def test_importing_L_normalise(is_file, mock_image):
+    mock_image.return_value = PILImage.new('L', (10, 10))
+    is_file.return_value = True
+
+    im = mio.import_image('fake_image_being_mocked.jpg', normalise=True)
+    assert im.shape == (10, 10)
+    assert im.n_channels == 1
+    assert im.pixels.dtype == np.float
+
+
+@patch('menpo.io.input.image.PILImage.open')
+@patch('menpo.io.input.base.Path.is_file')
+def test_importing_I_normalise(is_file, mock_image):
+    mock_image.return_value = PILImage.new('I', (10, 10))
+    is_file.return_value = True
+
+    im = mio.import_image('fake_image_being_mocked.jpg', normalise=True)
+    assert im.shape == (10, 10)
+    assert im.n_channels == 1
+    assert im.pixels.dtype == np.float
+
+
+@patch('menpo.io.input.image.PILImage.open')
+@patch('menpo.io.input.base.Path.is_file')
+def test_importing_I_no_normalise(is_file, mock_image):
+    mock_image.return_value = PILImage.new('I', (10, 10))
+    is_file.return_value = True
+
+    im = mio.import_image('fake_image_being_mocked.jpg', normalise=False)
+    assert im.shape == (10, 10)
+    assert im.n_channels == 1
+    assert im.pixels.dtype == np.int32
+
+
+@patch('menpo.io.input.image.PILImage.open')
+@patch('menpo.io.input.base.Path.is_file')
+def test_importing_1_normalise(is_file, mock_image):
+    from menpo.image import BooleanImage
+
+    mock_image.return_value = PILImage.new('1', (10, 10))
+    is_file.return_value = True
+
+    im = mio.import_image('fake_image_being_mocked.jpg', normalise=True)
+    assert im.shape == (10, 10)
+    assert im.n_channels == 1
+    assert im.pixels.dtype == np.bool
+    assert type(im) == BooleanImage
+
+
+@patch('menpo.io.input.image.PILImage.open')
+@patch('menpo.io.input.base.Path.is_file')
+def test_importing_1_no_normalise(is_file, mock_image):
+    from menpo.image import BooleanImage
+
+    mock_image.return_value = PILImage.new('1', (10, 10))
+    is_file.return_value = True
+
+    im = mio.import_image('fake_image_being_mocked.jpg', normalise=False)
+    assert im.shape == (10, 10)
+    assert im.n_channels == 1
+    assert im.pixels.dtype == np.bool
+    assert type(im) == BooleanImage
+
+
+@patch('menpo.io.input.image.PILImage.open')
+@patch('menpo.io.input.base.Path.is_file')
+def test_importing_P_normalise(is_file, mock_image):
+    mock_image.return_value = PILImage.new('P', (10, 10))
+    is_file.return_value = True
+
+    im = mio.import_image('fake_image_being_mocked.jpg', normalise=True)
+    assert im.shape == (10, 10)
+    assert im.n_channels == 3
+    assert im.pixels.dtype == np.float
+
+
+@patch('menpo.io.input.image.PILImage.open')
+@patch('menpo.io.input.base.Path.is_file')
+def test_importing_P_no_normalise(is_file, mock_image):
+    mock_image.return_value = PILImage.new('P', (10, 10))
+    is_file.return_value = True
+
+    im = mio.import_image('fake_image_being_mocked.jpg', normalise=False)
+    assert im.shape == (10, 10)
+    assert im.n_channels == 3
+    assert im.pixels.dtype == np.uint8
+
+
+@patch('menpo.io.input.image.PILImage.open')
+@patch('menpo.io.input.base.Path.is_file')
+def test_importing_GIF_normalise(is_file, mock_image):
+    mock_image.return_value = PILImage.new('P', (10, 10))
+    is_file.return_value = True
+
+    im = mio.import_image('fake_image_being_mocked.gif', normalise=True)
+    assert im.shape == (10, 10)
+    assert im.n_channels == 3
+    assert im.pixels.dtype == np.float
+
+
+@patch('menpo.io.input.image.PILImage.open')
+@patch('menpo.io.input.base.Path.is_file')
+def test_importing_GIF_no_normalise(is_file, mock_image):
+    mock_image.return_value = PILImage.new('P', (10, 10))
+    is_file.return_value = True
+
+    im = mio.import_image('fake_image_being_mocked.gif', normalise=False)
+    assert im.shape == (10, 10)
+    assert im.n_channels == 3
+    assert im.pixels.dtype == np.uint8
+
+
+@patch('menpo.io.input.image.PILImage.open')
+@patch('menpo.io.input.base.Path.is_file')
+@raises(ValueError)
+def test_importing_GIF_non_pallete_exception(is_file, mock_image):
+    mock_image.return_value = PILImage.new('RGB', (10, 10))
+    is_file.return_value = True
+
+    mio.import_image('fake_image_being_mocked.gif', normalise=False)


### PR DESCRIPTION
We were not handling PIL images properly, now we do (in terms of
the data type). We can now handle more image types including
alpha channel PNGs. I also added a kwarg to allow you to
skip the normalisation of images.

This also adds a `GIF` importer which can import animated `GIF`s.
