### PR TITLE
path is now preserved on image warping

### DIFF
--- a/menpo/image/base.py
+++ b/menpo/image/base.py
@@ -935,6 +935,8 @@ class Image(Vectorizable, LandmarkableViewable):
         if warp_landmarks and self.has_landmarks:
             warped_image.landmarks = self.landmarks
             transform.pseudoinverse().apply_inplace(warped_image.landmarks)
+        if hasattr(self, 'path'):
+            warped_image.path = self.path
         return warped_image
 
     def _build_warped_to_mask(self, template_mask, sampled_pixel_values):
@@ -1017,6 +1019,8 @@ class Image(Vectorizable, LandmarkableViewable):
         if warp_landmarks and self.has_landmarks:
             warped_image.landmarks = self.landmarks
             transform.pseudoinverse().apply_inplace(warped_image.landmarks)
+        if hasattr(self, 'path'):
+            warped_image.path = self.path
         return warped_image
 
     def rescale(self, scale, round='ceil', order=1):

--- a/menpo/image/boolean.py
+++ b/menpo/image/boolean.py
@@ -381,6 +381,8 @@ class BooleanImage(Image):
         boolean_image = BooleanImage(warped.pixels.reshape(template_shape))
         if warped.has_landmarks:
             boolean_image.landmarks = warped.landmarks
+        if hasattr(warped, 'path'):
+            boolean_image.path = warped.path
         return boolean_image
 
     def _build_warped_to_mask(self, template_mask, sampled_pixel_values,

--- a/menpo/image/test/image_basics_test.py
+++ b/menpo/image/test/image_basics_test.py
@@ -1,7 +1,10 @@
 import numpy as np
 from nose.tools import raises
-from numpy.testing import assert_allclose
+from pathlib import Path
+
+import menpo
 from menpo.image import Image, MaskedImage, BooleanImage
+from menpo.transform import UniformScale
 
 
 def test_image_as_masked():
@@ -22,3 +25,26 @@ def test_masked_image_as_unmasked():
 def test_boolean_image_as_masked_raises_not_implemented_error():
     b_img = BooleanImage.blank((4, 5))
     b_img.as_masked()
+
+
+def test_warp_to_shape_preserves_path():
+    bb = menpo.io.import_builtin_asset.breakingbad_jpg()
+    bb2 = bb.rescale(0.1)
+    assert hasattr(bb2, 'path')
+    assert bb2.path == bb.path
+
+
+def test_warp_to_mask_preserves_path():
+    bb = menpo.io.import_builtin_asset.breakingbad_jpg()
+    no_op = UniformScale(1.0, n_dims=2)
+    bb2 = bb.warp_to_mask(BooleanImage.blank((10, 10)), no_op)
+    assert hasattr(bb2, 'path')
+    assert bb2.path == bb.path
+
+
+def test_warp_to_shape_boolean_preserves_path():
+    i1 = BooleanImage.blank((10, 10))
+    i1.path = Path('.')
+    i2 = i1.rescale(0.8)
+    assert hasattr(i2, 'path')
+    assert i2.path == i1.path


### PR DESCRIPTION
up to now, path information is lost whenever an image warp is performed (this is very commonly what we do as a preprocessing step which is particularly painful). This PR ensures that the `.path` property is preserved on both `warp_to_shape` and `warp_to_mask`.
