### PR TITLE
all menpo io glob operations are now always sorted

### DIFF
--- a/menpo/io/input/base.py
+++ b/menpo/io/input/base.py
@@ -486,9 +486,9 @@ def _pathlib_glob_for_pattern(pattern):
         # the glob pattern is in the middle of a path segment. pair back
         # to the nearest dir and add the reminder to the pattern
         preglob, pattern_prefix = os.path.split(preglob)
-        pattern  = pattern_prefix + pattern
+        pattern = pattern_prefix + pattern
     p = Path(preglob)
-    return p.glob(str(pattern))
+    return sorted(p.glob(str(pattern)))
 
 
 def glob_with_suffix(pattern, extensions_map):


### PR DESCRIPTION
now we guarantee that any time a glob is used in `menpo.io` we will always return alphabetically sorted paths.
