### PR TITLE
2D Rotation convenience constructor, Image.rotate_ccw_about_centre

### DIFF
--- a/menpo/image/base.py
+++ b/menpo/image/base.py
@@ -1238,13 +1238,26 @@ class Image(Vectorizable, LandmarkableViewable):
         # floating point inaccuracy.
         return self.rescale(scales, round='round', order=order)
 
-    def rotate_about_centre(self, theta, degrees=True, cval=0):
+    def rotate_ccw_about_centre(self, theta, degrees=True, cval=0):
+        r"""
+        Return a rotation of this image clockwise about it's centre.
+
+        Parameters
+        ----------
+        theta : ``float``
+            The angle of rotation about the origin
+        degrees : ``bool``, optional
+            If true theta is interpreted as a degree. If False, theta is
+            interpreted as radians.
+        cval : ``float``, optional
+            The value to be set outside the rotated image boundaries
+        """
         if self.n_dims != 2:
             raise ValueError('Image rotation is presently only supported on '
                              '2D images')
         # create a translation that moves the centre of the image to the origin
         t = Translation(self.centre)
-        r = Rotation.from_2D_angle(theta, degrees=degrees)
+        r = Rotation.from_2d_ccw_angle(theta, degrees=degrees)
         r_about_centre = t.pseudoinverse().compose_before(r).compose_before(t)
         return self.warp_to_shape(self.shape, r_about_centre.pseudoinverse(),
                                   warp_landmarks=True, cval=cval)

--- a/menpo/transform/homogeneous/rotation.py
+++ b/menpo/transform/homogeneous/rotation.py
@@ -52,7 +52,23 @@ class Rotation(DiscreteAffine, Similarity):
         self.set_rotation_matrix(rotation_matrix, skip_checks=skip_checks)
 
     @classmethod
-    def from_2D_angle(cls, theta, degrees=True):
+    def from_2d_ccw_angle(cls, theta, degrees=True):
+        r"""
+        Convenience constructor for 2D CCW rotations about the origin
+
+        Parameters
+        ----------
+        theta : float
+            The angle of rotation about the origin
+        degrees : bool, optional
+            If true theta is interpreted as a degree. If False, theta is
+            interpreted as radians.
+
+        Returns
+        -------
+        rotation : :map:`Rotation`
+            A 2D rotation transform.
+        """
         if degrees:
             # convert to radians
             theta = theta * np.pi / 180.0


### PR DESCRIPTION
Adds a convenience constructor for 2D Rotation transforms and a new `rotate_about_centre` method on Image classes.
