### PR TITLE
WIP: remove_all_landmarks convienience method, quick lm filter

### DIFF
--- a/menpo/landmark/base.py
+++ b/menpo/landmark/base.py
@@ -1,5 +1,6 @@
 import abc
 from collections import OrderedDict, MutableMapping
+import fnmatch
 
 import numpy as np
 
@@ -58,6 +59,9 @@ class Landmarkable(Copyable):
         :type: `int`
         """
         return self.landmarks.n_groups
+
+    def remove_all_landmarks(self):
+        self._landmarks = None
 
 
 class LandmarkableViewable(Landmarkable, Viewable):
@@ -272,6 +276,14 @@ class LandmarkManager(MutableMapping, Transformable, Viewable):
         :type: list of `string`
         """
         return self._landmark_groups.keys()
+
+    def keys_matching(self, glob_pattern):
+        return fnmatch.filter(self.keys(), glob_pattern)
+
+    def items_matching(self, glob_pattern):
+        for k, v in self.items():
+            if fnmatch.fnmatch(k, glob_pattern):
+                yield k, v
 
     def _transform_inplace(self, transform):
         for group in self._landmark_groups.values():

--- a/menpo/landmark/base.py
+++ b/menpo/landmark/base.py
@@ -60,9 +60,6 @@ class Landmarkable(Copyable):
         """
         return self.landmarks.n_groups
 
-    def remove_all_landmarks(self):
-        self._landmarks = None
-
 
 class LandmarkableViewable(Landmarkable, Viewable):
     r"""
@@ -278,9 +275,36 @@ class LandmarkManager(MutableMapping, Transformable, Viewable):
         return self._landmark_groups.keys()
 
     def keys_matching(self, glob_pattern):
-        return fnmatch.filter(self.keys(), glob_pattern)
+        r"""
+        Yield only landmark group names (keys) matching a given glob.
+
+        Parameters
+        ----------
+        glob_pattern : `str`
+            A glob pattern e.g. 'frontal_face_*'
+
+        Yields
+        ------
+        keys: group labels that match the glob pattern
+        """
+        for key in fnmatch.filter(self.keys(), glob_pattern):
+            yield key
 
     def items_matching(self, glob_pattern):
+        r"""
+        Yield only items ``(group, LandmarkGroup)`` where the key matches a
+        given glob.
+
+        Parameters
+        ----------
+        glob_pattern : `str`
+            A glob pattern e.g. 'frontal_face_*'
+
+        Yields
+        ------
+        item : ``(group, LandmarkGroup)``
+            Tuple of group, LandmarkGroup where the group matches the glob
+        """
         for k, v in self.items():
             if fnmatch.fnmatch(k, glob_pattern):
                 yield k, v


### PR DESCRIPTION
adds `.remove_all_landmarks()` API to `Landmarkable` to safely remove all annotations. Also adds convience filter methods on landmarks, which are useful with `menpodetect`. For instance:

```python
>> print(list(group_photo.landmarks.keys()))
frontal_face_00
frontal_face_01
frontal_face_02
PTS
ground_truth

>> print(list(group_photo.landmarks.keys_matching('frontal_face*')))
frontal_face_00
frontal_face_01
frontal_face_02
```