### PR TITLE
allow index masking of PointCloud

### DIFF
--- a/menpo/model/pca.py
+++ b/menpo/model/pca.py
@@ -72,7 +72,8 @@ class PCAModel(MeanInstanceLinearModel):
                         n_samples,
                     progress_bar_str(float(i + 1) / n_samples, show_bar=True)))
             data[i] = sample.as_vector()
-
+        if verbose:
+            print('')
         # compute pca
         e_vectors, e_values, mean = principal_component_decomposition(
             data, whiten=False,  centre=centre, bias=bias, inplace=True)

--- a/menpo/shape/pointcloud.py
+++ b/menpo/shape/pointcloud.py
@@ -247,25 +247,18 @@ class PointCloud(Shape):
 
     def from_mask(self, mask):
         """
-        A 1D boolean array with the same number of elements as the number of
-        points in the pointcloud. This is then broadcast across the dimensions
-        of the pointcloud and returns a new pointcloud containing only those
-        points that were ``True`` in the mask.
+        Return a copy of this PointCloud which only contains some points.
 
         Parameters
         ----------
-        mask : ``(n_points,)`` `ndarray`
-            1D array of booleans
+        mask : any valid ndarray index
+            any valid indexer for a dimension of a numpy array
 
         Returns
         -------
         pointcloud : :map:`PointCloud`
             A new pointcloud that has been masked.
 
-        Raises
-        ------
-        ValueError
-            Mask must have same number of points as pointcloud.
         """
         pc = self.copy()
         pc.points = pc.points[mask, :]

--- a/menpo/shape/pointcloud.py
+++ b/menpo/shape/pointcloud.py
@@ -267,9 +267,6 @@ class PointCloud(Shape):
         ValueError
             Mask must have same number of points as pointcloud.
         """
-        if mask.shape[0] != self.n_points:
-            raise ValueError('Mask must be a 1D boolean array of the same '
-                             'number of entries as points in this PointCloud.')
         pc = self.copy()
         pc.points = pc.points[mask, :]
         return pc


### PR DESCRIPTION
Currently we have a guard in `PointCloud.from_mask()` that means it can only be used with boolean masks. There are use cases where it is useful to mask PointClouds with indices (e.g. `[1, 2]` not `[False, True, True]`). As we only call numpy anyway I propose we remove the guard so we can use both styles.

Also very minor print fix for verbose PCA (was missing a newline after completion).