### PR TITLE
Move docs to Sphinx 1.3b2

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,5 +1,4 @@
-sphinx==1.2.3
+sphinx==1.3b2
 sphinx_rtd_theme==0.1.6
-sphinxmapxrefrole==0.1.0
-numpydoc==0.5
+sphinxmapxrefrole==0.2.1
 pathlib==1.0

--- a/docs/source/_static/rtd_hack.css
+++ b/docs/source/_static/rtd_hack.css
@@ -1,0 +1,31 @@
+/* Code References (using the class or map commands) */
+a>code.xref.py.py-class.docutils.literal {
+    color: #2980B9;
+    font-weight: bold;
+    padding: 0;
+    font-size: 90%;
+}
+a:hover>code.xref.py.py-class.docutils.literal {
+    color: purple;
+}
+/* Class names */
+code.descclassname, code.descname {
+    background-color: transparent;
+    font-size: 100% !important;
+    border: none;
+    padding: 0;
+    color: #000000;
+}
+/* Inline Code */
+code.docutils.literal {
+    color: #000000;
+    font-weight: bold;
+}
+/* Inline Code Links e.g. for module links*/
+a>code.docutils.literal {
+    color: gray;
+    font-weight: bold;
+    border: none;
+    background: transparent;
+    font-size: 80%;
+}

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -53,7 +53,7 @@ import menpo
 # -- General configuration -----------------------------------------------------
 
 # If your documentation needs a minimal Sphinx version, state it here.
-#needs_sphinx = '1.0'
+needs_sphinx = '1.3'
 
 # Add any Sphinx extension module names here, as strings. They can be extensions
 # coming with Sphinx (named 'sphinx.ext.*') or your custom ones.
@@ -63,8 +63,9 @@ extensions = ['sphinx.ext.autodoc',
               'sphinx.ext.mathjax',
               'sphinx.ext.viewcode',
               'sphinx.ext.autosummary',
-              'numpydoc',
+              'sphinx.ext.napoleon',
               'sphinxext.ref_prettify',
+              'sphinxext.theme_hack',
               'sphinxmapxrefrole']
 
 # Import the mapping dictionary and set it for sphinxmapxrefrole
@@ -73,10 +74,17 @@ xref_mapping_dict = xref_map
 
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ['_templates']
+html_static_path = ['_static']
 
 # Otherwise Sphinx emits thousands of warnings
-numpydoc_show_class_members = False
-numpydoc_class_members_toctree = False
+napoleon_include_special_with_doc = False
+napoleon_numpy_docstring = True
+napoleon_use_rtype = False
+napoleon_use_ivar = False
+napoleon_use_param = True
+napoleon_use_admonition_for_examples = True
+napoleon_use_admonition_for_notes = True
+napoleon_use_admonition_for_references = True
 
 # The suffix of source filenames.
 source_suffix = '.rst'
@@ -87,7 +95,7 @@ source_suffix = '.rst'
 # The master toctree document.
 master_doc = 'index'
 
-# Sort attributes by type (functions seperate from properties)
+# Sort attributes by type (functions separate from properties)
 autodoc_member_order = 'groupwise'
 
 # General information about the project.
@@ -134,7 +142,7 @@ exclude_patterns = ['_build', '**/test/**']
 #show_authors = False
 
 # The name of the Pygments (syntax highlighting) style to use.
-pygments_style = 'sphinx'
+#pygments_style = 'sphinx'
 
 # A list of ignored prefixes for module index sorting.
 #modindex_common_prefix = []

--- a/docs/sphinxext/ref_prettify.py
+++ b/docs/sphinxext/ref_prettify.py
@@ -7,6 +7,7 @@ def setup(app):
     include the full package path. This makes the base classes much prettier.
     """
     app.add_role_to_domain('py', 'class', truncate_class_role)
+    return {'parallel_read_safe': True}
 
 
 def truncate_class_role(name, rawtext, text, lineno, inliner,

--- a/docs/sphinxext/theme_hack.py
+++ b/docs/sphinxext/theme_hack.py
@@ -1,0 +1,4 @@
+def setup(app):
+    app.add_stylesheet('rtd_hack.css')
+
+    return {'parallel_read_safe': True, 'parallel_write_safe': True}


### PR DESCRIPTION
Now we are using Napolean, which has been introduced to
Sphinx 1.3, and parses both google doc style comments and
numpydoc style comments. Most importantly, it supports things
like Yield which is very nice. Unfortunately, it parses cross
references as code blocks and so I had to add some hacky code
that basically overrides the formatting of the cross references
in CSS.

I also bumped the requirements file.