### PR TITLE
landmark module documentation fixes

### DIFF
--- a/docs/source/api/menpo/landmark/index.rst
+++ b/docs/source/api/menpo/landmark/index.rst
@@ -23,8 +23,8 @@ Landmarks & Labeller
 .. toctree::
   :maxdepth: 1
 
-  LandmarkGroup
   LandmarkManager
+  LandmarkGroup
   labeller
 
 

--- a/menpo/landmark/base.py
+++ b/menpo/landmark/base.py
@@ -83,14 +83,22 @@ class Landmarkable(Copyable):
 
 
 class LandmarkManager(MutableMapping, Transformable):
-    """
-    Class for storing and manipulating Landmarks associated with an object.
-    This involves managing the internal dictionary, as well as providing
-    convenience functions for operations like viewing.
+    """Store for :map:`LandmarkGroup` instances associated with an object
 
-    A LandmarkManager ensures that all it's Landmarks are of the
-    same dimensionality.
+    Every :map:`Landmarkable` instance has an instance of this class available
+    at the ``.landmarks`` property.  It is through this class that all access
+    to landmarks attached to instances is handled. In general the
+    :map:`LandmarkManager` provides a dictionary-like interface for storing
+    landmarks. :map:`LandmarkGroup` instances are stored under string keys -
+    these keys are refereed to as the **group name**. A special case is
+    where there is a single unambiguous :map:`LandmarkGroup` attached to a
+    :map:`LandmarkManager` - in this case ``None`` can be used as a key to
+    access the sole group.
 
+
+    Note that all landmarks stored on a :map:`Landmarkable` in it's attached
+    :map:`LandmarkManager` are automatically transformed and copied with their
+    parent object.
     """
     def __init__(self):
         super(LandmarkManager, self).__init__()
@@ -473,14 +481,13 @@ class LandmarkGroup(MutableMapping, Copyable, Viewable):
         return self._pointcloud.n_dims
 
     def with_labels(self, labels=None):
-        """
-        Returns a new landmark group that contains only the given labels.
+        """A new landmark group that contains only the certain labels
 
         Parameters
         ----------
         labels : `str` or `list` of `str`, optional
             Labels that should be kept in the returned landmark group. If
-            None is passed, and if there is only one label on this group,
+            ``None`` is passed, and if there is only one label on this group,
             the label will be substituted automatically.
 
         Returns
@@ -502,14 +509,13 @@ class LandmarkGroup(MutableMapping, Copyable, Viewable):
         return self._new_group_with_only_labels(labels)
 
     def without_labels(self, labels):
-        """
-        Returns a new landmark group that contains all labels EXCEPT the given
+        """A new landmark group that excludes certain labels
         label.
 
         Parameters
         ----------
-        label : `str`
-            Label to exclude.
+        labels : `str` or `list` of `str`
+            Labels that should be excluded in the returned landmark group.
 
         Returns
         -------
@@ -571,9 +577,8 @@ class LandmarkGroup(MutableMapping, Copyable, Viewable):
 
         Returns
         -------
-        Dictionary with 'groups' key. Groups contains a landmark label set,
-        containing the label, spatial points and connectivity information.
-        Suitable or use in the by the `json` standard library package.
+        json : ``dict``
+            Dictionary conforming to the LJSON v2 specification.
         """
         labels = [{'mask': mask.nonzero()[0].tolist(),
                    'label': label}

--- a/menpo/landmark/base.py
+++ b/menpo/landmark/base.py
@@ -282,7 +282,7 @@ class LandmarkManager(MutableMapping, Transformable):
 
 
 class LandmarkGroup(MutableMapping, Copyable, Viewable):
-    """
+    r"""
     An immutable object that holds a :map:`PointCloud` (or a subclass) and
     stores labels for each point. These labels are defined via masks on the
     :map:`PointCloud`. For this reason, the :map:`PointCloud` is considered to
@@ -293,13 +293,9 @@ class LandmarkGroup(MutableMapping, Copyable, Viewable):
 
     Parameters
     ----------
-    target : :map:`Landmarkable`
-        The parent object of this landmark group.
-    group : `str`
-        The label of the group.
     pointcloud : :map:`PointCloud`
         The pointcloud representing the landmarks.
-    labels_to_masks : `OrderedDict` of `str` to `bool` `ndarrays`
+    labels_to_masks : `ordereddict` {`str` -> `bool ndarray`}
         For each label, the mask that specifies the indices in to the
         pointcloud that belong to the label.
     copy : `bool`, optional

--- a/menpo/landmark/labels.py
+++ b/menpo/landmark/labels.py
@@ -2008,8 +2008,7 @@ def bu3dfe_83(landmark_group):
 
 
 def labeller(landmarkable, group, label_func):
-    """
-    Takes a landmarkable object and a group label indicating which
+    """Assign labels to :map:`Landmarkable` object and a group label indicating which
     set of landmarks should have semantic meaning attached to them.
     The labelling function will add a new landmark group to each object that
     have been semantically annotated.

--- a/menpo/landmark/labels.py
+++ b/menpo/landmark/labels.py
@@ -138,7 +138,7 @@ def ibug_face_68(landmark_group):
     Apply the ibug's "standard" 68 point semantic labels (based on the
     original semantic labels of multiPIE) to the landmark group.
 
-    The group label will be 'ibug_face_68'.
+    The group label will be ``ibug_face_68``.
 
     The semantic labels applied are as follows:
 
@@ -158,7 +158,7 @@ def ibug_face_68(landmark_group):
     Returns
     -------
     group : `str`
-        The group label: 'ibug_face_68'
+        The group label: ``ibug_face_68``
     landmark_group : :map:`LandmarkGroup`
         New landmark group.
 
@@ -230,7 +230,7 @@ def ibug_face_66(landmark_group):
     original semantic labels of multiPIE but ignoring the 2 points
     describing the inner mouth corners) to the landmark group.
 
-    The group label will be 'ibug_face_66'.
+    The group label will be ``ibug_face_66``.
 
     The semantic labels applied are as follows:
 
@@ -250,7 +250,7 @@ def ibug_face_66(landmark_group):
     Returns
     -------
     group : `str`
-        The group label: 'ibug_face_66'
+        The group label: ``ibug_face_66``
     landmark_group : :map:`LandmarkGroup`
         New landmark group.
 
@@ -325,7 +325,7 @@ def ibug_face_51(landmark_group):
     original semantic labels of multiPIE but removing the annotations
     corresponding to the jaw region) to the landmark group.
 
-    The group label will be 'ibug_face_51'.
+    The group label will be ``ibug_face_51``.
 
     The semantic labels applied are as follows:
 
@@ -344,7 +344,7 @@ def ibug_face_51(landmark_group):
     Returns
     -------
     group : `str`
-        The group label: 'ibug_face_51'
+        The group label: ``ibug_face_51``
     landmark_group : :map:`LandmarkGroup`
         New landmark group.
 
@@ -415,7 +415,7 @@ def ibug_face_49(landmark_group):
     corresponding to the jaw region and the 2 describing the inner mouth
     corners) to the landmark group.
 
-    The group label will be 'ibug_face_49'.
+    The group label will be ``ibug_face_49``.
 
     The semantic labels applied are as follows:
 
@@ -434,7 +434,7 @@ def ibug_face_49(landmark_group):
     Returns
     -------
     group : `str`
-        The group label: 'ibug_face_49'
+        The group label: ``ibug_face_49``
     landmark_group : :map:`LandmarkGroup`
         New landmark group.
 
@@ -504,7 +504,7 @@ def ibug_face_68_trimesh(landmark_group):
     Apply the ibug's "standard" 68 point triangulation to the landmarks in
     the given landmark group.
 
-    The group label will be 'ibug_face_68_trimesh'.
+    The group label will be ``ibug_face_68_trimesh``.
 
     The semantic labels applied are as follows:
 
@@ -518,7 +518,7 @@ def ibug_face_68_trimesh(landmark_group):
     Returns
     -------
     group : `str`
-        The group label: 'ibug_face_68_trimesh'
+        The group label: ``ibug_face_68_trimesh``
     landmark_group : :map:`LandmarkGroup`
         New landmark group.
 
@@ -580,7 +580,7 @@ def ibug_face_65_closed_mouth(landmark_group):
     the given landmark group - but ignore the 3 points that are coincident for
     a closed mouth. Therefore, there only 65 points are returned.
 
-    The group label will be 'ibug_face_65_closed_mouth'.
+    The group label will be ``ibug_face_65_closed_mouth``.
 
     The semantic labels applied are as follows:
 
@@ -600,7 +600,7 @@ def ibug_face_65_closed_mouth(landmark_group):
     Returns
     -------
     group : `str`
-        The group label: 'ibug_face_65_closed_mouth'
+        The group label: ``ibug_face_65_closed_mouth``
     landmark_group : :map:`LandmarkGroup`
         New landmark group.
 
@@ -702,7 +702,7 @@ def imm_face(landmark_group):
         If the given landmark group contains less than 58 points
 
     References
-    -----------
+    ----------
     .. [1] http://www2.imm.dtu.dk/~aam/
     """
     group = 'imm_face'
@@ -724,7 +724,7 @@ def lfpw_face(landmark_group):
     Apply the 29 point semantic labels from the LFPW dataset to the
     landmarks in the given landmark group.
 
-    The group label will be 'lfpw_face'.
+    The group label will be ``lfpw_face``.
 
     The semantic labels applied are as follows:
 
@@ -744,7 +744,7 @@ def lfpw_face(landmark_group):
     Returns
     -------
     group : `str`
-        The group label: 'lfpw_face'
+        The group label: ``lfpw_face``
     landmark_group: :map:`LandmarkGroup`
         New landmark group
 
@@ -754,7 +754,7 @@ def lfpw_face(landmark_group):
         If the given landmark group contains less than 29 points
 
     References
-    -----------
+    ----------
     .. [1] http://homes.cs.washington.edu/~neeraj/databases/lfpw/
     """
     from menpo.shape import PointUndirectedGraph
@@ -834,7 +834,7 @@ def ibug_open_eye(landmark_group):
     Apply the ibug's "standard" open eye semantic labels to the
     landmarks in the given landmark group.
 
-    The group label will be 'ibug_open_eye'.
+    The group label will be ``ibug_open_eye``.
 
     The semantic labels applied are as follows:
 
@@ -852,7 +852,7 @@ def ibug_open_eye(landmark_group):
     Returns
     -------
     group : `str`
-        The group label: 'ibug_open_eye'
+        The group label: ``ibug_open_eye``
     landmark_group : :map:`LandmarkGroup`
         New landmark group.
 
@@ -917,7 +917,7 @@ def ibug_close_eye_points(landmark_group):
     Apply the ibug's "standard" close eye semantic labels to the
     landmarks in the given landmark group.
 
-    The group label will be 'ibug_close_eye'.
+    The group label will be ``ibug_close_eye``.
 
     The semantic labels applied are as follows:
 
@@ -932,7 +932,7 @@ def ibug_close_eye_points(landmark_group):
     Returns
     -------
     group : `str`
-        The group label: 'ibug_close_eye'
+        The group label: ``ibug_close_eye``
     landmark_group : :map:`LandmarkGroup`
         New landmark group.
 
@@ -975,7 +975,7 @@ def ibug_open_eye_trimesh(landmark_group):
     Apply the ibug's "standard" open eye semantic labels to the
     landmarks in the given landmark group.
 
-    The group label will be 'ibug_open_eye_trimesh'.
+    The group label will be ``ibug_open_eye_trimesh``.
 
     The semantic labels applied are as follows:
 
@@ -989,7 +989,7 @@ def ibug_open_eye_trimesh(landmark_group):
     Returns
     -------
     group : `str`
-        The group label: 'ibug_open_eye_trimesh'
+        The group label: ``ibug_open_eye_trimesh``
     landmark_group : :map:`LandmarkGroup`
         New landmark group.
 
@@ -1040,7 +1040,7 @@ def ibug_close_eye_trimesh(landmark_group):
     Apply the ibug's "standard" close eye semantic labels to the
     landmarks in the given landmark group.
 
-    The group label will be 'ibug_close_eye_trimesh'.
+    The group label will be ``ibug_close_eye_trimesh``.
 
     The semantic labels applied are as follows:
 
@@ -1054,7 +1054,7 @@ def ibug_close_eye_trimesh(landmark_group):
     Returns
     -------
     group : `str`
-        The group label: 'ibug_close_eye_trimesh'
+        The group label: ``ibug_close_eye_trimesh``
     landmark_group : :map:`LandmarkGroup`
         New landmark group.
 
@@ -1091,7 +1091,7 @@ def ibug_tongue(landmark_group):
     Apply the ibug's "standard" tongue semantic labels to the landmarks in the
     given landmark group.
 
-    The group label will be 'ibug_tongue'.
+    The group label will be ``ibug_tongue``.
 
     The semantic labels applied are as follows:
 
@@ -1106,7 +1106,7 @@ def ibug_tongue(landmark_group):
     Returns
     -------
     group : `str`
-        The group label: 'ibug_tongue'
+        The group label: ``ibug_tongue``
     landmark_group : :map:`LandmarkGroup`
         New landmark group.
 
@@ -1128,7 +1128,7 @@ def ibug_hand(landmark_group):
     """
     Apply the ibug's "standard" 39 point semantic labels to the landmark group.
 
-    The group label will be 'ibug_hand'.
+    The group label will be ``ibug_hand``.
 
     The semantic labels applied are as follows:
 
@@ -1147,7 +1147,7 @@ def ibug_hand(landmark_group):
     Returns
     -------
     group : `str`
-        The group label: 'ibug_hand'
+        The group label: ``ibug_hand``
     landmark_group : :map:`LandmarkGroup`
         New landmark group.
 
@@ -1207,7 +1207,7 @@ def stickmen_pose(landmark_group):
     Apply the stickmen "standard" 12 point semantic labels to the landmark
     group.
 
-    The group label will be 'stickmen_pose'.
+    The group label will be ``stickmen_pose``.
 
     The semantic labels applied are as follows:
 
@@ -1226,7 +1226,7 @@ def stickmen_pose(landmark_group):
     Returns
     -------
     group : `str`
-        The group label: 'stickmen_pose'
+        The group label: ``stickmen_pose``
     landmark_group : :map:`LandmarkGroup`
         New landmark group.
 
@@ -1236,7 +1236,7 @@ def stickmen_pose(landmark_group):
         If the given landmark group contains less than 12 points
 
     References
-    -----------
+    ----------
     .. [1] http://www.robots.ox.ac.uk/~vgg/data/stickmen/
     """
     group = 'stickmen_pose'
@@ -1257,7 +1257,7 @@ def lsp_pose(landmark_group):
     Apply the lsp "standard" 14 point semantic labels to the landmark
     group.
 
-    The group label will be 'lsp_pose'.
+    The group label will be ``lsp_pose``.
 
     The semantic labels applied are as follows:
 
@@ -1275,7 +1275,7 @@ def lsp_pose(landmark_group):
     Returns
     -------
     group : `str`
-        The group label: 'lsp_pose'
+        The group label: ``lsp_pose``
     landmark_group : :map:`LandmarkGroup`
         New landmark group.
 
@@ -1285,7 +1285,7 @@ def lsp_pose(landmark_group):
         If the given landmark group contains less than 14 points
 
     References
-    -----------
+    ----------
     .. [1] http://www.comp.leeds.ac.uk/mat4saj/lsp.html
     """
     from menpo.shape import PointUndirectedGraph
@@ -1332,7 +1332,7 @@ def flic_pose(landmark_group):
     Apply the flic "standard" 11 point semantic labels to the landmark
     group.
 
-    The group label will be 'flic_pose'.
+    The group label will be ``flic_pose``.
 
     The semantic labels applied are as follows:
 
@@ -1349,7 +1349,7 @@ def flic_pose(landmark_group):
     Returns
     -------
     group : `str`
-        The group label: 'flic_pose'
+        The group label: ``flic_pose``
     landmark_group : :map:`LandmarkGroup`
         New landmark group.
 
@@ -1359,7 +1359,7 @@ def flic_pose(landmark_group):
         If the given landmark group contains less than 11 points
 
     References
-    -----------
+    ----------
     .. [1] http://vision.grasp.upenn.edu/cgi-bin/index.php?n=VideoLearning.FLIC
     """
     group = 'flic_pose'
@@ -1378,7 +1378,7 @@ def streetscene_car_view_0(landmark_group):
     Apply the 8 point semantic labels of the view 0  of the MIT Street Scene
     Car dataset to the landmark group.
 
-    The group label will be 'streetscene_car_view_0'.
+    The group label will be ``streetscene_car_view_0``.
 
     The semantic labels applied are as follows:
 
@@ -1394,7 +1394,7 @@ def streetscene_car_view_0(landmark_group):
     Returns
     -------
     group : `str`
-        The group label: 'streetscene_car_view_0'
+        The group label: ``streetscene_car_view_0``
     landmark_group : :map:`LandmarkGroup`
         New landmark group.
 
@@ -1404,7 +1404,7 @@ def streetscene_car_view_0(landmark_group):
         If the given landmark group contains less than 20 points
 
     References
-    -----------
+    ----------
     .. [1] http://www.cs.cmu.edu/~vboddeti/alignment.html
     """
     from menpo.shape import PointUndirectedGraph
@@ -1445,7 +1445,7 @@ def streetscene_car_view_1(landmark_group):
     Apply the 14 point semantic labels of the view 1  of the MIT Street Scene
     Car dataset to the landmark group.
 
-    The group label will be 'streetscene_car_view_1'.
+    The group label will be ``streetscene_car_view_1``.
 
     The semantic labels applied are as follows:
 
@@ -1462,7 +1462,7 @@ def streetscene_car_view_1(landmark_group):
     Returns
     -------
     group : `str`
-        The group label: 'streetscene_car_view_1'
+        The group label: ``streetscene_car_view_1``
     landmark_group : :map:`LandmarkGroup`
         New landmark group.
 
@@ -1472,7 +1472,7 @@ def streetscene_car_view_1(landmark_group):
         If the given landmark group contains less than 20 points
 
     References
-    -----------
+    ----------
     .. [1] http://www.cs.cmu.edu/~vboddeti/alignment.html
     """
     from menpo.shape import PointUndirectedGraph
@@ -1517,7 +1517,7 @@ def streetscene_car_view_2(landmark_group):
     Apply the 10 point semantic labels of the view 2  of the MIT Street Scene
     Car dataset to the landmark group.
 
-    The group label will be 'streetscene_car_view_2'.
+    The group label will be ``streetscene_car_view_2``.
 
     The semantic labels applied are as follows:
 
@@ -1541,7 +1541,7 @@ def streetscene_car_view_2(landmark_group):
         If the given landmark group contains less than 20 points
 
     References
-    -----------
+    ----------
     .. [1] http://www.cs.cmu.edu/~vboddeti/alignment.html
     """
     from menpo.shape import PointUndirectedGraph
@@ -1573,7 +1573,7 @@ def streetscene_car_view_3(landmark_group):
     Apply the 14 point semantic labels of the view 3  of the MIT Street Scene
     Car dataset to the landmark group.
 
-    The group label will be 'streetscene_car_view_2'.
+    The group label will be ``streetscene_car_view_2``.
 
     The semantic labels applied are as follows:
 
@@ -1590,7 +1590,7 @@ def streetscene_car_view_3(landmark_group):
     Returns
     -------
     group : `str`
-        The group label: 'streetscene_car_view_3'
+        The group label: ``streetscene_car_view_3``
     landmark_group : :map:`LandmarkGroup`
         New landmark group.
 
@@ -1600,7 +1600,7 @@ def streetscene_car_view_3(landmark_group):
         If the given landmark group contains less than 20 points
 
     References
-    -----------
+    ----------
     .. [1] http://www.cs.cmu.edu/~vboddeti/alignment.html
     """
     from menpo.shape import PointUndirectedGraph
@@ -1645,7 +1645,7 @@ def streetscene_car_view_4(landmark_group):
     Apply the 14 point semantic labels of the view 4  of the MIT Street Scene
     Car dataset to the landmark group.
 
-    The group label will be 'streetscene_car_view_4'.
+    The group label will be ``streetscene_car_view_4``.
 
     The semantic labels applied are as follows:
 
@@ -1672,7 +1672,7 @@ def streetscene_car_view_4(landmark_group):
         If the given landmark group contains less than 20 points
 
     References
-    -----------
+    ----------
     .. [1] http://www.cs.cmu.edu/~vboddeti/alignment.html
     """
     from menpo.shape import PointUndirectedGraph
@@ -1715,10 +1715,10 @@ def streetscene_car_view_4(landmark_group):
 
 def streetscene_car_view_5(landmark_group):
     """
-    Apply the 10 point semantic labels of the view 5  of the MIT Street Scene
+    Apply the 10 point semantic labels of the view 5 of the MIT Street Scene
     Car dataset to the landmark group.
 
-    The group label will be 'streetscene_car_view_5'.
+    The group label will be ``streetscene_car_view_5``.
 
     The semantic labels applied are as follows:
 
@@ -1732,7 +1732,7 @@ def streetscene_car_view_5(landmark_group):
     Returns
     -------
     group : `str`
-        The group label: 'streetscene_car_view_5'
+        The group label: ``streetscene_car_view_5``
     landmark_group : :map:`LandmarkGroup`
         New landmark group.
 
@@ -1742,7 +1742,7 @@ def streetscene_car_view_5(landmark_group):
         If the given landmark group contains less than 20 points
 
     References
-    -----------
+    ----------
     .. [1] http://www.cs.cmu.edu/~vboddeti/alignment.html
     """
     from menpo.shape import PointUndirectedGraph
@@ -1774,7 +1774,7 @@ def streetscene_car_view_6(landmark_group):
     Apply the 14 point semantic labels of the view 6  of the MIT Street Scene
     Car dataset to the landmark group.
 
-    The group label will be 'streetscene_car_view_6'.
+    The group label will be ``streetscene_car_view_6``.
 
     The semantic labels applied are as follows:
 
@@ -1791,7 +1791,7 @@ def streetscene_car_view_6(landmark_group):
     Returns
     -------
     group : `str`
-        The group label: 'streetscene_car_view_3'
+        The group label: ``streetscene_car_view_3``
     landmark_group : :map:`LandmarkGroup`
         New landmark group.
 
@@ -1801,7 +1801,7 @@ def streetscene_car_view_6(landmark_group):
         If the given landmark group contains less than 20 points
 
     References
-    -----------
+    ----------
     .. [1] http://www.cs.cmu.edu/~vboddeti/alignment.html
     """
     from menpo.shape import PointUndirectedGraph
@@ -1846,7 +1846,7 @@ def streetscene_car_view_7(landmark_group):
     Apply the 8 point semantic labels of the view 0  of the MIT Street Scene
     Car dataset to the landmark group.
 
-    The group label will be 'streetscene_car_view_7'.
+    The group label will be ``streetscene_car_view_7``.
 
     The semantic labels applied are as follows:
 
@@ -1862,7 +1862,7 @@ def streetscene_car_view_7(landmark_group):
     Returns
     -------
     group : `str`
-        The group label: 'streetscene_car_view_7'
+        The group label: ``streetscene_car_view_7``
     landmark_group : :map:`LandmarkGroup`
         New landmark group.
 
@@ -1872,7 +1872,7 @@ def streetscene_car_view_7(landmark_group):
         If the given landmark group contains less than 20 points
 
     References
-    -----------
+    ----------
     .. [1] http://www.cs.cmu.edu/~vboddeti/alignment.html
     """
     from menpo.shape import PointUndirectedGraph
@@ -1913,18 +1913,20 @@ def bu3dfe_83(landmark_group):
     Database 83 point facial annotation markup to this landmark group.
 
 
-    The group label will be 'bu3dfe_83'.
+    The group label will be ``bu3dfe_83``.
 
     The semantic labels applied are as follows:
 
-      - jaw
-      - left_eyebrow
-      - right_eyebrow
-      - nose
-      - left_eye
       - right_eye
-      - inner_mouth
+      - left_eye
+      - right_eyebrow
+      - left_eyebrow
+      - right_nose
+      - left_nose
+      - nostrils
       - outer_mouth
+      - inner_mouth
+      - jaw
 
     Parameters
     ----------
@@ -1934,14 +1936,14 @@ def bu3dfe_83(landmark_group):
     Returns
     -------
     group : `str`
-        The group label: 'ibug_face_68'
+        The group label: ``bu3dfe_83``
     landmark_group : :map:`LandmarkGroup`
         New landmark group.
 
     Raises
     ------
     :class:`menpo.landmark.exceptions.LabellingError`
-        If the given landmark group contains less than 68 points
+        If the given landmark group contains less than 83 points
 
     References
     ----------
@@ -1949,7 +1951,7 @@ def bu3dfe_83(landmark_group):
     """
     from menpo.shape import PointUndirectedGraph
 
-    group = 'bu3dfe'
+    group = 'bu3dfe_83'
     n_points = 83
     _validate_input(landmark_group, n_points, group)
 

--- a/menpo/landmark/labels.py
+++ b/menpo/landmark/labels.py
@@ -2008,26 +2008,29 @@ def bu3dfe_83(landmark_group):
 
 
 def labeller(landmarkable, group, label_func):
-    """Assign labels to :map:`Landmarkable` object and a group label indicating which
-    set of landmarks should have semantic meaning attached to them.
-    The labelling function will add a new landmark group to each object that
-    have been semantically annotated.
+    """
+    Re-label an existing landmark group on a :map:`Landmarkable` object with a
+    new label set.
 
     Parameters
     ----------
     landmarkable: :map:`Landmarkable`
-        Landmarkable object
+        :map:`Landmarkable` that will have it's :map:`LandmarkManager`
+        augmented with a new :map:`LandmarkGroup`
     group: `str`
-        The group label of the landmark group to apply semantic labels to.
-    label_func: `func`
-        A labelling function taken from this module. `func` should take a
-        :map:`LandmarkGroup` and return a tuple of
-        (group label, new LandmarkGroup with semantic labels applied.)
+        The group label of the existing landmark group that should be
+        re-labelled. A copy of this group will be attached to it's landmark
+        manager with new labels. The group label of this new group and the
+        labels it will have is determined by ``label_func``
+    label_func: `func`  -> `(str, LandmarkGroup)`
+        A labelling function taken from this module, Takes as input a
+        :map:`LandmarkGroup` and returns a tuple of
+        (new group label, new LandmarkGroup with semantic labels applied).
 
     Returns
     -------
     landmarkable : :map:`Landmarkable`
-        Landmarkable with label (this is just for convenience,
+        Augmented ``landmarkable`` (this is just for convenience,
         the object will actually be modified in place)
     """
     new_group, lmark_group = label_func(landmarkable.landmarks[group])


### PR DESCRIPTION
Fixes documentation for the landmark module.

Also contains one minor fix - bu3dfe labeller now has a group label of `bu3dfe_83` rather than `bu3dfe` which matches it with what is promised in it's documentation and makes it consistent with other labels.