### PR TITLE
Bugfix:visualize_images

### DIFF
--- a/menpo/landmark/base.py
+++ b/menpo/landmark/base.py
@@ -48,7 +48,7 @@ class Landmarkable(Copyable):
 
         :type: `bool`
         """
-        return self._landmarks is not None
+        return self._landmarks is not None and self.landmarks.n_groups != 0
 
     @landmarks.setter
     def landmarks(self, value):

--- a/menpo/visualize/widgets/base.py
+++ b/menpo/visualize/widgets/base.py
@@ -1129,7 +1129,7 @@ def visualize_images(images, figure_size=(10, 8), popup=False,
             im = image_number_wid.selected_values['index']
 
         # update info text widget
-        image_has_landmarks = images[im].landmarks.n_groups != 0
+        image_has_landmarks = images[im].has_landmarks
         image_is_masked = isinstance(images[im], MaskedImage)
         update_info(images[im], image_is_masked, image_has_landmarks,
                     landmark_options_wid.selected_values['group'])
@@ -1148,7 +1148,7 @@ def visualize_images(images, figure_size=(10, 8), popup=False,
         renderer = _visualize(
             images[im], save_figure_wid.renderer[0],
             landmark_options_wid.selected_values['render_landmarks'],
-            channel_options_wid.selected_values['image_is_masked'],
+            image_is_masked,
             channel_options_wid.selected_values['masked_enabled'],
             channel_options_wid.selected_values['channels'],
             channel_options_wid.selected_values['glyph_enabled'],

--- a/menpo/visualize/widgets/options.py
+++ b/menpo/visualize/widgets/options.py
@@ -782,8 +782,7 @@ def update_landmark_options(landmark_options_wid, group_keys, labels_keys,
         If None, then nothing is assigned.
     """
     import IPython.html.widgets as ipywidgets
-    # check if the new group_keys and labels_keys are the same as the old
-    # ones
+    # check if the new group_keys and labels_keys are the same as the old ones
     if not _compare_groups_and_labels(
             group_keys, labels_keys,
             landmark_options_wid.selected_values['group_keys'],


### PR DESCRIPTION
This PR solves a bug (thanks to @patricksnape ) in the `visualize_images` widget. The widget would crash when moving from a `MaskedImage` without landmarks to an `Image` with landmarks.

It also fixes the `has_landmarks` property in `Landmarkable` (this was fixed in the past for `LandmarkManager` but not `Landmarkable`).