### PR TITLE
[0.4.x] Ljson nan/null fixes

### DIFF
--- a/menpo/io/input/base.py
+++ b/menpo/io/input/base.py
@@ -290,9 +290,9 @@ def import_pickles(pattern, max_pickles=None, verbose=False):
 
 
 def _import_builtin_asset(asset_name):
-    r"""Single builtin asset (mesh or image) importer.
+    r"""Single builtin asset (landmark or image) importer.
 
-    Imports the relevant builtin asset from the ./data directory that
+    Imports the relevant builtin asset from the ``./data`` directory that
     ships with Menpo.
 
     Parameters
@@ -303,13 +303,17 @@ def _import_builtin_asset(asset_name):
 
     Returns
     -------
-    asset
-        An instantiated :map:`Image` or :map:`TriMesh` asset.
-
+    asset :
+        An instantiated :map:`Image` or :map:`LandmarkGroup` asset.
     """
     asset_path = data_path_to(asset_name)
-    return _import(asset_path, image_types,
-                   landmark_ext_map=image_landmark_types)
+    # Import could be either an image or a set of landmarks, so we try
+    # importing them both separately.
+    try:
+        return _import(asset_path, image_types,
+                       landmark_ext_map=image_landmark_types)
+    except ValueError:
+        return _import(asset_path, image_landmark_types)
 
 
 def ls_builtin_assets():

--- a/menpo/io/input/landmark.py
+++ b/menpo/io/input/landmark.py
@@ -1,4 +1,5 @@
 import abc
+import itertools
 from collections import OrderedDict
 import json
 import warnings
@@ -293,6 +294,12 @@ class LM2Importer(LandmarkImporter):
         self.labels_to_masks = OrderedDict(zip(labels, masks))
 
 
+def _ljson_parse_null_values(points_list):
+    filtered_points = [np.nan if x is None else x
+                       for x in itertools.chain(*points_list)]
+    return np.array(filtered_points).reshape([-1, 2])
+
+
 def _parse_ljson_v1(lms_dict):
     from menpo.base import MenpoDeprecationWarning
     warnings.warn('LJSON v1 is deprecated. export_landmark_file{s}() will '
@@ -319,7 +326,7 @@ def _parse_ljson_v1(lms_dict):
         offset += len(lms)
 
     # Don't create a PointUndirectedGraph with no connectivity
-    points = np.array(all_points)
+    points = _ljson_parse_null_values(all_points)
     if len(connectivity) == 0:
         pcloud = PointCloud(points)
     else:
@@ -336,7 +343,7 @@ def _parse_ljson_v1(lms_dict):
 def _parse_ljson_v2(lms_dict):
     labels_to_mask = OrderedDict()  # masks into the full pointcloud per label
 
-    points = np.array(lms_dict['landmarks']['points'])
+    points = _ljson_parse_null_values(lms_dict['landmarks']['points'])
     connectivity = lms_dict['landmarks'].get('connectivity')
 
     # Don't create a PointUndirectedGraph with no connectivity

--- a/menpo/io/output/landmark.py
+++ b/menpo/io/output/landmark.py
@@ -1,4 +1,5 @@
 import json
+import itertools
 import numpy as np
 
 
@@ -22,8 +23,18 @@ def LJSONExporter(landmark_group, file_handle):
     lg_json = landmark_group.tojson()
     # Add version string
     lg_json['version'] = 2
+
+    # Convert nan values to None so that json correctly maps them to 'null'
+    points = lg_json['landmarks']['points']
+    # Flatten list
+    filtered_points = [None if np.isnan(x) else x
+                       for x in itertools.chain(*points)]
+    # Recreate tuples
+    lg_json['landmarks']['points'] = zip(filtered_points[::2],
+                                         filtered_points[1::2])
+
     return json.dump(lg_json, file_handle, indent=4, separators=(',', ': '),
-                     sort_keys=True)
+                     sort_keys=True, allow_nan=False)
 
 
 def PTSExporter(landmark_group, file_handle):

--- a/menpo/io/test/io_export_test.py
+++ b/menpo/io/test/io_export_test.py
@@ -7,6 +7,8 @@ from menpo.image import Image
 
 
 test_lg = mio.import_landmark_file(mio.data_path_to('breakingbad.pts'))
+nan_lg = test_lg.copy()
+nan_lg.lms.points[0, :] = np.nan
 test_img = Image(np.random.random([100, 100]))
 fake_path = '/tmp/test.fake'
 
@@ -162,6 +164,23 @@ def test_export_landmark_ljson(mock_open, exists, json_dump):
         type(f).name = PropertyMock(return_value=fake_path)
         mio.export_landmark_file(test_lg, f, extension='ljson')
     json_dump.assert_called_once()
+
+
+@patch('menpo.io.output.base.Path.exists')
+@patch('{}.open'.format(__name__), create=True)
+def test_export_landmark_ljson_nan_values(mock_open, exists):
+    exists.return_value = False
+    fake_path = '/fake/fake.ljson'
+    with open(fake_path) as f:
+        type(f).name = PropertyMock(return_value=fake_path)
+        mio.export_landmark_file(nan_lg, f, extension='ljson')
+
+    # This is a bit ugly, but we parse the write calls to check that json
+    # wrote null values
+    first_null = mock_open.mock_calls[97][1][0][1:].strip()
+    second_null = mock_open.mock_calls[98][1][0][1:].strip()
+    assert first_null == 'null'
+    assert second_null == 'null'
 
 
 @patch('menpo.io.output.landmark.np.savetxt')

--- a/menpo/io/test/io_import_test.py
+++ b/menpo/io/test/io_import_test.py
@@ -38,6 +38,16 @@ def test_lenna_import():
     assert(img.landmarks['LJSON'].n_landmarks == 68)
 
 
+def test_import_builtin_ljson():
+    lmarks = mio.import_builtin_asset('lenna.ljson')
+    assert(lmarks.n_landmarks == 68)
+
+
+def test_import_builtin_pts():
+    lmarks = mio.import_builtin_asset('einstein.pts')
+    assert(lmarks.n_landmarks == 68)
+
+
 def test_path():
     # choose a random asset (all should have it!)
     img = mio.import_builtin_asset('einstein.jpg')
@@ -261,3 +271,54 @@ def test_importing_GIF_non_pallete_exception(is_file, mock_image):
     is_file.return_value = True
 
     mio.import_image('fake_image_being_mocked.gif', normalise=False)
+
+
+@patch('menpo.io.input.landmark.json.load')
+@patch('__builtin__.open')
+@patch('menpo.io.input.base.Path.is_file')
+def test_importing_v1_ljson_null_values(is_file, mock_open, mock_dict):
+    v1_ljson = { "groups": [
+        { "connectivity": [ [ 0, 1 ], [ 1, 2 ], [ 2, 3 ] ],
+          "label": "chin", "landmarks": [
+            { "point": [ 987.9, 1294.1 ] }, { "point": [ 96.78, 1246.8 ] },
+            { "point": [ None, 0.1 ] }, { "point": [303.22, 167.2 ] } ] },
+        { "connectivity": [ [ 0, 1 ] ],
+          "label": "leye", "landmarks": [
+            { "point": [ None, None ] },
+            { "point": [ None, None ] }] }
+        ], "version": 1 }
+    mock_dict.return_value = v1_ljson
+    is_file.return_value = True
+
+    lmark = mio.import_landmark_file('fake_lmark_being_mocked.ljson')
+    nan_points = np.isnan(lmark.lms.points)
+    assert nan_points[2, 0]  # y-coord None point is nan
+    assert not nan_points[2, 1]  # x-coord point is not nan
+    assert np.all(nan_points[4:, :]) # all of leye label is nan
+
+
+@patch('menpo.io.input.landmark.json.load')
+@patch('__builtin__.open')
+@patch('menpo.io.input.base.Path.is_file')
+def test_importing_v2_ljson_null_values(is_file, mock_open, mock_dict):
+    v2_ljson = { "labels": [
+                    { "label": "left_eye", "mask": [0, 1, 2] },
+                    { "label": "right_eye", "mask": [3, 4, 5] }
+                 ],
+                 "landmarks": {
+                     "connectivity": [ [0, 1], [1, 2], [2, 0], [3, 4],
+                                       [4, 5],  [5, 3] ],
+                     "points": [ [None, 200.5], [None, None],
+                                 [316.8, 199.15], [339.48, 205.0],
+                                 [358.54, 217.82], [375.0, 233.4]]
+                 },
+                 "version": 2 }
+
+    mock_dict.return_value = v2_ljson
+    is_file.return_value = True
+
+    lmark = mio.import_landmark_file('fake_lmark_being_mocked.ljson')
+    nan_points = np.isnan(lmark.lms.points)
+    assert nan_points[0, 0]  # y-coord None point is nan
+    assert not nan_points[0, 1]  # x-coord point is not nan
+    assert np.all(nan_points[1, :]) # all of leye label is nan

--- a/menpo/io/test/io_import_test.py
+++ b/menpo/io/test/io_import_test.py
@@ -3,6 +3,7 @@ from mock import patch
 from nose.tools import raises
 from PIL import Image as PILImage
 import menpo.io as mio
+import warnings
 
 
 @raises(ValueError)
@@ -290,8 +291,12 @@ def test_importing_v1_ljson_null_values(is_file, mock_open, mock_dict):
     mock_dict.return_value = v1_ljson
     is_file.return_value = True
 
-    lmark = mio.import_landmark_file('fake_lmark_being_mocked.ljson')
+    with warnings.catch_warnings(record=True) as w:
+        lmark = mio.import_landmark_file('fake_lmark_being_mocked.ljson')
     nan_points = np.isnan(lmark.lms.points)
+
+    # Should raise deprecation warning
+    assert len(w) == 1
     assert nan_points[2, 0]  # y-coord None point is nan
     assert not nan_points[2, 1]  # x-coord point is not nan
     assert np.all(nan_points[4:, :]) # all of leye label is nan


### PR DESCRIPTION
Two separate small fixes:

  1. Importing built-in landmarks was broken. This is now fixed.
  2. Serializing `nan` values was leaving `nan`, which is not officially supported by JSON. De-serializing `null` values was causing an object array and `null` was serializing to `None`. Now, `null` will de-serialize to `nan` for landmarks and `nan` will serialize to `null`.