### PR TITLE
Channel roll

### DIFF
--- a/menpo/image/base.py
+++ b/menpo/image/base.py
@@ -84,7 +84,7 @@ def channels_to_back(image):
     else:
         pixels = image.pixels
 
-    return np.rollaxis(pixels, 0, pixels.ndim)
+    return np.ascontiguousarray(np.rollaxis(pixels, 0, pixels.ndim))
 
 
 class Image(Vectorizable, Landmarkable, Viewable, LandmarkableViewable):
@@ -1760,6 +1760,20 @@ class Image(Vectorizable, Landmarkable, Viewable, LandmarkableViewable):
         if pixels.dtype != np.uint8:
             raise ValueError('Unexpected data type - {}.'.format(pixels.dtype))
         return PILImage.fromarray(pixels)
+
+    def rolled_channels(self):
+        r"""
+        Returns the pixels matrix, with the channels rolled to the back axis.
+        This may be required for interacting with external code bases that
+        require images to have channels as the last axis, rather than the
+        menpo convention of channels as the first axis.
+
+        Returns
+        -------
+        rolled_channels : `ndarray`
+            Pixels with channels as the back (last) axis.
+        """
+        return channels_to_back(self)
 
     def __str__(self):
         return ('{} {}D Image with {} channel{}'.format(

--- a/menpo/image/base.py
+++ b/menpo/image/base.py
@@ -2,7 +2,6 @@ from __future__ import division
 from warnings import warn
 
 import numpy as np
-import scipy.linalg
 import PIL.Image as PILImage
 
 from menpo.compatibility import basestring
@@ -13,6 +12,13 @@ from menpo.transform import (Translation, NonUniformScale,
 from menpo.visualize.base import ImageViewer, LandmarkableViewable, Viewable
 from .interpolation import scipy_interpolation, cython_interpolation
 from .extract_patches import extract_patches
+
+
+# Cache the greyscale luminosity coefficients as they are invariant.
+_greyscale_luminosity_coef = np.linalg.inv(
+    np.array([[1.0, 0.956, 0.621],
+              [1.0, -0.272, -0.647],
+              [1.0, -1.106, 1.703]]))[0, :]
 
 
 class ImageBoundaryError(ValueError):
@@ -1682,15 +1688,7 @@ class Image(Vectorizable, Landmarkable, Viewable, LandmarkableViewable):
                 raise ValueError("The 'luminosity' mode only works on RGB"
                                  "images. {} channels found, "
                                  "3 expected.".format(self.n_channels))
-
-            # cache the luminosity coefficients as they are invariant
-            if not hasattr(self, '_luminosity_coefficients'):
-                # Invert the transformation matrix to get more precise values
-                T = scipy.linalg.inv(np.array([[1.0, 0.956, 0.621],
-                                               [1.0, -0.272, -0.647],
-                                               [1.0, -1.106, 1.703]]))
-                self._luminosity_coefficients = T[0, :]
-            pixels = np.einsum('i,ikl->kl', self._luminosity_coefficients,
+            pixels = np.einsum('i,ikl->kl', _greyscale_luminosity_coef,
                                greyscale.pixels)
         elif mode == 'average':
             pixels = np.mean(greyscale.pixels, axis=0)

--- a/menpo/image/base.py
+++ b/menpo/image/base.py
@@ -15,10 +15,7 @@ from .extract_patches import extract_patches
 
 
 # Cache the greyscale luminosity coefficients as they are invariant.
-_greyscale_luminosity_coef = np.linalg.inv(
-    np.array([[1.0, 0.956, 0.621],
-              [1.0, -0.272, -0.647],
-              [1.0, -1.106, 1.703]]))[0, :]
+_greyscale_luminosity_coef = None
 
 
 class ImageBoundaryError(ValueError):
@@ -1688,6 +1685,13 @@ class Image(Vectorizable, Landmarkable, Viewable, LandmarkableViewable):
                 raise ValueError("The 'luminosity' mode only works on RGB"
                                  "images. {} channels found, "
                                  "3 expected.".format(self.n_channels))
+            # Only compute the coefficients once.
+            global _greyscale_luminosity_coef
+            if _greyscale_luminosity_coef is None:
+                _greyscale_luminosity_coef = np.linalg.inv(
+                    np.array([[1.0, 0.956, 0.621],
+                              [1.0, -0.272, -0.647],
+                              [1.0, -1.106, 1.703]]))[0, :]
             pixels = np.einsum('i,ikl->kl', _greyscale_luminosity_coef,
                                greyscale.pixels)
         elif mode == 'average':

--- a/menpo/image/test/image_test.py
+++ b/menpo/image/test/image_test.py
@@ -577,17 +577,23 @@ def test_resize():
 
 
 def test_as_greyscale_luminosity():
-    image = MaskedImage(np.ones([3, 120, 120]))
+    ones = np.ones([3, 120, 120])
+    image = MaskedImage(ones)
+    image.pixels[0] *= 0.5
     new_image = image.as_greyscale(mode='luminosity')
     assert (new_image.shape == image.shape)
     assert (new_image.n_channels == 1)
+    assert_allclose(new_image.pixels[0], ones[0] * 0.850532)
 
 
 def test_as_greyscale_average():
-    image = MaskedImage(np.ones([3, 120, 120]))
+    ones = np.ones([3, 120, 120])
+    image = MaskedImage(ones)
+    image.pixels[0] *= 0.5
     new_image = image.as_greyscale(mode='average')
     assert (new_image.shape == image.shape)
     assert (new_image.n_channels == 1)
+    assert_allclose(new_image.pixels[0], ones[0] * 0.83333333)
 
 
 @raises(ValueError)

--- a/menpo/image/test/image_test.py
+++ b/menpo/image/test/image_test.py
@@ -585,6 +585,11 @@ def test_as_greyscale_luminosity():
     assert (new_image.n_channels == 1)
     assert_allclose(new_image.pixels[0], ones[0] * 0.850532)
 
+def test_rolled_channels():
+    ones = np.ones([3, 120, 120])
+    image = MaskedImage(ones)
+    rolled_channels = image.rolled_channels()
+    assert rolled_channels.shape == (120, 120, 3)
 
 def test_as_greyscale_average():
     ones = np.ones([3, 120, 120])


### PR DESCRIPTION
New function for getting access to the rolled channels.

Also, optimise the ``as_greyscale`` method by caching the inverted matrix. Order of magnitude speedup.