### PR TITLE
Optional cmaps

### DIFF
--- a/menpo/image/base.py
+++ b/menpo/image/base.py
@@ -502,10 +502,11 @@ class Image(Vectorizable, Landmarkable, Viewable, LandmarkableViewable):
         return hist, bin_edges
 
     def _view_2d(self, figure_id=None, new_figure=False, channels=None,
-                 interpolation='bilinear', alpha=1., render_axes=False,
-                 axes_font_name='sans-serif', axes_font_size=10,
-                 axes_font_style='normal', axes_font_weight='normal',
-                 axes_x_limits=None, axes_y_limits=None, figure_size=(10, 8)):
+                 interpolation='bilinear', cmap_name=None, alpha=1.,
+                 render_axes=False, axes_font_name='sans-serif',
+                 axes_font_size=10, axes_font_style='normal',
+                 axes_font_weight='normal', axes_x_limits=None,
+                 axes_y_limits=None, figure_size=(10, 8)):
         r"""
         View the image using the default image viewer. This method will appear 
         on the Image as ``view`` if the Image is 2D.
@@ -530,7 +531,9 @@ class Image(Vectorizable, Landmarkable, Viewable, LandmarkableViewable):
                 {none, nearest, bilinear, bicubic, spline16, spline36,
                 hanning, hamming, hermite, kaiser, quadric, catrom, gaussian,
                 bessel, mitchell, sinc, lanczos}
-
+        cmap_name: `Colormap name`, optional,
+            If None, single channel and three channel images default
+            to greyscale and rgb colormaps respectively.
         alpha : `float`, optional
             The alpha blending value, between 0 (transparent) and 1 (opaque).
         render_axes : `bool`, optional
@@ -566,7 +569,7 @@ class Image(Vectorizable, Landmarkable, Viewable, LandmarkableViewable):
         """
         return ImageViewer(figure_id, new_figure, self.n_dims,
                            self.pixels, channels=channels).render(
-            interpolation=interpolation, alpha=alpha,
+            interpolation=interpolation, cmap_name=cmap_name, alpha=alpha,
             render_axes=render_axes, axes_font_name=axes_font_name,
             axes_font_size=axes_font_size, axes_font_style=axes_font_style,
             axes_font_weight=axes_font_weight, axes_x_limits=axes_x_limits,
@@ -592,7 +595,7 @@ class Image(Vectorizable, Landmarkable, Viewable, LandmarkableViewable):
     def _view_landmarks_2d(self, channels=None, group=None,
                            with_labels=None, without_labels=None,
                            figure_id=None, new_figure=False,
-                           interpolation='bilinear', alpha=1.,
+                           interpolation='bilinear', cmap_name=None, alpha=1.,
                            render_lines=True, line_colour=None, line_style='-',
                            line_width=1, render_markers=True, marker_style='o',
                            marker_size=20, marker_face_colour=None,
@@ -651,6 +654,9 @@ class Image(Vectorizable, Landmarkable, Viewable, LandmarkableViewable):
                 hamming, hermite, kaiser, quadric, catrom, gaussian, bessel,
                 mitchell, sinc, lanczos}
 
+        cmap_name: `Colormap name`, optional,
+            If None, single channel and three channel images default
+            to greyscale and rgb colormaps respectively.
         alpha : `float`, optional
             The alpha blending value, between 0 (transparent) and 1 (opaque).
         render_lines : `bool`, optional
@@ -816,13 +822,14 @@ class Image(Vectorizable, Landmarkable, Viewable, LandmarkableViewable):
         from menpo.visualize import view_image_landmarks
         return view_image_landmarks(
             self, channels, False, group, with_labels, without_labels,
-            figure_id, new_figure, interpolation, alpha, render_lines,
-            line_colour, line_style, line_width, render_markers, marker_style,
-            marker_size, marker_face_colour, marker_edge_colour,
-            marker_edge_width, render_numbering, numbers_horizontal_align,
-            numbers_vertical_align, numbers_font_name, numbers_font_size,
-            numbers_font_style, numbers_font_weight, numbers_font_colour,
-            render_legend, legend_title, legend_font_name, legend_font_style,
+            figure_id, new_figure, interpolation, cmap_name, alpha,
+            render_lines, line_colour, line_style, line_width,
+            render_markers, marker_style, marker_size, marker_face_colour,
+            marker_edge_colour, marker_edge_width, render_numbering,
+            numbers_horizontal_align, numbers_vertical_align,
+            numbers_font_name, numbers_font_size, numbers_font_style,
+            numbers_font_weight, numbers_font_colour, render_legend,
+            legend_title, legend_font_name, legend_font_style,
             legend_font_size, legend_font_weight, legend_marker_scale,
             legend_location, legend_bbox_to_anchor, legend_border_axes_pad,
             legend_n_columns, legend_horizontal_spacing,

--- a/menpo/visualize/base.py
+++ b/menpo/visualize/base.py
@@ -332,9 +332,10 @@ class ImageViewer(object):
 
 def view_image_landmarks(image, channels, masked, group,
                          with_labels, without_labels, figure_id, new_figure,
-                         interpolation, alpha, render_lines, line_colour,
-                         line_style, line_width, render_markers, marker_style,
-                         marker_size, marker_face_colour, marker_edge_colour,
+                         interpolation, cmap_name, alpha, render_lines,
+                         line_colour, line_style, line_width,
+                         render_markers, marker_style, marker_size,
+                         marker_face_colour, marker_edge_colour,
                          marker_edge_width, render_numbering,
                          numbers_horizontal_align, numbers_vertical_align,
                          numbers_font_name, numbers_font_size,
@@ -369,11 +370,15 @@ def view_image_landmarks(image, channels, masked, group,
     if isinstance(image, MaskedImage):
         self_view = image.view(figure_id=figure_id, new_figure=new_figure,
                                channels=channels, masked=masked,
-                               interpolation=interpolation, alpha=alpha)
+                               interpolation=interpolation,
+                               cmap_name=cmap_name,
+                               alpha=alpha)
     else:
         self_view = image.view(figure_id=figure_id, new_figure=new_figure,
                                channels=channels,
-                               interpolation=interpolation, alpha=alpha)
+                               interpolation=interpolation,
+                               cmap_name=cmap_name,
+                               alpha=alpha)
 
     # Make sure axes are constrained to the image size
     if axes_x_limits is None:

--- a/menpo/visualize/viewmatplotlib.py
+++ b/menpo/visualize/viewmatplotlib.py
@@ -196,18 +196,24 @@ class MatplotlibImageViewer2d(MatplotlibRenderer):
         self.image = image
         self.axes_list = []
 
-    def render(self, interpolation='bilinear', alpha=1., render_axes=False,
-               axes_font_name='sans-serif', axes_font_size=10,
-               axes_font_style='normal', axes_font_weight='normal',
-               axes_x_limits=None, axes_y_limits=None, figure_size=(10, 8)):
+    def render(self, interpolation='bilinear', cmap_name=None, alpha=1.,
+               render_axes=False, axes_font_name='sans-serif',
+               axes_font_size=10, axes_font_style='normal',
+               axes_font_weight='normal', axes_x_limits=None,
+               axes_y_limits=None, figure_size=(10, 8)):
         import matplotlib.cm as cm
         import matplotlib.pyplot as plt
 
-        if len(self.image.shape) == 2:  # Single channels are viewed in Gray
-            plt.imshow(self.image, cmap=cm.Greys_r, interpolation=interpolation,
-                       alpha=alpha)
+        if cmap_name is not None:
+            cmap = cm.get_cmap(cmap_name)
+        elif len(self.image.shape) == 2:
+            # Single channels are viewed in Gray by default
+            cmap = cm.Greys_r
         else:
-            plt.imshow(self.image, interpolation=interpolation, alpha=alpha)
+            cmap = None
+
+        plt.imshow(self.image, cmap=cmap, interpolation=interpolation,
+                   alpha=alpha)
 
         # render axes options
         if render_axes:
@@ -250,10 +256,11 @@ class MatplotlibImageSubplotsViewer2d(MatplotlibRenderer, MatplotlibSubplots):
         self.plot_layout = self._subplot_layout(self.num_subplots)
         self.axes_list = []
 
-    def render(self, interpolation='bilinear', alpha=1., render_axes=False,
-               axes_font_name='sans-serif', axes_font_size=10,
-               axes_font_style='normal', axes_font_weight='normal',
-               axes_x_limits=None, axes_y_limits=None, figure_size=(10, 8)):
+    def render(self, interpolation='bilinear', cmap_name=None, alpha=1.,
+               render_axes=False, axes_font_name='sans-serif',
+               axes_font_size=10, axes_font_style='normal',
+               axes_font_weight='normal', axes_x_limits=None,
+               axes_y_limits=None, figure_size=(10, 8)):
         import matplotlib.cm as cm
         import matplotlib.pyplot as plt
 
@@ -283,8 +290,13 @@ class MatplotlibImageSubplotsViewer2d(MatplotlibRenderer, MatplotlibSubplots):
             if axes_y_limits is not None:
                 plt.ylim(axes_y_limits[::-1])
 
-            # show image
-            plt.imshow(self.image[:, :, i], cmap=cm.Greys_r,
+            if cmap_name is not None:
+                cmap = cm.get_cmap(cmap_name)
+            else:
+                # Single channels are viewed in Gray by default
+                cmap = cm.Greys_r
+
+            plt.imshow(self.image[:, :, i], cmap=cmap,
                        interpolation=interpolation, alpha=alpha)
 
         # Set figure size


### PR DESCRIPTION
In Menpo, 1 channel images are always rendered using a grey-scale colormap. This PR allows the user to optionally pass the colormap under which a Menpo image should be rendered as a `kwarg` in its `view` method.

Note that the previous `kwarg` can also be passed in case of multi channel images and that previously default behaviours are preserved. 