### PR TITLE
rescale_pixels() for rescaling the range of pixels

### DIFF
--- a/menpo/image/base.py
+++ b/menpo/image/base.py
@@ -1874,13 +1874,10 @@ class Image(Vectorizable, Landmarkable, Viewable, LandmarkableViewable):
 
         Parameters
         ----------
-
         minimum: `float`
             The minimal value of the rescaled pixels
-
         maximum: `float`
             The maximal value of the rescaled pixels
-
         per_channel: `boolean`, optional
             If ``True``, each channel will be rescaled independently. If
             ``False``, the scaling will be over all channels.

--- a/menpo/image/base.py
+++ b/menpo/image/base.py
@@ -1864,6 +1864,42 @@ class Image(Vectorizable, Landmarkable, Viewable, LandmarkableViewable):
         else:
             self.from_vector_inplace(centered_pixels / scale_factor)
 
+    def rescale_pixels(self, minimum, maximum, per_channel=True):
+        r"""A copy of this image with pixels linearly rescaled to fit a range.
+
+        Note that the only pixels that will considered and rescaled are those
+        that feature in the vectorized form of this image. If you want to use
+        this routine on all the pixels in a :map:`MaskedImage`, consider
+        using `as_unmasked()` prior to this call.
+
+        Parameters
+        ----------
+
+        minimum: `float`
+            The minimal value of the rescaled pixels
+
+        maximum: `float`
+            The maximal value of the rescaled pixels
+
+        per_channel: `boolean`, optional
+            If ``True``, each channel will be rescaled independently. If
+            ``False``, the scaling will be over all channels.
+
+        Returns
+        -------
+        rescaled_image: ``type(self)``
+            A copy of this image with pixels linearly rescaled to fit in the
+            range provided.
+        """
+        v = self.as_vector(keep_channels=True).T
+        if per_channel:
+            min_, max_ = v.min(axis=0), v.max(axis=0)
+        else:
+            min_, max_ = v.min(), v.max()
+        sf = ((maximum - minimum) * 1.0) / (max_ - min_)
+        v_new = ((v - min_) * sf) + minimum
+        return self.from_vector(v_new.T.ravel())
+
 
 def round_image_shape(shape, round):
     if round not in ['ceil', 'round', 'floor']:

--- a/menpo/image/test/image_pixel_recale_test.py
+++ b/menpo/image/test/image_pixel_recale_test.py
@@ -1,0 +1,50 @@
+from menpo.image import Image, MaskedImage
+import numpy as np
+
+
+def test_rescale_pixels():
+    img = Image.init_blank((10, 10), n_channels=1)
+    img.pixels[:, 6:, 6:] = 2
+
+    img_rescaled = img.rescale_pixels(0, 255)
+    assert np.min(img_rescaled.pixels) == 0
+    assert np.max(img_rescaled.pixels) == 255
+    assert np.all(img_rescaled.pixels[:, 6:, 6:] == 255)
+
+
+def test_rescale_pixels_all_channels():
+    img = Image.init_blank((10, 10), n_channels=2)
+    img.pixels[0, 6:, 6:] = 2
+    img.pixels[1, 6:, 6:] = 4
+
+    img_rescaled = img.rescale_pixels(0, 100, per_channel=False)
+    assert np.min(img_rescaled.pixels) == 0
+    assert np.max(img_rescaled.pixels) == 100
+    assert np.all(img_rescaled.pixels[0, 6:, 6:] == 50)
+    assert np.all(img_rescaled.pixels[1, 6:, 6:] == 100)
+
+
+def test_rescale_pixels_per_channel():
+    img = Image.init_blank((10, 10), n_channels=2)
+    img.pixels[0, 6:, 6:] = 2
+    img.pixels[1, 6:, 6:] = 4
+
+    img_rescaled = img.rescale_pixels(0, 100, per_channel=True)
+    assert np.min(img_rescaled.pixels) == 0
+    assert np.max(img_rescaled.pixels) == 100
+    assert np.all(img_rescaled.pixels[0, 6:, 6:] == 100)
+    assert np.all(img_rescaled.pixels[1, 6:, 6:] == 100)
+
+
+def test_rescale_pixels_only_masked():
+    img = MaskedImage.init_blank((10, 10), n_channels=1, fill=1)
+    img.pixels[0, 0, 0] = 0
+    img.pixels[0, 6:, 6:] = 2
+    img.mask.pixels[:, 6:, 6:] = False
+
+    img_rescaled = img.rescale_pixels(0, 100)
+    assert np.min(img_rescaled.pixels) == 0
+    assert np.max(img_rescaled.pixels) == 100
+    assert img_rescaled.pixels[0, 0, 0] == 0
+    assert img_rescaled.pixels[0, 1, 1] == 100
+    assert np.all(img_rescaled.mask.pixels == img.mask.pixels)


### PR DESCRIPTION
Adds a new method to Images that makes it easy to linearly rescale the range of pixels to a certain range. The range is given by a maximum and minimum value. The user can choose whether the scaling should be performed per channel independently, or for all pixels in the image across channels.