### PR TITLE
Allowing expanding user paths in exporting pickle

### DIFF
--- a/menpo/io/output/base.py
+++ b/menpo/io/output/base.py
@@ -127,7 +127,7 @@ def export_pickle(obj, fp, overwrite=False):
         # user provided a path - if it ended .gz we will compress
         path_filepath = _validate_filepath(fp, '.pkl', overwrite)
         o = gzip_open if path_filepath.suffix == '.gz' else open
-        with o(fp, 'wb') as f:
+        with o(str(path_filepath), 'wb') as f:
             # force overwrite as True we've already done the check above
             _export(obj, f, pickle_types, '.pkl', True)
     else:


### PR DESCRIPTION
Also, adds tests that check this is the case. Further, fixes
a currently broken test where it didn't check .pkl.gz properly.