### PR TITLE
Fix the landmark importer in case the landmark file has a '.' in its filename.

### DIFF
--- a/menpo/io/input/base.py
+++ b/menpo/io/input/base.py
@@ -604,9 +604,9 @@ def glob_with_suffix(pattern, extensions_map):
         # .suffix only takes
         if ''.join(path.suffixes) in extensions_map:
             yield path
-	# try again in case the filename has a '.' in it, this time only with the suffix
-	if path.suffix in extensions_map:
-	    yield path
+        # try again in case the filename has a '.' in it, this time only with the suffix
+        if path.suffix in extensions_map:
+            yield path
 
 
 def importer_for_filepath(filepath, extensions_map, importer_kwargs=None):

--- a/menpo/io/input/base.py
+++ b/menpo/io/input/base.py
@@ -604,6 +604,9 @@ def glob_with_suffix(pattern, extensions_map):
         # .suffix only takes
         if ''.join(path.suffixes) in extensions_map:
             yield path
+	# try again in case the filename has a '.' in it, this time only with the suffix
+	if path.suffix in extensions_map:
+	    yield path
 
 
 def importer_for_filepath(filepath, extensions_map, importer_kwargs=None):


### PR DESCRIPTION
The extension in this case is the last one of the .suffixes. Similar to https://github.com/menpo/menpo/pull/543 that was the respective one for images. 