### PR TITLE
new print_progress visualization function

### DIFF
--- a/docs/source/api/menpo/visualize/bytes_str.rst
+++ b/docs/source/api/menpo/visualize/bytes_str.rst
@@ -1,0 +1,7 @@
+.. _menpo-visualize-bytes_str:
+
+.. currentmodule:: menpo.visualize
+
+bytes_str
+=========
+.. autofunction:: bytes_str

--- a/docs/source/api/menpo/visualize/index.rst
+++ b/docs/source/api/menpo/visualize/index.rst
@@ -42,4 +42,4 @@ Print Utilities
   print_progress
   print_dynamic
   progress_bar_str
-  print_bytes
+  bytes_str

--- a/docs/source/api/menpo/visualize/index.rst
+++ b/docs/source/api/menpo/visualize/index.rst
@@ -39,6 +39,7 @@ Print Utilities
 .. toctree::
   :maxdepth: 1
 
+  print_progress
   print_dynamic
   progress_bar_str
   print_bytes

--- a/docs/source/api/menpo/visualize/print_bytes.rst
+++ b/docs/source/api/menpo/visualize/print_bytes.rst
@@ -1,7 +1,0 @@
-.. _menpo-visualize-print_bytes:
-
-.. currentmodule:: menpo.visualize
-
-print_bytes
-===========
-.. autofunction:: print_bytes

--- a/docs/source/api/menpo/visualize/print_progress.rst
+++ b/docs/source/api/menpo/visualize/print_progress.rst
@@ -1,0 +1,7 @@
+.. _menpo-visualize-print_progress:
+
+.. currentmodule:: menpo.visualize
+
+print_progress
+==============
+.. autofunction:: print_progress

--- a/menpo/io/input/base.py
+++ b/menpo/io/input/base.py
@@ -377,7 +377,8 @@ def _import_glob_generator(pattern, extension_map, max_assets=None,
 
     if verbose:
         # wrap the generator with the progress reporter
-        generator = print_progress(generator, n_items=n_files)
+        generator = print_progress(generator, prefix='Importing assets',
+                                   n_items=n_files)
 
     return generator
 

--- a/menpo/io/input/base.py
+++ b/menpo/io/input/base.py
@@ -3,7 +3,7 @@ from pathlib import Path
 
 from ..utils import _norm_path
 from menpo.base import menpo_src_dir_path
-from menpo.visualize import progress_bar_str, print_dynamic
+from menpo.visualize import print_progress
 
 
 def data_dir_path():
@@ -13,7 +13,6 @@ def data_dir_path():
     -------
     ``pathlib.Path``
         The path to the local Menpo ./data folder
-
     """
     return menpo_src_dir_path() / 'data'
 
@@ -37,7 +36,6 @@ def data_path_to(asset_filename):
     ------
     ValueError
         If the asset_filename doesn't exist in the `data` folder.
-
     """
     asset_path = data_dir_path() / asset_filename
     if not asset_path.is_file():
@@ -372,15 +370,16 @@ def _import_glob_generator(pattern, extension_map, max_assets=None,
     n_files = len(filepaths)
     if n_files == 0:
         raise ValueError('The glob {} yields no assets'.format(pattern))
-    for i, asset in enumerate(_multi_import_generator(filepaths, extension_map,
-                              landmark_resolver=landmark_resolver,
-                              landmark_ext_map=landmark_ext_map,
-                              importer_kwargs=importer_kwargs)):
-        if verbose:
-            print_dynamic('- Loading {} assets: {}'.format(
-                n_files, progress_bar_str(float(i + 1) / n_files,
-                                          show_bar=True)))
-        yield asset
+
+    generator = _multi_import_generator(
+        filepaths, extension_map,  landmark_resolver=landmark_resolver,
+        landmark_ext_map=landmark_ext_map, importer_kwargs=importer_kwargs)
+
+    if verbose:
+        # wrap the generator with the progress reporter
+        generator = print_progress(generator, n_items=n_files)
+
+    return generator
 
 
 def _import(filepath, extensions_map, keep_importer=False,

--- a/menpo/math/linalg.py
+++ b/menpo/math/linalg.py
@@ -1,5 +1,5 @@
 import numpy as np
-from menpo.visualize import print_progress, print_bytes
+from menpo.visualize import print_progress, bytes_str
 
 
 def dot_inplace_left(a, b, block_size=1000):
@@ -127,7 +127,7 @@ def as_matrix(vectorizables, length=None, return_template=False, verbose=False):
     data = np.zeros((length, n_features), dtype=template_vector.dtype)
     if verbose:
         print('Allocated data matrix of size {} '
-              '({} samples)'.format(print_bytes(data.nbytes), length))
+              '({} samples)'.format(bytes_str(data.nbytes), length))
 
     # now we can fill in the first element from the template
     data[0] = template_vector

--- a/menpo/math/linalg.py
+++ b/menpo/math/linalg.py
@@ -1,5 +1,5 @@
 import numpy as np
-from menpo.visualize import print_dynamic, progress_bar_str
+from menpo.visualize import print_progress, print_bytes
 
 
 def dot_inplace_left(a, b, block_size=1000):
@@ -126,22 +126,21 @@ def as_matrix(vectorizables, length=None, return_template=False, verbose=False):
 
     data = np.zeros((length, n_features), dtype=template_vector.dtype)
     if verbose:
-        print('Allocated data matrix {:.2f}'
-              'GB'.format(data.nbytes / 2 ** 30))
+        print('Allocated data matrix of size {} '
+              '({} samples)'.format(print_bytes(data.nbytes), length))
 
     # now we can fill in the first element from the template
     data[0] = template_vector
     del template_vector
 
+    if verbose:
+        vectorizables = print_progress(vectorizables, n_items=length, offset=1,
+                                       prefix='Building data matrix')
+
     # 1-based as we have the template vector set already
     for i, sample in enumerate(vectorizables, 1):
         if i >= length:
             break
-        if verbose:
-            print_dynamic(
-                'Building data matrix from {} samples - {}'.format(
-                    length,
-                    progress_bar_str(float(i + 1) / length, show_bar=True)))
         data[i] = sample.as_vector()
 
     if return_template:

--- a/menpo/visualize/__init__.py
+++ b/menpo/visualize/__init__.py
@@ -3,7 +3,7 @@ from .base import (
     PointGraphViewer2d, LandmarkViewer2d, ImageViewer2d, ImageViewer,
     AlignmentViewer2d, GraphPlotter, view_image_landmarks)
 from .text_utils import (print_progress, progress_bar_str, print_dynamic,
-                         print_bytes)
+                         bytes_str)
 from .widgets import (visualize_pointclouds, visualize_images,
                       visualize_landmarks, features_selection,
                       save_matplotlib_figure, visualize_landmarkgroups)

--- a/menpo/visualize/__init__.py
+++ b/menpo/visualize/__init__.py
@@ -2,7 +2,8 @@ from .base import (
     Renderer, Viewable, LandmarkableViewable, viewwrapper, Menpo3dErrorMessage,
     PointGraphViewer2d, LandmarkViewer2d, ImageViewer2d, ImageViewer,
     AlignmentViewer2d, GraphPlotter, view_image_landmarks)
-from .text_utils import progress_bar_str, print_dynamic, print_bytes
+from .text_utils import (print_progress, progress_bar_str, print_dynamic,
+                         print_bytes)
 from .widgets import (visualize_pointclouds, visualize_images,
                       visualize_landmarks, features_selection,
                       save_matplotlib_figure, visualize_landmarkgroups)

--- a/menpo/visualize/__init__.py
+++ b/menpo/visualize/__init__.py
@@ -2,8 +2,8 @@ from .base import (
     Renderer, Viewable, LandmarkableViewable, viewwrapper, Menpo3dErrorMessage,
     PointGraphViewer2d, LandmarkViewer2d, ImageViewer2d, ImageViewer,
     AlignmentViewer2d, GraphPlotter, view_image_landmarks)
-from .text_utils import (print_progress, progress_bar_str, print_dynamic,
-                         bytes_str)
+from .textutils import (print_progress, progress_bar_str, print_dynamic,
+                        bytes_str)
 from .widgets import (visualize_pointclouds, visualize_images,
                       visualize_landmarks, features_selection,
                       save_matplotlib_figure, visualize_landmarkgroups)

--- a/menpo/visualize/text_utils.py
+++ b/menpo/visualize/text_utils.py
@@ -1,4 +1,7 @@
+from collections import deque
+import datetime
 import sys
+from time import time
 
 
 def progress_bar_str(percentage, bar_length=20, bar_marker='=', show_bar=True):
@@ -105,3 +108,48 @@ def print_bytes(num):
             return "{0:3.2f} {1:s}".format(num, x)
         num /= 1024.0
     return "{0:3.2f} {1:s}".format(num, 'TB')
+
+
+def print_progress(iterable):
+    r"""
+    Print the remaining time needed to compute over an iterable.
+
+    To use, wrap an existing iterable with this function before processing in
+    a for loop (see example).
+
+    The estimate of the remaining time is based on a moving average of the last
+    10 items completed in the loop.
+
+    Parameters
+    ----------
+    iterator : `iterator`
+        An iterator that will be processed. The iterator is passed through by
+        this function.
+
+    Examples
+    --------
+    This for loop: ::
+
+        from time import sleep
+        for i in print_progress(range(10)):
+            sleep(1)
+
+    prints a progress report of the form: ::
+
+        [=============       ] 70% (7/10) 00:00:03 remaining
+    """
+    n = len(iterable)
+    timings = deque([], 10)
+    for i, x in enumerate(iterable):
+        time1 = time()
+        yield x
+        time2 = time()
+        timings.append(time2 - time1)
+        remaining = n - i - 1
+        duration = datetime.utcfromtimestamp(sum(timings) / len(timings) *
+                                             remaining)
+        remaining_str = duration.strftime('%H:%M:%S')
+        bar_str = progress_bar_str((i + 1.0) / n)
+        print_dynamic('{} ({}/{}) - {} remaining'.format(bar_str, i + 1, n,
+                                                         remaining_str))
+    print('')

--- a/menpo/visualize/text_utils.py
+++ b/menpo/visualize/text_utils.py
@@ -85,9 +85,9 @@ def print_dynamic(str_to_print):
     sys.stdout.flush()
 
 
-def print_bytes(num):
+def bytes_str(num):
     r"""
-    Converts bytes to a sensible format to be printed. For example: ::
+    Converts bytes to a human readable format. For example: ::
 
         print_bytes(12345) returns '12.06 KB'
         print_bytes(123456789) returns '117.74 MB'

--- a/menpo/visualize/text_utils.py
+++ b/menpo/visualize/text_utils.py
@@ -1,5 +1,5 @@
 from collections import deque
-import datetime
+from datetime import datetime
 import sys
 from time import time
 
@@ -110,7 +110,7 @@ def print_bytes(num):
     return "{0:3.2f} {1:s}".format(num, 'TB')
 
 
-def print_progress(iterable):
+def print_progress(iterable, n_items=None):
     r"""
     Print the remaining time needed to compute over an iterable.
 
@@ -118,33 +118,38 @@ def print_progress(iterable):
     a for loop (see example).
 
     The estimate of the remaining time is based on a moving average of the last
-    10 items completed in the loop.
+    100 items completed in the loop.
 
     Parameters
     ----------
     iterator : `iterator`
         An iterator that will be processed. The iterator is passed through by
         this function.
+    n_items : `int`, optional
+        Allows for ``iterator`` to be a generator whose length will be assumed
+        to be `n_items`. If not provided, then ``iterator`` needs to be
+        `Sizable`.
 
     Examples
     --------
     This for loop: ::
 
         from time import sleep
-        for i in print_progress(range(10)):
+        for i in print_progress(range(100)):
             sleep(1)
 
     prints a progress report of the form: ::
 
         [=============       ] 70% (7/10) 00:00:03 remaining
     """
-    n = len(iterable)
-    timings = deque([], 10)
+    n = n_items if n_items is not None else len(iterable)
+    timings = deque([], 100)
+    time1 = time()
     for i, x in enumerate(iterable):
-        time1 = time()
         yield x
         time2 = time()
         timings.append(time2 - time1)
+        time1 = time2
         remaining = n - i - 1
         duration = datetime.utcfromtimestamp(sum(timings) / len(timings) *
                                              remaining)

--- a/menpo/visualize/text_utils.py
+++ b/menpo/visualize/text_utils.py
@@ -1,3 +1,4 @@
+from __future__ import division
 from collections import deque
 from datetime import datetime
 import sys
@@ -110,7 +111,7 @@ def print_bytes(num):
     return "{0:3.2f} {1:s}".format(num, 'TB')
 
 
-def print_progress(iterable, n_items=None):
+def print_progress(iterable, prefix='', n_items=None, offset=0):
     r"""
     Print the remaining time needed to compute over an iterable.
 
@@ -125,10 +126,15 @@ def print_progress(iterable, n_items=None):
     iterator : `iterator`
         An iterator that will be processed. The iterator is passed through by
         this function.
+    prefix : `str`, optional
+        If provided a string that will be prepended to the progress report at
+        each level.
     n_items : `int`, optional
         Allows for ``iterator`` to be a generator whose length will be assumed
         to be `n_items`. If not provided, then ``iterator`` needs to be
         `Sizable`.
+    offset : `int`, optional
+        Report back the progress as if `offset` items have already been handled
 
     Examples
     --------
@@ -142,19 +148,26 @@ def print_progress(iterable, n_items=None):
 
         [=============       ] 70% (7/10) 00:00:03 remaining
     """
+    if prefix != '':
+        prefix = prefix + ': '
+        bar_length = 10
+    else:
+        bar_length = 20
     n = n_items if n_items is not None else len(iterable)
+    # n = n + offset
     timings = deque([], 100)
     time1 = time()
-    for i, x in enumerate(iterable):
+    for i, x in enumerate(iterable, 1 + offset):
         yield x
         time2 = time()
         timings.append(time2 - time1)
         time1 = time2
-        remaining = n - i - 1
+        remaining = n - i
         duration = datetime.utcfromtimestamp(sum(timings) / len(timings) *
                                              remaining)
         remaining_str = duration.strftime('%H:%M:%S')
-        bar_str = progress_bar_str((i + 1.0) / n)
-        print_dynamic('{} ({}/{}) - {} remaining'.format(bar_str, i + 1, n,
-                                                         remaining_str))
+        bar_str = progress_bar_str(i / n, bar_length=bar_length)
+        print_dynamic('{}{} ({}/{}) - {} remaining'.format(prefix, bar_str,
+                                                           i, n,
+                                                           remaining_str))
     print('')

--- a/menpo/visualize/textutils.py
+++ b/menpo/visualize/textutils.py
@@ -123,9 +123,9 @@ def print_progress(iterable, prefix='', n_items=None, offset=0):
 
     Parameters
     ----------
-    iterator : `iterator`
-        An iterator that will be processed. The iterator is passed through by
-        this function.
+    iterable : `iterable`
+        An iterable that will be processed. The iterable is passed through by
+        this function, with the time taken for each complete iteration logged.
     prefix : `str`, optional
         If provided a string that will be prepended to the progress report at
         each level.
@@ -134,7 +134,14 @@ def print_progress(iterable, prefix='', n_items=None, offset=0):
         to be `n_items`. If not provided, then ``iterator`` needs to be
         `Sizable`.
     offset : `int`, optional
-        Report back the progress as if `offset` items have already been handled
+        Useful in combination with ``n_items`` - report back the progress as
+        if `offset` items have already been handled. ``n_items``  will be left
+        unchanged.
+
+    Raises
+    ------
+    ValueError
+        ``offset`` provided without ``n_items``
 
     Examples
     --------
@@ -148,13 +155,16 @@ def print_progress(iterable, prefix='', n_items=None, offset=0):
 
         [=============       ] 70% (7/10) 00:00:03 remaining
     """
+    if n_items is None and offset != 0:
+        raise ValueError('offset can only be set when n_items has been'
+                         ' manually provided.')
     if prefix != '':
         prefix = prefix + ': '
         bar_length = 10
     else:
         bar_length = 20
     n = n_items if n_items is not None else len(iterable)
-    # n = n + offset
+
     timings = deque([], 100)
     time1 = time()
     for i, x in enumerate(iterable, 1 + offset):


### PR DESCRIPTION
new convenience function for reporting on the time remaining for processing an iterator. Saves you manually calling `print_dynamic()` and `progress_bar_str()`

This for loop:

```python
from time import sleep
for i in print_progress(range(10)):
    sleep(1)
```
prints a progress report of the form:
```
[=============       ] 70% (7/10) 00:00:03 remaining
```