### PR TITLE
fix as_matrix where the iterator finished early

### DIFF
--- a/menpo/math/linalg.py
+++ b/menpo/math/linalg.py
@@ -115,6 +115,7 @@ def as_matrix(vectorizables, length=None, return_template=False, verbose=False):
     Raises
     ------
     ValueError
+        ``vectorizables`` terminates in fewer than ``length`` iterations
     """
     # get the first element as the template and use it to configure the
     # data matrix

--- a/menpo/math/linalg.py
+++ b/menpo/math/linalg.py
@@ -1,3 +1,4 @@
+from itertools import islice
 import numpy as np
 from menpo.visualize import print_progress, bytes_str
 
@@ -110,6 +111,10 @@ def as_matrix(vectorizables, length=None, return_template=False, verbose=False):
     template : :map:`Vectorizable`, optional
         If ``return_template == True``, will return the template used to
         build the matrix `M`.
+
+    Raises
+    ------
+    ValueError
     """
     # get the first element as the template and use it to configure the
     # data matrix
@@ -133,15 +138,23 @@ def as_matrix(vectorizables, length=None, return_template=False, verbose=False):
     data[0] = template_vector
     del template_vector
 
+    # ensure we take at most the remaining length - 1 elements
+    vectorizables = islice(vectorizables, length - 1)
+
     if verbose:
         vectorizables = print_progress(vectorizables, n_items=length, offset=1,
                                        prefix='Building data matrix')
 
     # 1-based as we have the template vector set already
+    i = 0
     for i, sample in enumerate(vectorizables, 1):
-        if i >= length:
-            break
         data[i] = sample.as_vector()
+
+    # we have exhausted the iterable, but did we get enough items?
+    if i != length - 1:  # -1
+        raise ValueError('Incomplete data matrix due to early iterator '
+                         'termination (expected {} items, got {})'.format(
+            length, i + 1))
 
     if return_template:
         return data, template

--- a/menpo/math/test/linalg_test.py
+++ b/menpo/math/test/linalg_test.py
@@ -79,6 +79,11 @@ def test_as_matrix_short_length():
     assert_equal(data.shape, (1, 20))
 
 
+@raises(ValueError)
+def test_as_matrix_long_length_raises_value_error():
+    as_matrix((template.copy() for _ in range(4)), length=5)
+
+
 def test_as_matrix_return_template():
     data, t = as_matrix((template.copy() for _ in range(n_images)),
                         length=1, return_template=True)


### PR DESCRIPTION
`as_matrix()` presently did not report an error if an iterator terminated early. Fixed, and added test.