### PR TITLE
promote non-inplace crop methods, crop performance improvements

### DIFF
--- a/menpo/feature/test/test_features.py
+++ b/menpo/feature/test/test_features.py
@@ -256,7 +256,7 @@ def test_lbp_values():
 
 def test_constrain_landmarks():
     breaking_bad = mio.import_builtin_asset('breakingbad.jpg').as_masked()
-    breaking_bad.crop_to_landmarks_inplace(boundary=20)
+    breaking_bad = breaking_bad.crop_to_landmarks(boundary=20)
     breaking_bad = breaking_bad.resize([50, 50])
     breaking_bad.constrain_mask_to_landmarks()
     hog_b = hog(breaking_bad, mode='sparse')

--- a/menpo/image/base.py
+++ b/menpo/image/base.py
@@ -1367,7 +1367,9 @@ class Image(Vectorizable, Landmarkable, Viewable, LandmarkableViewable):
 
             if isinstance(transform, Translation) and order == 0:
                 # an integer translation (e.g. a crop) If this lies entirely
-                # in the bounds then we can just do a copy.
+                # in the bounds then we can just do a copy. We need to match
+                # the behavior of cython_interpolation exactly, which means
+                # matching its rounding behavior too:
                 t = transform.translation_component.copy()
                 pos_t = t > 0.0
                 t[pos_t] += 0.5

--- a/menpo/image/base.py
+++ b/menpo/image/base.py
@@ -1006,6 +1006,8 @@ class Image(Vectorizable, Landmarkable, Viewable, LandmarkableViewable):
             constrain_to_boundary=constrain_to_boundary)
 
     def _propagate_crop_to_inplace(self, cropped):
+        # helper method that sets self's state to the result of a crop call.
+        # only needed for the deprecation period of the inplace crop methods.
         self.pixels = cropped.pixels
         self.landmarks = cropped.landmarks
         if hasattr(self, 'mask'):
@@ -1397,6 +1399,9 @@ class Image(Vectorizable, Landmarkable, Viewable, LandmarkableViewable):
                                            warp_landmarks)
 
     def _build_warp_to_shape(self, warped_pixels, transform, warp_landmarks):
+        # factored out common logic from the different paths we can take in
+        # warp_to_shape. Rebuilds an image post-warp, adjusting landmarks
+        # as necessary.
         warped_image = Image(warped_pixels, copy=False)
 
         # warp landmarks if requested.

--- a/menpo/image/base.py
+++ b/menpo/image/base.py
@@ -1368,9 +1368,13 @@ class Image(Vectorizable, Landmarkable, Viewable, LandmarkableViewable):
             if isinstance(transform, Translation) and order == 0:
                 # an integer translation (e.g. a crop) If this lies entirely
                 # in the bounds then we can just do a copy.
-                min_ = transform.translation_component.astype(np.int)
+                t = transform.translation_component.copy()
+                pos_t = t > 0.0
+                t[pos_t] += 0.5
+                t[~pos_t] -= 0.5
+                min_ = t.astype(np.int)
                 max_ = template_shape + min_
-                if np.all(max_ <= template_shape) and np.all(min_ >= 0):
+                if np.all(max_ <= np.array(self.shape)) and np.all(min_ >= 0):
                     # we have a crop - slice the pixels.
                     warped_pixels = self.pixels[:,
                                     int(min_[0]):int(max_[0]),

--- a/menpo/image/masked.py
+++ b/menpo/image/masked.py
@@ -671,48 +671,6 @@ class MaskedImage(Image):
             axes_font_size, axes_font_style, axes_font_weight, axes_x_limits,
             axes_y_limits, figure_size)
 
-    def crop_inplace(self, min_indices, max_indices,
-                     constrain_to_boundary=True):
-        r"""
-        Crops this image using the given minimum and maximum indices.
-        Landmarks are correctly adjusted so they maintain their position
-        relative to the newly cropped image.
-
-        Parameters
-        ----------
-        min_indices: ``(n_dims, )`` `ndarray`
-            The minimum index over each dimension.
-        max_indices: ``(n_dims, )`` `ndarray`
-            The maximum index over each dimension.
-        constrain_to_boundary : `bool`, optional
-            If ``True`` the crop will be snapped to not go beyond this images
-            boundary. If ``False``, an :map:`ImageBoundaryError` will be raised
-            if an attempt is made to go beyond the edge of the image.
-
-        Returns
-        -------
-        cropped_image : `type(self)`
-            This image, but cropped.
-
-        Raises
-        ------
-        ValueError
-            ``min_indices`` and ``max_indices`` both have to be of length
-            ``n_dims``. All ``max_indices`` must be greater than
-            ``min_indices``.
-        :map`ImageBoundaryError`
-            Raised if ``constrain_to_boundary=False``, and an attempt is made
-            to crop the image in a way that violates the image bounds.
-        """
-        # crop our image
-        super(MaskedImage, self).crop_inplace(
-            min_indices, max_indices,
-            constrain_to_boundary=constrain_to_boundary)
-        # crop our mask
-        self.mask.crop_inplace(min_indices, max_indices,
-                               constrain_to_boundary=constrain_to_boundary)
-        return self
-
     def crop_to_true_mask(self, boundary=0, constrain_to_boundary=True):
         r"""
         Crop this image to be bounded just the `True` values of it's mask.
@@ -728,6 +686,11 @@ class MaskedImage(Image):
             if an attempt is made to go beyond the edge of the image. Note that
             is only possible if ``boundary != 0``.
 
+        Returns
+        -------
+        cropped_image : ``type(self)``
+            A copy of this image, cropped to the true mask.
+
         Raises
         ------
         ImageBoundaryError
@@ -737,8 +700,8 @@ class MaskedImage(Image):
         min_indices, max_indices = self.mask.bounds_true(
             boundary=boundary, constrain_to_bounds=False)
         # no point doing the bounds check twice - let the crop do it only.
-        self.crop_inplace(min_indices, max_indices,
-                          constrain_to_boundary=constrain_to_boundary)
+        return self.crop(min_indices, max_indices,
+                         constrain_to_boundary=constrain_to_boundary)
 
     def sample(self, points_to_sample, order=1, mode='constant', cval=0.0):
         r"""
@@ -911,10 +874,7 @@ class MaskedImage(Image):
                                        mode=mode, cval=cval)
         # efficiently turn the Image into a MaskedImage, attaching the
         # landmarks
-        masked_warped_image = MaskedImage(warped_image.pixels, mask=mask,
-                                          copy=False)
-        if warped_image.has_landmarks:
-            masked_warped_image.landmarks = warped_image.landmarks
+        masked_warped_image = warped_image.as_masked(mask=mask, copy=False)
         if hasattr(warped_image, 'path'):
             masked_warped_image.path = warped_image.path
         return masked_warped_image

--- a/menpo/transform/test/pwa_test.py
+++ b/menpo/transform/test/pwa_test.py
@@ -4,7 +4,7 @@ from menpo.transform.piecewiseaffine.base import (CythonPWA, CachedPWA,
                                                   PythonPWA)
 
 b = menpo.io.import_builtin_asset('breakingbad.jpg').as_masked()
-b.crop_to_landmarks_proportion_inplace(0.1)
+b = b.crop_to_landmarks_proportion(0.1)
 b = b.rescale_landmarks_to_diagonal_range(120)
 b.constrain_mask_to_landmarks()
 points = b.mask.true_indices()


### PR DESCRIPTION
Addresses #482, and prepares for #583.

Summary of changes:

1. `warp_to_shape()` now has a fast path for crops (which are simply when the transform is a `Translation`, `order=0`, and no out-of-bounds sampling is needed). `Image.crop()` and friends now take advantage of this and call `warp_to_shape()`. This cleans up the image package somewhat, as all our reconstruction logic (handling landmarks, different image types, etc) is now all centralized in the `warp_to_{shape,mask}()` methods.
2. `crop_to_landmarks_{proportion}()` now exist as non-inplace versions of  `crop_to_landmarks_{proportion}_inplace()`
3. All existing inplace crop methods are present but raise deprecation warnings. There implementation is now slower than the non-inplace varient, as they perform extra work (they basically call the non-inplace versions, and then graft the result back on to `self`). They will go away in `0.6.x`.
4. `MaskedImage.crop_to_true_mask()` (which is seemingly an unused method) is now non-inplace.

This is fairly major change, but we already have pretty good coverage on the image package and all tests are passing.