### PR TITLE
Fix centre and diagonal being properties on Images

### DIFF
--- a/menpo/image/base.py
+++ b/menpo/image/base.py
@@ -272,7 +272,6 @@ class Image(Vectorizable, Landmarkable, Viewable, LandmarkableViewable):
         """
         return self.pixels.shape[1:]
 
-    @property
     def diagonal(self):
         r"""
         The diagonal size of this image
@@ -281,7 +280,6 @@ class Image(Vectorizable, Landmarkable, Viewable, LandmarkableViewable):
         """
         return np.sqrt(np.sum(np.array(self.shape) ** 2))
 
-    @property
     def centre(self):
         r"""
         The geometric centre of the Image - the subpixel that is in the
@@ -1488,7 +1486,7 @@ class Image(Vectorizable, Landmarkable, Viewable, LandmarkableViewable):
         rescaled_image : type(self)
             A copy of this image, rescaled.
         """
-        return self.rescale(diagonal / self.diagonal, round=round)
+        return self.rescale(diagonal / self.diagonal(), round=round)
 
     def rescale_to_reference_shape(self, reference_shape, group=None,
                                    label=None, round='ceil', order=1):

--- a/menpo/image/base.py
+++ b/menpo/image/base.py
@@ -1639,7 +1639,7 @@ class Image(Vectorizable, Landmarkable, Viewable, LandmarkableViewable):
         cval : ``float``, optional
             The value to be set outside the rotated image boundaries.
         """
-        centre = Translation(-self.centre)
+        centre = Translation(-self.centre())
         t = (centre.compose_before(UniformScale(1.0 / scale, self.n_dims))
                    .compose_before(centre.pseudoinverse()))
 

--- a/menpo/image/test/image_test.py
+++ b/menpo/image/test/image_test.py
@@ -47,7 +47,7 @@ def test_image_blank_n_channels():
 def test_image_centre():
     pixels = np.ones((1, 10, 20))
     image = Image(pixels)
-    assert(np.all(image.centre == np.array([5, 10])))
+    assert(np.all(image.centre() == np.array([5, 10])))
 
 
 def test_image_str_shape_4d():
@@ -680,27 +680,27 @@ def test_image_extract_channels_multiple_reversed():
 
 def test_diagonal_greyscale():
     image = Image.init_blank((100, 250), n_channels=1)
-    assert image.diagonal == (100 ** 2 + 250 ** 2) ** 0.5
+    assert image.diagonal() == (100 ** 2 + 250 ** 2) ** 0.5
 
 
 def test_diagonal_color():
     image = Image.init_blank((100, 250), n_channels=3)
-    assert image.diagonal == (100 ** 2 + 250 ** 2) ** 0.5
+    assert image.diagonal() == (100 ** 2 + 250 ** 2) ** 0.5
 
 
 def test_diagonal_greyscale_ndim():
     image = Image.init_blank((100, 250, 50), n_channels=1)
-    assert image.diagonal == (100 ** 2 + 250 ** 2 + 50 ** 2) ** 0.5
+    assert image.diagonal() == (100 ** 2 + 250 ** 2 + 50 ** 2) ** 0.5
 
 
 def test_diagonal_kchannel_ndim():
     image = Image.init_blank((100, 250, 50), n_channels=5)
-    assert image.diagonal == (100 ** 2 + 250 ** 2 + 50 ** 2) ** 0.5
+    assert image.diagonal() == (100 ** 2 + 250 ** 2 + 50 ** 2) ** 0.5
 
 
 def test_rescale_to_diagonal():
     image = Image.init_blank((8, 6), n_channels=2)
-    assert image.diagonal == 10
+    assert image.diagonal() == 10
     rescaled = image.rescale_to_diagonal(5)
     assert rescaled.shape == (4, 3)
     assert rescaled.n_channels == 2


### PR DESCRIPTION
Given some new work I'm doing, I noticed that the `centre` method
is not consistent between `PointCloud` and ``Image``. A while ago,
@jabooth changed all properties that performed calculations
to methods, but `diagonal` and `centre` on images seem to have slipped
under the radar.

This turns them into methods and fixes the tests.