### PR TITLE
Refactor out bounding_box method

### DIFF
--- a/menpo/shape/__init__.py
+++ b/menpo/shape/__init__.py
@@ -1,4 +1,4 @@
-from .pointcloud import PointCloud
+from .pointcloud import PointCloud, bounding_box
 from .mesh import TriMesh, ColouredTriMesh, TexturedTriMesh
 from .groupops import mean_pointcloud
 from .graph import (UndirectedGraph, DirectedGraph, Tree, PointUndirectedGraph,

--- a/menpo/shape/test/pointcloud_test.py
+++ b/menpo/shape/test/pointcloud_test.py
@@ -1,6 +1,8 @@
 import warnings
 import numpy as np
-from menpo.shape import PointCloud
+from nose.tools import raises
+from numpy.testing import assert_allclose
+from menpo.shape import PointCloud, bounding_box
 from menpo.testing import is_same_array
 
 
@@ -81,3 +83,27 @@ def test_pointcloud_flatten_rebuild():
     assert (np.all(new_pc.n_dims == pc.n_dims))
     assert (np.all(new_pc.n_points == pc.n_points))
     assert (np.all(pc.points == new_pc.points))
+
+
+def test_pointcloud_bounding_box():
+    points = np.array([[0, 0],
+                       [1, 1],
+                       [0, 2]])
+    pc = PointCloud(points)
+    bb = pc.bounding_box()
+    bb_bounds = bb.bounds()
+    assert_allclose(bb_bounds[0], [0., 0.])
+    assert_allclose(bb_bounds[1], [1., 2.])
+
+
+@raises(ValueError)
+def test_pointcloud_bounding_box_3d_fail():
+    points = np.array([[0, 0, 0],
+                       [1, 1, 1]])
+    pc = PointCloud(points)
+    pc.bounding_box()
+
+
+def test_bounding_box_creation():
+    bb = bounding_box([0, 0], [1, 1])
+    assert_allclose(bb.points, [[0, 0], [1, 0], [1, 1], [0, 1]])


### PR DESCRIPTION
At the moment, in menpofit and menpodetect, we have need
of creating bounding boxes, and it is awkward right now
because there is now way to do it. You have to create a pointcloud
and then call `bounding_box` on it. This makes this a lot simpler
by exposing a `bounding_box` function globally from the shape
module