### PR TITLE
Human3.6M labels

### DIFF
--- a/menpo/landmark/labels.py
+++ b/menpo/landmark/labels.py
@@ -811,6 +811,7 @@ def ibug_face_49_trimesh(landmark_group):
 
     return group, new_landmark_group
 
+
 def ibug_face_65_closed_mouth(landmark_group):
     """
     Apply the ibug's "standard" 68 point semantic labels (based on the
@@ -1608,7 +1609,7 @@ def human36M_pose_32(landmark_group):
     Apply the human3.6M "standard" 32 point semantic labels to the landmark
     group.
 
-    The group label will be ``human36M_pose``.
+    The group label will be ``human36M_pose_32``.
 
     The semantic labels applied are as follows:
 
@@ -1621,6 +1622,7 @@ def human36M_pose_32(landmark_group):
       - left_hand
       - right_arm
       - right_hand
+      - torso
 
     Parameters
     ----------
@@ -1630,7 +1632,7 @@ def human36M_pose_32(landmark_group):
     Returns
     -------
     group : `str`
-        The group label: ``human36M_pose``
+        The group label: ``human36M_pose_32``
     landmark_group : :map:`LandmarkGroup`
         New landmark group.
 
@@ -1645,7 +1647,7 @@ def human36M_pose_32(landmark_group):
     """
     from menpo.shape import PointUndirectedGraph
 
-    group = 'human36M_pose'
+    group = 'human36M_pose_32'
     _validate_input(landmark_group, 32, group)
 
     pelvis_indices = np.array([1, 0, 6])
@@ -1657,6 +1659,7 @@ def human36M_pose_32(landmark_group):
     left_hand_indices = np.array([20, 21, 22])
     right_arm_indices = np.array([24, 25, 26, 27, 29, 31])
     right_hand_indices = np.array([28, 29, 30])
+    torso_indices = np.array([0, 1, 25, 13, 17, 6])
 
     pelvis_connectivity = _connectivity_from_array(pelvis_indices)
     right_leg_connectivity = _connectivity_from_array(right_leg_indices)
@@ -1667,12 +1670,14 @@ def human36M_pose_32(landmark_group):
     left_hand_connectivity = _connectivity_from_array(left_hand_indices)
     right_arm_connectivity = _connectivity_from_array(right_arm_indices)
     right_hand_connectivity = _connectivity_from_array(right_hand_indices)
+    torso_connectivity = _connectivity_from_array(torso_indices,
+                                                  close_loop=True)
 
     total_conn = np.vstack([
         pelvis_connectivity, right_leg_connectivity, left_leg_connectivity,
         spine_connectivity, head_connectivity, left_arm_connectivity,
         left_hand_connectivity, right_arm_connectivity,
-        right_hand_connectivity])
+        right_hand_connectivity, torso_connectivity])
 
     new_landmark_group = LandmarkGroup.init_with_all_label(
         PointUndirectedGraph.init_from_edges(landmark_group.lms.points,
@@ -1687,6 +1692,97 @@ def human36M_pose_32(landmark_group):
     new_landmark_group['left_hand'] = left_hand_indices
     new_landmark_group['right_arm'] = right_arm_indices
     new_landmark_group['right_hand'] = right_hand_indices
+    new_landmark_group['torso'] = torso_indices
+
+    del new_landmark_group['all']  # Remove pointless all group
+
+    return group, new_landmark_group
+
+
+def human36M_pose_17(landmark_group):
+    """
+    Apply the human3.6M "standard" 17 point semantic labels (based on the
+    original semantic labels of Human3.6 but removing the annotations
+    corresponding to duplicate points, soles and palms) to the landmark group.
+
+    The group label will be ``human36M_pose_17``.
+
+    The semantic labels applied are as follows:
+
+      - pelvis
+      - right_leg
+      - left_leg
+      - spine
+      - head
+      - left_arm
+      - right_arm
+      - torso
+
+    Parameters
+    ----------
+    landmark_group : :map:`LandmarkGroup`
+        The landmark group to apply semantic labels to.
+
+    Returns
+    -------
+    group : `str`
+        The group label: ``human36M_pose_17``
+    landmark_group : :map:`LandmarkGroup`
+        New landmark group.
+
+    Raises
+    ------
+    error : :map:`LabellingError`
+        If the given landmark group contains less than 32 points
+
+    References
+    ----------
+    .. [1] http://vision.imar.ro/human3.6m/
+    """
+    from menpo.shape import PointUndirectedGraph
+
+    group = 'human36M_pose_17'
+    _validate_input(landmark_group, 32, group)
+
+    pelvis_indices = np.array([1, 0, 4])
+    right_leg_indices = np.arange(1, 4)
+    left_leg_indices = np.arange(4, 7)
+    spine_indices = np.array([0, 7, 8])
+    head_indices = np.array([8, 9, 10])
+    left_arm_indices = np.array([8, 11, 12, 13])
+    right_arm_indices = np.array([8, 14, 15, 16])
+    torso_indices = np.array([0, 1, 14, 8, 11, 4])
+
+    pelvis_connectivity = _connectivity_from_array(pelvis_indices)
+    right_leg_connectivity = _connectivity_from_array(right_leg_indices)
+    left_leg_connectivity = _connectivity_from_array(left_leg_indices)
+    spine_connectivity = _connectivity_from_array(spine_indices)
+    head_connectivity = _connectivity_from_array(head_indices)
+    left_arm_connectivity = _connectivity_from_array(left_arm_indices)
+    right_arm_connectivity = _connectivity_from_array(right_arm_indices)
+    torso_connectivity = _connectivity_from_array(torso_indices,
+                                                  close_loop=True)
+
+    total_conn = np.vstack([
+        pelvis_connectivity, right_leg_connectivity, left_leg_connectivity,
+        spine_connectivity, head_connectivity, left_arm_connectivity,
+        right_arm_connectivity, torso_connectivity])
+
+    # Ignore duplicate points, sole and palms
+    ind = np.hstack((np.arange(0, 4), np.arange(6, 9), np.arange(12, 16),
+                     np.arange(17, 20), np.arange(25, 28)))
+    new_landmark_group = LandmarkGroup.init_with_all_label(
+        PointUndirectedGraph.init_from_edges(landmark_group.lms.points[ind],
+                                             total_conn))
+
+    new_landmark_group['pelvis'] = pelvis_indices
+    new_landmark_group['right_leg'] = right_leg_indices
+    new_landmark_group['left_leg'] = left_leg_indices
+    new_landmark_group['spine'] = spine_indices
+    new_landmark_group['head'] = head_indices
+    new_landmark_group['left_arm'] = left_arm_indices
+    new_landmark_group['right_arm'] = right_arm_indices
+    new_landmark_group['torso'] = torso_indices
 
     del new_landmark_group['all']  # Remove pointless all group
 

--- a/menpo/landmark/labels.py
+++ b/menpo/landmark/labels.py
@@ -1603,6 +1603,96 @@ def flic_pose(landmark_group):
     return group, _relabel_group_from_dict(landmark_group.lms, labels)
 
 
+def human36M_pose_32(landmark_group):
+    """
+    Apply the human3.6M "standard" 32 point semantic labels to the landmark
+    group.
+
+    The group label will be ``human36M_pose``.
+
+    The semantic labels applied are as follows:
+
+      - pelvis
+      - right_leg
+      - left_leg
+      - spine
+      - head
+      - left_arm
+      - left_hand
+      - right_arm
+      - right_hand
+
+    Parameters
+    ----------
+    landmark_group : :map:`LandmarkGroup`
+        The landmark group to apply semantic labels to.
+
+    Returns
+    -------
+    group : `str`
+        The group label: ``human36M_pose``
+    landmark_group : :map:`LandmarkGroup`
+        New landmark group.
+
+    Raises
+    ------
+    error : :map:`LabellingError`
+        If the given landmark group contains less than 32 points
+
+    References
+    ----------
+    .. [1] http://vision.imar.ro/human3.6m/
+    """
+    from menpo.shape import PointUndirectedGraph
+
+    group = 'human36M_pose'
+    _validate_input(landmark_group, 32, group)
+
+    pelvis_indices = np.array([1, 0, 6])
+    right_leg_indices = np.array(range(1, 6))
+    left_leg_indices = np.array(range(6, 11))
+    spine_indices = np.array([11, 12, 13])
+    head_indices = np.array([13, 14, 15])
+    left_arm_indices = np.array([16, 17, 18, 19, 23])
+    left_hand_indices = np.array([20, 21, 22])
+    right_arm_indices = np.array([24, 25, 26, 27, 29, 31])
+    right_hand_indices = np.array([28, 29, 30])
+
+    pelvis_connectivity = _connectivity_from_array(pelvis_indices)
+    right_leg_connectivity = _connectivity_from_array(right_leg_indices)
+    left_leg_connectivity = _connectivity_from_array(left_leg_indices)
+    spine_connectivity = _connectivity_from_array(spine_indices)
+    head_connectivity = _connectivity_from_array(head_indices)
+    left_arm_connectivity = _connectivity_from_array(left_arm_indices)
+    left_hand_connectivity = _connectivity_from_array(left_hand_indices)
+    right_arm_connectivity = _connectivity_from_array(right_arm_indices)
+    right_hand_connectivity = _connectivity_from_array(right_hand_indices)
+
+    total_conn = np.vstack([
+        pelvis_connectivity, right_leg_connectivity, left_leg_connectivity,
+        spine_connectivity, head_connectivity, left_arm_connectivity,
+        left_hand_connectivity, right_arm_connectivity,
+        right_hand_connectivity])
+
+    new_landmark_group = LandmarkGroup.init_with_all_label(
+        PointUndirectedGraph.init_from_edges(landmark_group.lms.points,
+                                             total_conn))
+
+    new_landmark_group['pelvis'] = pelvis_indices
+    new_landmark_group['right_leg'] = right_leg_indices
+    new_landmark_group['left_leg'] = left_leg_indices
+    new_landmark_group['spine'] = spine_indices
+    new_landmark_group['head'] = head_indices
+    new_landmark_group['left_arm'] = left_arm_indices
+    new_landmark_group['left_hand'] = left_hand_indices
+    new_landmark_group['right_arm'] = right_arm_indices
+    new_landmark_group['right_hand'] = right_hand_indices
+
+    del new_landmark_group['all']  # Remove pointless all group
+
+    return group, new_landmark_group
+
+
 def streetscene_car_view_0(landmark_group):
     """
     Apply the 8 point semantic labels of the view 0  of the MIT Street Scene


### PR DESCRIPTION
This PR defines two new labels fro th Human3.6M human body pose database:

* `human36M_pose_32`: This includes all the original (32) landmarks of the database.
* `human36M_pose_17`: This includes a subset of 17 landmarks. Some duplicate points and some badly annotated ones are removed.