### PR TITLE
Add sudo: false to turn on container builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,5 @@
+sudo: false
+
 os:
 - linux
 - osx


### PR DESCRIPTION
Should be faster, and we don't need sudo or anything fancy since we setup conda ourselves. See http://docs.travis-ci.com/user/workers/container-based-infrastructure/
for more information.