### PR TITLE
Extract patches types

### DIFF
--- a/menpo/cy_utils.pxd
+++ b/menpo/cy_utils.pxd
@@ -1,0 +1,6 @@
+cimport cython
+cimport numpy as np
+
+
+cdef inline np.dtype dtype_from_memoryview(cython.view.memoryview arr):
+    return np.dtype(arr.view.format)

--- a/menpo/image/test/image_extract_patches_test.py
+++ b/menpo/image/test/image_extract_patches_test.py
@@ -1,8 +1,43 @@
+import numpy as np
 from nose.tools import assert_equals
 
 import menpo.io as mio
 from menpo.landmark import labeller, ibug_face_68
 from menpo.shape import PointCloud
+
+
+def test_double_type():
+    image = mio.import_builtin_asset('breakingbad.jpg')
+    patch_shape = (16, 16)
+    patches = image.extract_patches(image.landmarks['PTS'].lms,
+                                    patch_size=patch_shape)
+    assert(patches[0].pixels.dtype == np.float64)
+
+
+def test_float_type():
+    image = mio.import_builtin_asset('breakingbad.jpg')
+    image.pixels = image.pixels.astype(np.float32)
+    patch_shape = (16, 16)
+    patches = image.extract_patches(image.landmarks['PTS'].lms,
+                                    patch_size=patch_shape)
+    assert(patches[0].pixels.dtype == np.float32)
+
+
+def test_uint8_type():
+    image = mio.import_builtin_asset('breakingbad.jpg', normalise=False)
+    patch_shape = (16, 16)
+    patches = image.extract_patches(image.landmarks['PTS'].lms,
+                                    patch_size=patch_shape)
+    assert(patches[0].pixels.dtype == np.uint8)
+
+
+def test_uint8_type_single_array():
+    image = mio.import_builtin_asset('breakingbad.jpg', normalise=False)
+    patch_shape = (16, 16)
+    patches = image.extract_patches(image.landmarks['PTS'].lms,
+                                    patch_size=patch_shape,
+                                    as_single_array=True)
+    assert(patches.dtype == np.uint8)
 
 
 def test_squared_even_patches():

--- a/menpo/io/input/base.py
+++ b/menpo/io/input/base.py
@@ -286,7 +286,7 @@ def import_pickles(pattern, max_pickles=None, verbose=False):
         yield asset
 
 
-def _import_builtin_asset(asset_name):
+def _import_builtin_asset(asset_name, **kwargs):
     r"""Single builtin asset (landmark or image) importer.
 
     Imports the relevant builtin asset from the ``./data`` directory that
@@ -308,9 +308,11 @@ def _import_builtin_asset(asset_name):
     # importing them both separately.
     try:
         return _import(asset_path, image_types,
-                       landmark_ext_map=image_landmark_types)
+                       landmark_ext_map=image_landmark_types,
+                       importer_kwargs=kwargs)
     except ValueError:
-        return _import(asset_path, image_landmark_types)
+        return _import(asset_path, image_landmark_types,
+                       importer_kwargs=kwargs)
 
 
 def ls_builtin_assets():
@@ -320,23 +322,22 @@ def ls_builtin_assets():
     -------
     list of strings
         Filenames of all assets in the data directory shipped with Menpo
-
     """
     return [p.name for p in data_dir_path().glob('*') if not p.is_dir()]
 
 
 def import_builtin(x):
 
-    def execute():
-        return _import_builtin_asset(x)
+    def execute(**kwargs):
+        return _import_builtin_asset(x, **kwargs)
 
     return execute
 
 
 class BuiltinAssets(object):
 
-    def __call__(self, asset_name):
-        return _import_builtin_asset(asset_name)
+    def __call__(self, asset_name, **kwargs):
+        return _import_builtin_asset(asset_name, **kwargs)
 
 import_builtin_asset = BuiltinAssets()
 

--- a/menpo/io/test/io_import_test.py
+++ b/menpo/io/test/io_import_test.py
@@ -22,6 +22,11 @@ def test_breaking_bad_import():
     assert(img.landmarks['PTS'].n_landmarks == 68)
 
 
+def test_breaking_bad_import_kwargs():
+    img = mio.import_builtin_asset('breakingbad.jpg', normalise=False)
+    assert(img.pixels.dtype == np.uint8)
+
+
 def test_takeo_import():
     img = mio.import_builtin_asset('takeo.ppm')
     assert(img.shape == (225, 150))


### PR DESCRIPTION
Adds the ability to extract patches from different type images:

  - ``np.float64``
  - ``np.float32``
  - ``np.uint8``

Also, adds passing of kwargs to ``import_builtin_asset`` so we can do:

    import menpo.io as mio
    bb = mio.import_builtin_asset.breakingbad_jpg(normalise=False)

And ``bb.pixels == np.uint8``