### PR TITLE
Fixes for new cyvlfeat

### DIFF
--- a/menpo/feature/test/test_features.py
+++ b/menpo/feature/test/test_features.py
@@ -265,17 +265,18 @@ def test_daisy_values():
 @attr('cyvlfeat')
 def test_dsift_values():
     from menpo.feature import dsift
+    # Equivalent to the transpose of image in Matlab
     image = Image([[1, 2, 3, 4], [2, 1, 3, 4], [1, 2, 3, 4], [2, 1, 3, 4]])
     sift_img = dsift(image, cell_size_horizontal=2, cell_size_vertical=2)
-    assert_allclose(np.around(sift_img.pixels[0, 0, 0], 6), 76.002098000000004,
+    assert_allclose(np.around(sift_img.pixels[0, 0, 0], 6), 19.719786,
                     rtol=1e-04)
-    assert_allclose(np.around(sift_img.pixels[1, 0, 1], 6), 139.76733400000001,
+    assert_allclose(np.around(sift_img.pixels[1, 0, 1], 6), 141.535736,
                     rtol=1e-04)
-    assert_allclose(np.around(sift_img.pixels[0, 1, 0], 6), 155.95297199999999,
+    assert_allclose(np.around(sift_img.pixels[0, 1, 0], 6), 184.377472,
                     rtol=1e-04)
-    assert_allclose(np.around(sift_img.pixels[5, 1, 1], 6), 18.307358000000001,
+    assert_allclose(np.around(sift_img.pixels[5, 1, 1], 6), 39.04007,
                     rtol=1e-04)
-
+    assert 1
 
 def test_lbp_values():
     image = Image([[0., 6., 0.], [5., 18., 13.], [0., 20., 0.]])

--- a/menpo/feature/vlfeat.py
+++ b/menpo/feature/vlfeat.py
@@ -63,14 +63,14 @@ def dsift(pixels, window_step_horizontal=1, window_step_vertical=1,
         pixels[0], step=[window_step_vertical, window_step_horizontal],
         size=[cell_size_vertical, cell_size_horizontal], bounds=None,
         norm=False, fast=fast, float_descriptors=True,
-        geometry=(num_bins_horizontal, num_bins_vertical, num_or_bins),
+        geometry=(num_bins_vertical, num_bins_horizontal, num_or_bins),
         verbose=False)
 
     # the output shape can be calculated from looking at the range of
     # centres / the window step size in each dimension. Note that cyvlfeat
     # returns x, y centres.
-    shape = (((centers[:, -1] - centers[:, 0]) /
-              [window_step_horizontal, window_step_vertical]) + 1)
+    shape = (((centers[-1, :] - centers[0, :]) /
+              [window_step_vertical, window_step_horizontal]) + 1)
 
     # print information
     if verbose:
@@ -90,9 +90,8 @@ def dsift(pixels, window_step_horizontal=1, window_step_vertical=1,
         print(info_str)
 
     # return SIFT and centers in the correct form
-    return (np.require(np.transpose(output.reshape((-1, shape[1], shape[0])),
-                                    [0, 2, 1]),
+    return (np.require(np.rollaxis(output.reshape((shape[0], shape[1], -1)),
+                                   -1),
                        dtype=np.double, requirements=['C']),
-            np.require(np.transpose(centers.reshape((-1, shape[1], shape[0])),
-                                    (2, 1, 0)),
-                       dtype=np.int, requirements=['C']))
+            np.require(centers.reshape((shape[0], shape[1], -1)),
+                       dtype=np.int))


### PR DESCRIPTION
This should fix menpo for the newly updated cyvlfeat - which
should now be consistently Y, X instead of X, Y and also
returns the arrays (n_samples, n_features) which makes
them C-contiguous. The only thing is that it seems equivalent
to the transpose in Matlab, which may be a mistake or may
be by design... who knows.

Also, since I messed up the versioning, the master builds are picking up the new cyvlfeat, and this should stop PRs from failing...