### PR TITLE
print_progress enhancements

### DIFF
--- a/menpo/visualize/textutils.py
+++ b/menpo/visualize/textutils.py
@@ -111,7 +111,8 @@ def bytes_str(num):
     return "{0:3.2f} {1:s}".format(num, 'TB')
 
 
-def print_progress(iterable, prefix='', n_items=None, offset=0):
+def print_progress(iterable, prefix='', n_items=None, offset=0,
+                   show_count=True):
     r"""
     Print the remaining time needed to compute over an iterable.
 
@@ -137,6 +138,8 @@ def print_progress(iterable, prefix='', n_items=None, offset=0):
         Useful in combination with ``n_items`` - report back the progress as
         if `offset` items have already been handled. ``n_items``  will be left
         unchanged.
+    show_count : `bool`, optional
+        If False, The item count (e.g.: (4/25)) will be hidden.
 
     Raises
     ------
@@ -177,7 +180,7 @@ def print_progress(iterable, prefix='', n_items=None, offset=0):
                                              remaining)
         remaining_str = duration.strftime('%H:%M:%S')
         bar_str = progress_bar_str(i / n, bar_length=bar_length)
-        print_dynamic('{}{} ({}/{}) - {} remaining'.format(prefix, bar_str,
-                                                           i, n,
-                                                           remaining_str))
+        count_str = ' ({}/{})'.format(i, n) if show_count else ''
+        print_dynamic('{}{}{} - {} remaining'.format(prefix, bar_str,
+                                                     count_str, remaining_str))
     print('')

--- a/menpo/visualize/textutils.py
+++ b/menpo/visualize/textutils.py
@@ -1,4 +1,4 @@
-from __future__ import division
+from __future__ import division, print_function
 from collections import deque
 from datetime import datetime
 import sys
@@ -81,7 +81,8 @@ def print_dynamic(str_to_print):
     str_to_print : `str`
         The string to print.
     """
-    sys.stdout.write("\r%s" % str_to_print)
+    # here we use the print function, so we need the __future__ import for Py2
+    print("{}".format(str_to_print.ljust(80)), end='\r')
     sys.stdout.flush()
 
 
@@ -112,7 +113,7 @@ def bytes_str(num):
 
 
 def print_progress(iterable, prefix='', n_items=None, offset=0,
-                   show_count=True):
+                   show_bar=True, show_count=True, show_eta=True):
     r"""
     Print the remaining time needed to compute over an iterable.
 
@@ -138,8 +139,13 @@ def print_progress(iterable, prefix='', n_items=None, offset=0,
         Useful in combination with ``n_items`` - report back the progress as
         if `offset` items have already been handled. ``n_items``  will be left
         unchanged.
+    show_bar : `bool`, optional
+        If False, The progress bar (e.g. [=========      ]) will be hidden.
     show_count : `bool`, optional
-        If False, The item count (e.g.: (4/25)) will be hidden.
+        If False, The item count (e.g. (4/25)) will be hidden.
+    show_eta : `bool`, optional
+        If False, The estimated time to finish (e.g. - 00:00:03 remaining)
+        will be hidden.
 
     Raises
     ------
@@ -156,7 +162,7 @@ def print_progress(iterable, prefix='', n_items=None, offset=0,
 
     prints a progress report of the form: ::
 
-        [=============       ] 70% (7/10) 00:00:03 remaining
+        [=============       ] 70% (7/10) - 00:00:03 remaining
     """
     if n_items is None and offset != 0:
         raise ValueError('offset can only be set when n_items has been'
@@ -178,9 +184,14 @@ def print_progress(iterable, prefix='', n_items=None, offset=0,
         remaining = n - i
         duration = datetime.utcfromtimestamp(sum(timings) / len(timings) *
                                              remaining)
-        remaining_str = duration.strftime('%H:%M:%S')
-        bar_str = progress_bar_str(i / n, bar_length=bar_length)
+        bar_str = progress_bar_str(i / n, bar_length=bar_length, show_bar=show_bar)
         count_str = ' ({}/{})'.format(i, n) if show_count else ''
-        print_dynamic('{}{}{} - {} remaining'.format(prefix, bar_str,
-                                                     count_str, remaining_str))
+        eta_str = " - {} remaining".format(duration.strftime('%H:%M:%S')) if show_eta else ''
+        print_dynamic('{}{}{}{}'.format(prefix, bar_str, count_str, eta_str))
+
+    # the iterable has now finished - to make it clear redraw the progress with
+    # a done message. We also hide the eta at this stage.
+    count_str = ' ({}/{})'.format(n, n) if show_count else ''
+    bar_str = progress_bar_str(1, bar_length=bar_length, show_bar=show_bar)
+    print_dynamic('{}{}{} - done.'.format(prefix, bar_str, count_str))
     print('')


### PR DESCRIPTION
This PR makes `print_progress()` more flexible by adding a number of keyword arguments:

1. `show_items=True`: Useful to reuse `print_progress` on generators where the count itself is not of great significance. For instance, we use this in menpobench to report download progress. Each item here is a chunk of bytes which is not relevant:
https://github.com/menpo/menpobench/blob/master/menpobench/utils.py#L45
2. `show_eta=True`: Useful to hide ETA for shorter running jobs
3. `show_bar=True`: Useful to hide bar on progress reports with long prefixes.

This also improves `print_dynamic()` to use the `print()` function, and has an automatic flushing behaviour - the first 80 characters of a previous dynamic line are cleared, which should remove some overlayed dynamic string issues.

Following this PR we can aim to use `print_progress()` throughout the Menpo libraries, unifying our approach to dynamically reporting progress over iterables.