### PR TITLE
Balance out rescale/crop methods

### DIFF
--- a/menpo/image/base.py
+++ b/menpo/image/base.py
@@ -316,7 +316,6 @@ class Image(Vectorizable, Landmarkable, Viewable, LandmarkableViewable):
         # noinspection PyUnresolvedReferences
         return np.array(self.shape, dtype=np.double) / 2
 
-    @property
     def _str_shape(self):
         if self.n_dims > 2:
             return ' x '.join(str(dim) for dim in self.shape)
@@ -1908,7 +1907,7 @@ class Image(Vectorizable, Landmarkable, Viewable, LandmarkableViewable):
 
     def __str__(self):
         return ('{} {}D Image with {} channel{}'.format(
-            self._str_shape, self.n_dims, self.n_channels,
+            self._str_shape(), self.n_dims, self.n_channels,
             's' * (self.n_channels > 1)))
 
     @property

--- a/menpo/image/base.py
+++ b/menpo/image/base.py
@@ -175,6 +175,29 @@ class Image(Vectorizable, Landmarkable, Viewable, LandmarkableViewable):
         # We know there is no need to copy...
         return cls(pixels, copy=False)
 
+    @classmethod
+    def init_from_rolled_channels(cls, pixels):
+        r"""
+        Create an Image from a set of pixels where the channels axis is on
+        the last axis (the back). This is common in other frameworks, and
+        therefore this method provides a convenient means of creating a menpo
+        Image from such data. Note that a copy is always created due to the
+        need to rearrange the data.
+
+        Parameters
+        ----------
+        pixels : ``(M, N ..., Q, C)`` `ndarray`
+            Array representing the image pixels, with the last axis being
+            channels.
+
+        Returns
+        -------
+        image : :map:`Image`
+            A new image from the given pixels, with the FIRST axis as the
+            channels.
+        """
+        return cls(np.rollaxis(pixels, -1))
+
     def as_masked(self, mask=None, copy=True):
         r"""
         Return a copy of this image with an attached mask behavior.

--- a/menpo/image/boolean.py
+++ b/menpo/image/boolean.py
@@ -223,7 +223,7 @@ class BooleanImage(Image):
 
     def __str__(self):
         return ('{} {}D mask, {:.1%} '
-                'of which is True'.format(self._str_shape, self.n_dims,
+                'of which is True'.format(self._str_shape(), self.n_dims,
                                           self.proportion_true()))
 
     def from_vector(self, vector, copy=True):

--- a/menpo/image/masked.py
+++ b/menpo/image/masked.py
@@ -246,7 +246,7 @@ class MaskedImage(Image):
     def __str__(self):
         return ('{} {}D MaskedImage with {} channels. '
                 'Attached mask {:.1%} true'.format(
-            self._str_shape, self.n_dims, self.n_channels,
+            self._str_shape(), self.n_dims, self.n_channels,
             self.mask.proportion_true()))
 
     def _as_vector(self, keep_channels=False):

--- a/menpo/image/test/image_basics_test.py
+++ b/menpo/image/test/image_basics_test.py
@@ -69,3 +69,11 @@ def test_warp_to_shape_boolean_preserves_path():
     i2 = i1.rescale(0.8)
     assert hasattr(i2, 'path')
     assert i2.path == i1.path
+
+
+def test_init_from_rolled_channels():
+    p = np.empty([50, 60, 3])
+    im = Image.init_from_rolled_channels(p)
+    assert im.n_channels == 3
+    assert im.height == 50
+    assert im.width == 60

--- a/menpo/image/test/image_masked_test.py
+++ b/menpo/image/test/image_masked_test.py
@@ -87,3 +87,10 @@ def test_dilate():
     img3 = img.dilate(n_pixels=3)
     assert(img3.mask.n_true() == 76)
 
+
+def test_init_from_rolled_channels():
+    p = np.empty([50, 60, 3])
+    im = MaskedImage.init_from_rolled_channels(p)
+    assert im.n_channels == 3
+    assert im.height == 50
+    assert im.width == 60

--- a/menpo/image/test/image_pointcloud_rescale_crop_test.py
+++ b/menpo/image/test/image_pointcloud_rescale_crop_test.py
@@ -1,0 +1,61 @@
+import numpy as np
+from numpy.testing import assert_allclose
+from menpo.image import Image
+from menpo.shape import bounding_box
+
+
+def test_rescale_landmarks_to_diagonal_range():
+    img = Image.init_blank((100, 100), n_channels=1)
+    img.landmarks['test'] = bounding_box([0, 0], [10, 10])
+
+    img_rescaled = img.rescale_landmarks_to_diagonal_range(20 * np.sqrt(2))
+    assert_allclose(img_rescaled.shape, (200, 200))
+
+
+def test_rescale_to_diagonal():
+    img = Image.init_blank((100, 100), n_channels=1)
+
+    img_rescaled = img.rescale_to_diagonal(200 * np.sqrt(2))
+    assert_allclose(img_rescaled.shape, (200, 200))
+
+
+def test_rescale_to_pointcloud():
+    img = Image.init_blank((100, 100), n_channels=1)
+    img.landmarks['test'] = bounding_box([0, 0], [10, 10])
+    pcloud = bounding_box([0, 0], [25, 25])
+
+    img_rescaled = img.rescale_to_pointcloud(pcloud)
+    assert_allclose(img_rescaled.shape, (250, 250))
+
+
+def test_crop_to_pointcloud():
+    img = Image.init_blank((100, 100), n_channels=1)
+    pcloud = bounding_box([0, 0], [50, 50])
+
+    img_cropped = img.crop_to_pointcloud(pcloud)
+    assert_allclose(img_cropped.shape, (50, 50))
+
+
+def test_crop_to_landmarks():
+    img = Image.init_blank((100, 100), n_channels=1)
+    img.landmarks['test'] = bounding_box([0, 0], [10, 10])
+
+    img_cropped = img.crop_to_landmarks()
+    assert_allclose(img_cropped.shape, (10, 10))
+    assert 1
+
+
+def test_crop_to_pointcloud_proportion():
+    img = Image.init_blank((100, 100), n_channels=1)
+    pcloud = bounding_box([0, 0], [50, 50])
+
+    img_cropped = img.crop_to_pointcloud_proportion(pcloud, 0.1)
+    assert_allclose(img_cropped.shape, (55, 55))
+
+
+def test_crop_to_landmarks_proportion():
+    img = Image.init_blank((100, 100), n_channels=1)
+    img.landmarks['test'] = bounding_box([0, 0], [10, 10])
+
+    img_cropped = img.crop_to_landmarks_proportion(0.1)
+    assert_allclose(img_cropped.shape, (11, 11))

--- a/menpo/image/test/image_test.py
+++ b/menpo/image/test/image_test.py
@@ -585,11 +585,13 @@ def test_as_greyscale_luminosity():
     assert (new_image.n_channels == 1)
     assert_allclose(new_image.pixels[0], ones[0] * 0.850532)
 
+
 def test_rolled_channels():
     ones = np.ones([3, 120, 120])
     image = MaskedImage(ones)
     rolled_channels = image.rolled_channels()
     assert rolled_channels.shape == (120, 120, 3)
+
 
 def test_as_greyscale_average():
     ones = np.ones([3, 120, 120])

--- a/menpo/image/test/image_test.py
+++ b/menpo/image/test/image_test.py
@@ -53,13 +53,13 @@ def test_image_centre():
 def test_image_str_shape_4d():
     pixels = np.ones((1, 10, 20, 11, 12))
     image = Image(pixels)
-    assert(image._str_shape == '10 x 20 x 11 x 12')
+    assert(image._str_shape() == '10 x 20 x 11 x 12')
 
 
 def test_image_str_shape_2d():
     pixels = np.ones((1, 10, 20))
     image = Image(pixels)
-    assert(image._str_shape == '20W x 10H')
+    assert(image._str_shape() == '20W x 10H')
 
 
 def test_image_as_vector():

--- a/menpo/visualize/widgets/base.py
+++ b/menpo/visualize/widgets/base.py
@@ -1102,7 +1102,7 @@ def visualize_images(images, figure_size=(10, 8), style='coloured',
         # Create text lines
         text_per_line = [
             "> {} of size {} with {} channel{}".format(
-                masked_str, img._str_shape, img.n_channels,
+                masked_str, img._str_shape(), img.n_channels,
                 's' * (img.n_channels > 1)),
             "> Path: '{}'".format(path_str)]
         n_lines = 2


### PR DESCRIPTION
Rounds out the image API with some extra methods:

  - deprecate ``rescale_to_reference_shape``
  - add ``rescale_to_pointcloud``
  - add ``crop_to_pointcloud``
  - add ``crop_to_pointcloud_proportion``
  - add ``init_from_rolled_channels``
  - tests
