### PR TITLE
Allow exporting of 3D landmarks.

### DIFF
--- a/menpo/io/output/landmark.py
+++ b/menpo/io/output/landmark.py
@@ -27,11 +27,22 @@ def LJSONExporter(landmark_group, file_handle):
     # Convert nan values to None so that json correctly maps them to 'null'
     points = lg_json['landmarks']['points']
     # Flatten list
+    try:
+        ndim = len(points[0])
+    except IndexError:
+        ndim = 0
     filtered_points = [None if np.isnan(x) else x
                        for x in itertools.chain(*points)]
     # Recreate tuples
-    lg_json['landmarks']['points'] = list(zip(filtered_points[::2],
+    if ndim == 2:
+        lg_json['landmarks']['points'] = list(zip(filtered_points[::2],
                                               filtered_points[1::2]))
+    elif ndim == 3:
+        lg_json['landmarks']['points'] = list(zip(filtered_points[::3],
+                                              filtered_points[1::3],
+                                              filtered_points[2::3]))
+    else:
+        lg_json['landmarks']['points'] = []
 
     return json.dump(lg_json, file_handle, indent=4, separators=(',', ': '),
                      sort_keys=True, allow_nan=False)

--- a/menpo/io/test/io_export_test.py
+++ b/menpo/io/test/io_export_test.py
@@ -1,4 +1,5 @@
 import numpy as np
+from numpy.testing import assert_allclose
 import os
 from menpo.io.utils import _norm_path
 from mock import patch, PropertyMock, MagicMock

--- a/menpo/io/test/io_export_test.py
+++ b/menpo/io/test/io_export_test.py
@@ -172,6 +172,24 @@ def test_export_landmark_ljson(mock_open, exists, json_dump):
         mio.export_landmark_file(test_lg, f, extension='ljson')
     json_dump.assert_called_once()
 
+@patch('menpo.io.output.landmark.json.dump')
+@patch('menpo.io.output.base.Path.exists')
+@patch('{}.open'.format(__name__), create=True)
+def test_export_landmark_ljson_3d(mock_open, exists, json_dump):
+    exists.return_value = False
+    fake_path = '/fake/fake3d.ljson'
+    test3d_lg = test_lg.copy()
+    fake_z_points = np.random.random(test3d_lg.lms.points.shape[0])
+    test3d_lg.lms.points = np.concatenate([
+        test3d_lg.lms.points, fake_z_points[..., None]], axis=-1)
+
+    with open(fake_path) as f:
+        type(f).name = PropertyMock(return_value=fake_path)
+        mio.export_landmark_file(test3d_lg, f, extension='ljson')
+
+    json_dump.assert_called_once()
+    json_points = np.array(json_dump.call_args[0][0]['landmarks']['points'])
+    assert_allclose(json_points[:, -1], fake_z_points)
 
 @patch('menpo.io.output.base.Path.exists')
 @patch('{}.open'.format(__name__), create=True)


### PR DESCRIPTION
Using `export_landmark_file` from `menpo3d.io` currently only outputs points with two dimensions even for meshes.

I only updated the LJSON exporter, since it looks like the PTS one does some swapping of axes, so I don't know where the z axis would fall in there.