### PR TITLE
Ensure that LJSON landmarks are read in as floats

### DIFF
--- a/menpo/io/input/landmark.py
+++ b/menpo/io/input/landmark.py
@@ -291,7 +291,8 @@ class LM2Importer(LandmarkImporter):
 def _ljson_parse_null_values(points_list):
     filtered_points = [np.nan if x is None else x
                        for x in itertools.chain(*points_list)]
-    return np.array(filtered_points).reshape([-1, len(points_list[0])])
+    return np.array(filtered_points,
+                    dtype=np.float).reshape([-1, len(points_list[0])])
 
 
 def _parse_ljson_v1(lms_dict):


### PR DESCRIPTION
Currently if LJSON file landmarks contain no decimal period (e.g. `403`, not `403.23`) then the numpy dtype ends up being np.int upon parsing. This was causing a problem in the menpobench matlab bridge -  maybe we're better just enforcing float all the time to avoid any small issues like this.
