### PR TITLE
Fix widgets for new Jupyter/IPython 4 release

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,7 @@ env:
     - PYTHON_VERSION: 3.4
 
 install:
-- wget https://raw.githubusercontent.com/menpo/condaci/v0.4.4/condaci.py -O condaci.py
+- wget https://raw.githubusercontent.com/menpo/condaci/v0.4.5/condaci.py -O condaci.py
 - python condaci.py setup
 
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,7 @@ env:
     - PYTHON_VERSION: 3.4
 
 install:
-- wget https://raw.githubusercontent.com/menpo/condaci/v0.4.2/condaci.py -O condaci.py
+- wget https://raw.githubusercontent.com/menpo/condaci/v0.4.4/condaci.py -O condaci.py
 - python condaci.py setup
 
 script:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -17,7 +17,7 @@ platform:
 - x64
 
 init:
-- ps: Start-FileDownload 'https://raw.githubusercontent.com/menpo/condaci/v0.4.2/condaci.py' C:\\condaci.py; echo "Done"
+- ps: Start-FileDownload 'https://raw.githubusercontent.com/menpo/condaci/v0.4.4/condaci.py' C:\\condaci.py; echo "Done"
 - cmd: python C:\\condaci.py setup
 
 install:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -17,7 +17,7 @@ platform:
 - x64
 
 init:
-- ps: Start-FileDownload 'https://raw.githubusercontent.com/menpo/condaci/vs2010_fixes/condaci.py' C:\\condaci.py; echo "Done"
+- ps: Start-FileDownload 'https://raw.githubusercontent.com/menpo/condaci/v0.4.5/condaci.py' C:\\condaci.py; echo "Done"
 - cmd: python C:\\condaci.py setup
 
 install:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -17,7 +17,7 @@ platform:
 - x64
 
 init:
-- ps: Start-FileDownload 'https://raw.githubusercontent.com/menpo/condaci/v0.4.4/condaci.py' C:\\condaci.py; echo "Done"
+- ps: Start-FileDownload 'https://raw.githubusercontent.com/menpo/condaci/vs2010_fixes/condaci.py' C:\\condaci.py; echo "Done"
 - cmd: python C:\\condaci.py setup
 
 install:

--- a/conda/meta.yaml
+++ b/conda/meta.yaml
@@ -23,7 +23,8 @@ requirements:
     # Convenience dependencies (not strictly required)
     - mock 1.0.1
     - nose
-    - ipython-notebook 3.*
+    - ipython 4.*
+    - jupyter 1.*
 
 test:
   requires:

--- a/menpo/visualize/widgets/base.py
+++ b/menpo/visualize/widgets/base.py
@@ -2,7 +2,7 @@ import numpy as np
 from collections import Sized
 from matplotlib.pyplot import show as pltshow
 
-import IPython.html.widgets as ipywidgets
+import ipywidgets
 import IPython.display as ipydisplay
 
 from menpo.visualize.viewmatplotlib import (MatplotlibImageViewer2d,

--- a/menpo/visualize/widgets/options.py
+++ b/menpo/visualize/widgets/options.py
@@ -2,8 +2,8 @@ from collections import OrderedDict
 from functools import partial
 import numpy as np
 
-import IPython.html.widgets as ipywidgets
-from IPython.utils.traitlets import link
+import ipywidgets
+from traitlets import link
 
 from .tools import (_format_box, _format_font, _convert_image_to_bytes,
                     IndexButtonsWidget, IndexSliderWidget, LineOptionsWidget,
@@ -359,7 +359,7 @@ class ChannelOptionsWidget(ipywidgets.FlexBox):
     def style(self, box_style=None, border_visible=False, border_color='black',
               border_style='solid', border_width=1, border_radius=0, padding=0,
               margin=0, font_family='', font_size=None, font_style='',
-              font_weight='', slider_width='', slider_colour=''):
+              font_weight='', slider_width='', slider_colour=None):
         r"""
         Function that defines the styling of the widget.
 
@@ -1907,10 +1907,10 @@ class AnimationOptionsWidget(ipywidgets.FlexBox):
                 self.index_wid.button_plus.font_weight = 'normal'
                 self.index_wid.button_minus.button_style = ''
                 self.index_wid.button_minus.font_weight = 'normal'
-                self.index_wid.index_text.background_color = ''
+                self.index_wid.index_text.background_color = None
             elif self.index_style == 'slider':
-                self.index_wid.slider.slider_color = ''
-                self.index_wid.slider.background_color = ''
+                self.index_wid.slider.slider_color = None
+                self.index_wid.slider.background_color = None
             self._toggle_play_style = ''
             self._toggle_stop_style = ''
         elif (style == 'info' or style == 'success' or style == 'danger' or

--- a/menpo/visualize/widgets/tools.py
+++ b/menpo/visualize/widgets/tools.py
@@ -3,7 +3,7 @@ try:
     from StringIO import StringIO
 except ImportError:
     from io import StringIO
-import IPython.html.widgets as ipywidgets
+import ipywidgets
 
 # Global variables to try and reduce overhead of loading the logo
 MENPO_MINIMAL_LOGO = None
@@ -320,7 +320,7 @@ class IndexSliderWidget(ipywidgets.FlexBox):
     def style(self, box_style=None, border_visible=False, border_color='black',
               border_style='solid', border_width=1, border_radius=0, padding=0,
               margin=0, font_family='', font_size=None, font_style='',
-              font_weight='', slider_width='6cm', slider_colour=''):
+              font_weight='', slider_width='6cm', slider_colour=None):
         r"""
         Function that defines the styling of the widget.
 
@@ -1023,8 +1023,9 @@ class ColourSelectionWidget(ipywidgets.FlexBox):
     def style(self, box_style=None, border_visible=False, border_color='black',
               border_style='solid', border_width=1, border_radius=0, padding=0,
               margin=0, font_family='', font_size=None, font_style='',
-              font_weight='', label_background_colour='',
-              colour_background_colour='', rgb_text_background_colour='',
+              font_weight='', label_background_colour=None,
+              colour_background_colour=None,
+              rgb_text_background_colour=None,
               apply_to_all_style=''):
         r"""
         Function that defines the styling of the widget.
@@ -1371,7 +1372,7 @@ class ImageOptionsWidget(ipywidgets.FlexBox):
     def style(self, box_style=None, border_visible=False, border_color='black',
               border_style='solid', border_width=1, border_radius=0, padding=0,
               margin=0, font_family='', font_size=None, font_style='',
-              font_weight='', alpha_colour='', cmap_colour=''):
+              font_weight='', alpha_colour=None, cmap_colour=None):
         r"""
         Function that defines the styling of the widget.
 
@@ -1685,8 +1686,8 @@ class LineOptionsWidget(ipywidgets.FlexBox):
         self.line_colour_widget.style(
             box_style=None, border_visible=False, font_family=font_family,
             font_size=font_size, font_weight=font_weight, font_style=font_style,
-            label_background_colour='', colour_background_colour='',
-            rgb_text_background_colour='', apply_to_all_style='')
+            label_background_colour=None, colour_background_colour=None,
+            rgb_text_background_colour=None, apply_to_all_style='')
 
     def add_render_function(self, render_function):
         r"""
@@ -1996,13 +1997,13 @@ class MarkerOptionsWidget(ipywidgets.FlexBox):
         self.marker_edge_colour_widget.style(
             box_style=None, border_visible=False, font_family=font_family,
             font_size=font_size, font_weight=font_weight, font_style=font_style,
-            label_background_colour='', colour_background_colour='',
-            rgb_text_background_colour='', apply_to_all_style='')
+            label_background_colour=None, colour_background_colour=None,
+            rgb_text_background_colour=None, apply_to_all_style='')
         self.marker_face_colour_widget.style(
             box_style=None, border_visible=False, font_family=font_family,
             font_size=font_size, font_weight=font_weight, font_style=font_style,
-            label_background_colour='', colour_background_colour='',
-            rgb_text_background_colour='', apply_to_all_style='')
+            label_background_colour=None, colour_background_colour=None,
+            rgb_text_background_colour=None, apply_to_all_style='')
 
     def add_render_function(self, render_function):
         r"""
@@ -2391,8 +2392,8 @@ class NumberingOptionsWidget(ipywidgets.FlexBox):
         self.numbers_font_colour_widget.style(
             box_style=None, border_visible=False, font_family=font_family,
             font_size=font_size, font_weight=font_weight, font_style=font_style,
-            label_background_colour='', colour_background_colour='',
-            rgb_text_background_colour='', apply_to_all_style='')
+            label_background_colour=None, colour_background_colour=None,
+            rgb_text_background_colour=None, apply_to_all_style='')
 
     def add_render_function(self, render_function):
         r"""


### PR DESCRIPTION
Small change in dependancy. Probably at some point we should
require the individual packages such as ipywidgets and traitlets
rather than requiring the jupyter metapackage.

Also, fixed the fact that HTML colours can no longer be passed
as empty strings and should be passed None instead.