### PR TITLE
Optional transform return on Image methods

### DIFF
--- a/menpo/image/base.py
+++ b/menpo/image/base.py
@@ -961,7 +961,8 @@ class Image(Vectorizable, Landmarkable, Viewable, LandmarkableViewable):
             return_inverse_transform=return_inverse_transform)
 
     def crop_to_pointcloud(self, pointcloud, boundary=0,
-                           constrain_to_boundary=True):
+                           constrain_to_boundary=True,
+                           return_inverse_transform=False):
         r"""
         Return a copy of this image cropped so that it is bounded around a
         pointcloud with an optional ``n_pixel`` boundary.
@@ -976,11 +977,17 @@ class Image(Vectorizable, Landmarkable, Viewable, LandmarkableViewable):
             If ``True`` the crop will be snapped to not go beyond this images
             boundary. If ``False``, an :map`ImageBoundaryError` will be raised
             if an attempt is made to go beyond the edge of the image.
+        return_inverse_transform : `bool`, optional
+            If ``True``, then the pseudoinverse of the :map:`Transform`
+            object that was used to perform the cropping is also returned.
 
         Returns
         -------
         image : :map:`Image`
             A copy of this image cropped to the bounds of the pointcloud.
+        inverse_transform : :map:`Transform`
+            The pseudoinverse of the transform that was used. It only applies if
+            `return_inverse_transform` is ``True``.
 
         Raises
         ------
@@ -990,10 +997,12 @@ class Image(Vectorizable, Landmarkable, Viewable, LandmarkableViewable):
         """
         min_indices, max_indices = pointcloud.bounds(boundary=boundary)
         return self.crop(min_indices, max_indices,
-                         constrain_to_boundary=constrain_to_boundary)
+                         constrain_to_boundary=constrain_to_boundary,
+                         return_inverse_transform=return_inverse_transform)
 
     def crop_to_landmarks(self, group=None, label=None, boundary=0,
-                          constrain_to_boundary=True):
+                          constrain_to_boundary=True,
+                          return_inverse_transform=False):
         r"""
         Return a copy of this image cropped so that it is bounded around a set
         of landmarks with an optional ``n_pixel`` boundary
@@ -1012,11 +1021,17 @@ class Image(Vectorizable, Landmarkable, Viewable, LandmarkableViewable):
             If ``True`` the crop will be snapped to not go beyond this images
             boundary. If ``False``, an :map`ImageBoundaryError` will be raised
             if an attempt is made to go beyond the edge of the image.
+        return_inverse_transform : `bool`, optional
+            If ``True``, then the pseudoinverse of the :map:`Transform`
+            object that was used to perform the cropping is also returned.
 
         Returns
         -------
         image : :map:`Image`
             A copy of this image cropped to its landmarks.
+        inverse_transform : :map:`Transform`
+            The pseudoinverse of the transform that was used. It only applies if
+            `return_inverse_transform` is ``True``.
 
         Raises
         ------
@@ -1026,11 +1041,13 @@ class Image(Vectorizable, Landmarkable, Viewable, LandmarkableViewable):
         """
         pc = self.landmarks[group][label]
         return self.crop_to_pointcloud(
-            pc, boundary=boundary, constrain_to_boundary=constrain_to_boundary)
+            pc, boundary=boundary, constrain_to_boundary=constrain_to_boundary,
+            return_inverse_transform=return_inverse_transform)
 
     def crop_to_pointcloud_proportion(self, pointcloud, boundary_proportion,
                                       minimum=True,
-                                      constrain_to_boundary=True):
+                                      constrain_to_boundary=True,
+                                      return_inverse_transform=False):
         r"""
         Return a copy of this image cropped so that it is bounded around a
         pointcloud with an optional ``n_pixel`` boundary.
@@ -1052,12 +1069,18 @@ class Image(Vectorizable, Landmarkable, Viewable, LandmarkableViewable):
             If ``True``, the crop will be snapped to not go beyond this images
             boundary. If ``False``, an :map:`ImageBoundaryError` will be raised
             if an attempt is made to go beyond the edge of the image.
+        return_inverse_transform : `bool`, optional
+            If ``True``, then the pseudoinverse of the :map:`Transform`
+            object that was used to perform the cropping is also returned.
 
         Returns
         -------
         image : :map:`Image`
             A copy of this image cropped to the border proportional to
             the pointcloud spread or range.
+        inverse_transform : :map:`Transform`
+            The pseudoinverse of the transform that was used. It only applies if
+            `return_inverse_transform` is ``True``.
 
         Raises
         ------
@@ -1071,11 +1094,13 @@ class Image(Vectorizable, Landmarkable, Viewable, LandmarkableViewable):
             boundary = boundary_proportion * np.max(pointcloud.range())
         return self.crop_to_pointcloud(
             pointcloud, boundary=boundary,
-            constrain_to_boundary=constrain_to_boundary)
+            constrain_to_boundary=constrain_to_boundary,
+            return_inverse_transform=return_inverse_transform)
 
     def crop_to_landmarks_proportion(self, boundary_proportion,
                                      group=None, label=None, minimum=True,
-                                     constrain_to_boundary=True):
+                                     constrain_to_boundary=True,
+                                     return_inverse_transform=False):
         r"""
         Crop this image to be bounded around a set of landmarks with a
         border proportional to the landmark spread or range.
@@ -1101,12 +1126,18 @@ class Image(Vectorizable, Landmarkable, Viewable, LandmarkableViewable):
             If ``True``, the crop will be snapped to not go beyond this images
             boundary. If ``False``, an :map:`ImageBoundaryError` will be raised
             if an attempt is made to go beyond the edge of the image.
+        return_inverse_transform : `bool`, optional
+            If ``True``, then the pseudoinverse of the :map:`Transform`
+            object that was used to perform the cropping is also returned.
 
         Returns
         -------
         image : :map:`Image`
             This image, cropped to its landmarks with a border proportional to
             the landmark spread or range.
+        inverse_transform : :map:`Transform`
+            The pseudoinverse of the transform that was used. It only applies if
+            `return_inverse_transform` is ``True``.
 
         Raises
         ------
@@ -1117,7 +1148,8 @@ class Image(Vectorizable, Landmarkable, Viewable, LandmarkableViewable):
         pc = self.landmarks[group][label]
         return self.crop_to_pointcloud_proportion(
             pc, boundary_proportion, minimum=minimum,
-            constrain_to_boundary=constrain_to_boundary)
+            constrain_to_boundary=constrain_to_boundary,
+            return_inverse_transform=return_inverse_transform)
 
     def _propagate_crop_to_inplace(self, cropped):
         # helper method that sets self's state to the result of a crop call.
@@ -1675,7 +1707,8 @@ class Image(Vectorizable, Landmarkable, Viewable, LandmarkableViewable):
         else:
             return warped_image
 
-    def rescale(self, scale, round='ceil', order=1):
+    def rescale(self, scale, round='ceil', order=1,
+                return_inverse_transform=False):
         r"""
         Return a copy of this image, rescaled by a given factor.
         Landmarks are rescaled appropriately.
@@ -1702,10 +1735,17 @@ class Image(Vectorizable, Landmarkable, Viewable, LandmarkableViewable):
             5         Bi-quintic
             ========= ====================
 
+        return_inverse_transform : `bool`, optional
+            If ``True``, then the pseudoinverse of the :map:`Transform`
+            object that was used to perform the rescale is also returned.
+
         Returns
         -------
         rescaled_image : ``type(self)``
             A copy of this image, rescaled.
+        inverse_transform : :map:`Transform`
+            The pseudoinverse of the transform that was used. It only applies if
+            `return_inverse_transform` is ``True``.
 
         Raises
         ------
@@ -1748,11 +1788,13 @@ class Image(Vectorizable, Landmarkable, Viewable, LandmarkableViewable):
         scale_factors = (scale * shape - 1) / (shape - 1)
         inverse_transform = NonUniformScale(scale_factors).pseudoinverse()
         # for rescaling we enforce that mode is nearest to avoid num. errors
-        return self.warp_to_shape(template_shape, inverse_transform,
-                                  warp_landmarks=True, order=order,
-                                  mode='nearest')
+        return self.warp_to_shape(
+            template_shape, inverse_transform, warp_landmarks=True,
+            order=order, mode='nearest',
+            return_inverse_transform=return_inverse_transform)
 
-    def rescale_to_diagonal(self, diagonal, round='ceil'):
+    def rescale_to_diagonal(self, diagonal, round='ceil',
+                            return_inverse_transform=False):
         r"""
         Return a copy of this image, rescaled so that the it's diagonal is a
         new size.
@@ -1763,13 +1805,20 @@ class Image(Vectorizable, Landmarkable, Viewable, LandmarkableViewable):
             The diagonal size of the new image.
         round: ``{ceil, floor, round}``, optional
             Rounding function to be applied to floating point shapes.
+        return_inverse_transform : `bool`, optional
+            If ``True``, then the pseudoinverse of the :map:`Transform`
+            object that was used to perform the rescale is also returned.
 
         Returns
         -------
         rescaled_image : type(self)
             A copy of this image, rescaled.
+        inverse_transform : :map:`Transform`
+            The pseudoinverse of the transform that was used. It only applies if
+            `return_inverse_transform` is ``True``.
         """
-        return self.rescale(diagonal / self.diagonal(), round=round)
+        return self.rescale(diagonal / self.diagonal(), round=round,
+                            return_inverse_transform=return_inverse_transform)
 
     def rescale_to_reference_shape(self, reference_shape, group=None,
                                    label=None, round='ceil', order=1):
@@ -1783,8 +1832,9 @@ class Image(Vectorizable, Landmarkable, Viewable, LandmarkableViewable):
         return self.rescale_to_pointcloud(reference_shape, group=group,
                                           label=label, round=round, order=order)
 
-    def rescale_to_pointcloud(self, pointcloud, group=None,
-                              label=None, round='ceil', order=1):
+    def rescale_to_pointcloud(self, pointcloud, group=None, label=None,
+                              round='ceil', order=1,
+                              return_inverse_transform=False):
         r"""
         Return a copy of this image, rescaled so that the scale of a
         particular group of landmarks matches the scale of the passed
@@ -1817,17 +1867,26 @@ class Image(Vectorizable, Landmarkable, Viewable, LandmarkableViewable):
             5         Bi-quintic
             ========= ====================
 
+        return_inverse_transform : `bool`, optional
+            If ``True``, then the pseudoinverse of the :map:`Transform`
+            object that was used to perform the rescale is also returned.
+
         Returns
         -------
         rescaled_image : ``type(self)``
             A copy of this image, rescaled.
+        inverse_transform : :map:`Transform`
+            The pseudoinverse of the transform that was used. It only applies if
+            `return_inverse_transform` is ``True``.
         """
         pc = self.landmarks[group][label]
         scale = AlignmentUniformScale(pc, pointcloud).as_vector().copy()
-        return self.rescale(scale, round=round, order=order)
+        return self.rescale(scale, round=round, order=order,
+                            return_inverse_transform=return_inverse_transform)
 
     def rescale_landmarks_to_diagonal_range(self, diagonal_range, group=None,
-                                            label=None, round='ceil', order=1):
+                                            label=None, round='ceil', order=1,
+                                            return_inverse_transform=False):
         r"""
         Return a copy of this image, rescaled so that the ``diagonal_range`` of
         the bounding box containing its landmarks matches the specified
@@ -1860,16 +1919,24 @@ class Image(Vectorizable, Landmarkable, Viewable, LandmarkableViewable):
             5         Bi-quintic
             ========= =====================
 
+        return_inverse_transform : `bool`, optional
+            If ``True``, then the pseudoinverse of the :map:`Transform`
+            object that was used to perform the rescale is also returned.
+
         Returns
         -------
         rescaled_image : ``type(self)``
             A copy of this image, rescaled.
+        inverse_transform : :map:`Transform`
+            The pseudoinverse of the transform that was used. It only applies if
+            `return_inverse_transform` is ``True``.
         """
         x, y = self.landmarks[group][label].range()
         scale = diagonal_range / np.sqrt(x ** 2 + y ** 2)
-        return self.rescale(scale, round=round, order=order)
+        return self.rescale(scale, round=round, order=order,
+                            return_inverse_transform=return_inverse_transform)
 
-    def resize(self, shape, order=1):
+    def resize(self, shape, order=1, return_inverse_transform=False):
         r"""
         Return a copy of this image, resized to a particular shape.
         All image information (landmarks, and mask in the case of
@@ -1893,10 +1960,17 @@ class Image(Vectorizable, Landmarkable, Viewable, LandmarkableViewable):
             5         Bi-quintic
             ========= =====================
 
+        return_inverse_transform : `bool`, optional
+            If ``True``, then the pseudoinverse of the :map:`Transform`
+            object that was used to perform the resize is also returned.
+
         Returns
         -------
         resized_image : ``type(self)``
             A copy of this image, resized.
+        inverse_transform : :map:`Transform`
+            The pseudoinverse of the transform that was used. It only applies if
+            `return_inverse_transform` is ``True``.
 
         Raises
         ------
@@ -1915,14 +1989,16 @@ class Image(Vectorizable, Landmarkable, Viewable, LandmarkableViewable):
         # errors. For example, if we want (250, 250), we need to ensure that
         # we get (250, 250) even if the number we obtain is 250 to some
         # floating point inaccuracy.
-        return self.rescale(scales, round='round', order=order)
+        return self.rescale(scales, round='round', order=order,
+                            return_inverse_transform=return_inverse_transform)
 
-    def zoom(self, scale, cval=0.0):
+    def zoom(self, scale, cval=0.0, return_inverse_transform=False):
         r"""
-        Zoom this image about the centre point. ``scale`` values greater
-        than 1.0 denote zooming **in** to the image and values less than
-        1.0 denote zooming **out** of the image. The size of the image will not
-        change, if you wish to scale an image, please see :meth:`rescale`.
+        Return a copy of this image, zoomed about the centre point. ``scale``
+        values greater than 1.0 denote zooming **in** to the image and values
+        less than 1.0 denote zooming **out** of the image. The size of the
+        image will not change, if you wish to scale an image, please see
+        :meth:`rescale`.
 
         Parameters
         ----------
@@ -1933,14 +2009,28 @@ class Image(Vectorizable, Landmarkable, Viewable, LandmarkableViewable):
             by the value of ``cval``.
         cval : ``float``, optional
             The value to be set outside the rotated image boundaries.
+        return_inverse_transform : `bool`, optional
+            If ``True``, then the pseudoinverse of the :map:`Transform`
+            object that was used to perform the zooming is also returned.
+
+        Returns
+        -------
+        zoomed_image : ``type(self)``
+            A copy of this image, zoomed.
+        inverse_transform : :map:`Transform`
+            The pseudoinverse of the transform that was used. It only applies if
+            `return_inverse_transform` is ``True``.
         """
         t = scale_about_centre(self, 1.0 / scale)
-        return self.warp_to_shape(self.shape, t, cval=cval)
+        return self.warp_to_shape(
+            self.shape, t, cval=cval,
+            return_inverse_transform=return_inverse_transform)
 
     def rotate_ccw_about_centre(self, theta, degrees=True, retain_shape=False,
-                                cval=0.0, round='round', order=1):
+                                cval=0.0, round='round', order=1,
+                                return_inverse_transform=False):
         r"""
-        Return a rotation of this image counter-clockwise about its centre.
+        Return a copy of this image, rotated counter-clockwise about its centre.
 
         Note that the `retain_shape` argument defines the shape of the rotated
         image. If ``retain_shape=True``, then the shape of the rotated image
@@ -1981,10 +2071,17 @@ class Image(Vectorizable, Landmarkable, Viewable, LandmarkableViewable):
             5         Bi-quintic
             ========= ====================
 
+        return_inverse_transform : `bool`, optional
+            If ``True``, then the pseudoinverse of the :map:`Transform`
+            object that was used to perform the rotation is also returned.
+
         Returns
         -------
         rotated_image : ``type(self)``
             The rotated image.
+        inverse_transform : :map:`Transform`
+            The pseudoinverse of the transform that was used. It only applies if
+            `return_inverse_transform` is ``True``.
 
         Raises
         ------
@@ -2017,22 +2114,29 @@ class Image(Vectorizable, Landmarkable, Viewable, LandmarkableViewable):
             shape = round_image_shape(rotated_bbox.range() + 1, round)
 
         # Warp image
-        return self.warp_to_shape(shape, trans.pseudoinverse(), order=order,
-                                  warp_landmarks=True, cval=cval)
+        return self.warp_to_shape(
+            shape, trans.pseudoinverse(), order=order, warp_landmarks=True,
+            cval=cval, return_inverse_transform=return_inverse_transform)
 
-    def mirror(self, axis=1):
+    def mirror(self, axis=1, return_inverse_transform=False):
         r"""
-        Return the mirrored/flipped version of this image about a certain axis.
+        Return a copy of this image, mirrored/flipped about a certain axis.
 
         Parameters
         ----------
         axis : `int`, optional
             The axis about which to mirror the image.
+        return_inverse_transform : `bool`, optional
+            If ``True``, then the pseudoinverse of the :map:`Transform`
+            object that was used to perform the mirroring is also returned.
 
         Returns
         -------
         mirrored_image : ``type(self)``
             The mirrored image.
+        inverse_transform : :map:`Transform`
+            The pseudoinverse of the transform that was used. It only applies if
+            `return_inverse_transform` is ``True``.
 
         Raises
         ------
@@ -2061,8 +2165,9 @@ class Image(Vectorizable, Landmarkable, Viewable, LandmarkableViewable):
             Translation(tr_matrix, skip_checks=True))
 
         # Warp image
-        return self.warp_to_shape(self.shape, trans.pseudoinverse(),
-                                  warp_landmarks=True)
+        return self.warp_to_shape(
+            self.shape, trans.pseudoinverse(), warp_landmarks=True,
+            return_inverse_transform=return_inverse_transform)
 
     def pyramid(self, n_levels=3, downscale=2):
         r"""

--- a/menpo/image/base.py
+++ b/menpo/image/base.py
@@ -899,7 +899,7 @@ class Image(Vectorizable, Landmarkable, Viewable, LandmarkableViewable):
         return grad_feature(self)
 
     def crop(self, min_indices, max_indices, constrain_to_boundary=False,
-             return_inverse_transform=False):
+             return_transform=False):
         r"""
         Return a cropped copy of this image using the given minimum and
         maximum indices. Landmarks are correctly adjusted so they maintain
@@ -915,17 +915,17 @@ class Image(Vectorizable, Landmarkable, Viewable, LandmarkableViewable):
             If ``True`` the crop will be snapped to not go beyond this images
             boundary. If ``False``, an :map:`ImageBoundaryError` will be raised
             if an attempt is made to go beyond the edge of the image.
-        return_inverse_transform : `bool`, optional
-            If ``True``, then the pseudoinverse of the :map:`Transform`
-            object that was used to perform the cropping is also returned.
+        return_transform : `bool`, optional
+            If ``True``, then the :map:`Transform` object that was used to
+            perform the cropping is also returned.
 
         Returns
         -------
         cropped_image : `type(self)`
             A new instance of self, but cropped.
-        inverse_transform : :map:`Transform`
-            The pseudoinverse of the transform that was used. It only applies if
-            `return_inverse_transform` is ``True``.
+        transform : :map:`Transform`
+            The transform that was used. It only applies if
+            `return_transform` is ``True``.
 
         Raises
         ------
@@ -956,13 +956,13 @@ class Image(Vectorizable, Landmarkable, Viewable, LandmarkableViewable):
                                      min_bounded, max_bounded)
 
         new_shape = max_bounded - min_bounded
-        return self.warp_to_shape(
-            new_shape, Translation(min_bounded), order=0, warp_landmarks=True,
-            return_inverse_transform=return_inverse_transform)
+        return self.warp_to_shape(new_shape, Translation(min_bounded), order=0,
+                                  warp_landmarks=True,
+                                  return_transform=return_transform)
 
     def crop_to_pointcloud(self, pointcloud, boundary=0,
                            constrain_to_boundary=True,
-                           return_inverse_transform=False):
+                           return_transform=False):
         r"""
         Return a copy of this image cropped so that it is bounded around a
         pointcloud with an optional ``n_pixel`` boundary.
@@ -977,17 +977,17 @@ class Image(Vectorizable, Landmarkable, Viewable, LandmarkableViewable):
             If ``True`` the crop will be snapped to not go beyond this images
             boundary. If ``False``, an :map`ImageBoundaryError` will be raised
             if an attempt is made to go beyond the edge of the image.
-        return_inverse_transform : `bool`, optional
-            If ``True``, then the pseudoinverse of the :map:`Transform`
-            object that was used to perform the cropping is also returned.
+        return_transform : `bool`, optional
+            If ``True``, then the :map:`Transform` object that was used to
+            perform the cropping is also returned.
 
         Returns
         -------
         image : :map:`Image`
             A copy of this image cropped to the bounds of the pointcloud.
-        inverse_transform : :map:`Transform`
-            The pseudoinverse of the transform that was used. It only applies if
-            `return_inverse_transform` is ``True``.
+        transform : :map:`Transform`
+            The transform that was used. It only applies if
+            `return_transform` is ``True``.
 
         Raises
         ------
@@ -998,11 +998,11 @@ class Image(Vectorizable, Landmarkable, Viewable, LandmarkableViewable):
         min_indices, max_indices = pointcloud.bounds(boundary=boundary)
         return self.crop(min_indices, max_indices,
                          constrain_to_boundary=constrain_to_boundary,
-                         return_inverse_transform=return_inverse_transform)
+                         return_transform=return_transform)
 
     def crop_to_landmarks(self, group=None, label=None, boundary=0,
                           constrain_to_boundary=True,
-                          return_inverse_transform=False):
+                          return_transform=False):
         r"""
         Return a copy of this image cropped so that it is bounded around a set
         of landmarks with an optional ``n_pixel`` boundary
@@ -1021,17 +1021,17 @@ class Image(Vectorizable, Landmarkable, Viewable, LandmarkableViewable):
             If ``True`` the crop will be snapped to not go beyond this images
             boundary. If ``False``, an :map`ImageBoundaryError` will be raised
             if an attempt is made to go beyond the edge of the image.
-        return_inverse_transform : `bool`, optional
-            If ``True``, then the pseudoinverse of the :map:`Transform`
-            object that was used to perform the cropping is also returned.
+        return_transform : `bool`, optional
+            If ``True``, then the :map:`Transform` object that was used to
+            perform the cropping is also returned.
 
         Returns
         -------
         image : :map:`Image`
             A copy of this image cropped to its landmarks.
-        inverse_transform : :map:`Transform`
-            The pseudoinverse of the transform that was used. It only applies if
-            `return_inverse_transform` is ``True``.
+        transform : :map:`Transform`
+            The transform that was used. It only applies if
+            `return_transform` is ``True``.
 
         Raises
         ------
@@ -1042,12 +1042,12 @@ class Image(Vectorizable, Landmarkable, Viewable, LandmarkableViewable):
         pc = self.landmarks[group][label]
         return self.crop_to_pointcloud(
             pc, boundary=boundary, constrain_to_boundary=constrain_to_boundary,
-            return_inverse_transform=return_inverse_transform)
+            return_transform=return_transform)
 
     def crop_to_pointcloud_proportion(self, pointcloud, boundary_proportion,
                                       minimum=True,
                                       constrain_to_boundary=True,
-                                      return_inverse_transform=False):
+                                      return_transform=False):
         r"""
         Return a copy of this image cropped so that it is bounded around a
         pointcloud with an optional ``n_pixel`` boundary.
@@ -1069,18 +1069,18 @@ class Image(Vectorizable, Landmarkable, Viewable, LandmarkableViewable):
             If ``True``, the crop will be snapped to not go beyond this images
             boundary. If ``False``, an :map:`ImageBoundaryError` will be raised
             if an attempt is made to go beyond the edge of the image.
-        return_inverse_transform : `bool`, optional
-            If ``True``, then the pseudoinverse of the :map:`Transform`
-            object that was used to perform the cropping is also returned.
+        return_transform : `bool`, optional
+            If ``True``, then the :map:`Transform` object that was used to
+            perform the cropping is also returned.
 
         Returns
         -------
         image : :map:`Image`
             A copy of this image cropped to the border proportional to
             the pointcloud spread or range.
-        inverse_transform : :map:`Transform`
-            The pseudoinverse of the transform that was used. It only applies if
-            `return_inverse_transform` is ``True``.
+        transform : :map:`Transform`
+            The transform that was used. It only applies if
+            `return_transform` is ``True``.
 
         Raises
         ------
@@ -1095,12 +1095,12 @@ class Image(Vectorizable, Landmarkable, Viewable, LandmarkableViewable):
         return self.crop_to_pointcloud(
             pointcloud, boundary=boundary,
             constrain_to_boundary=constrain_to_boundary,
-            return_inverse_transform=return_inverse_transform)
+            return_transform=return_transform)
 
     def crop_to_landmarks_proportion(self, boundary_proportion,
                                      group=None, label=None, minimum=True,
                                      constrain_to_boundary=True,
-                                     return_inverse_transform=False):
+                                     return_transform=False):
         r"""
         Crop this image to be bounded around a set of landmarks with a
         border proportional to the landmark spread or range.
@@ -1126,18 +1126,18 @@ class Image(Vectorizable, Landmarkable, Viewable, LandmarkableViewable):
             If ``True``, the crop will be snapped to not go beyond this images
             boundary. If ``False``, an :map:`ImageBoundaryError` will be raised
             if an attempt is made to go beyond the edge of the image.
-        return_inverse_transform : `bool`, optional
-            If ``True``, then the pseudoinverse of the :map:`Transform`
-            object that was used to perform the cropping is also returned.
+        return_transform : `bool`, optional
+            If ``True``, then the :map:`Transform` object that was used to
+            perform the cropping is also returned.
 
         Returns
         -------
         image : :map:`Image`
             This image, cropped to its landmarks with a border proportional to
             the landmark spread or range.
-        inverse_transform : :map:`Transform`
-            The pseudoinverse of the transform that was used. It only applies if
-            `return_inverse_transform` is ``True``.
+        transform : :map:`Transform`
+            The transform that was used. It only applies if
+            `return_transform` is ``True``.
 
         Raises
         ------
@@ -1149,7 +1149,7 @@ class Image(Vectorizable, Landmarkable, Viewable, LandmarkableViewable):
         return self.crop_to_pointcloud_proportion(
             pc, boundary_proportion, minimum=minimum,
             constrain_to_boundary=constrain_to_boundary,
-            return_inverse_transform=return_inverse_transform)
+            return_transform=return_transform)
 
     def _propagate_crop_to_inplace(self, cropped):
         # helper method that sets self's state to the result of a crop call.
@@ -1442,7 +1442,7 @@ class Image(Vectorizable, Landmarkable, Viewable, LandmarkableViewable):
 
     def warp_to_mask(self, template_mask, transform, warp_landmarks=True,
                      order=1, mode='constant', cval=0.0, batch_size=None,
-                     return_inverse_transform=False):
+                     return_transform=False):
         r"""
         Return a copy of this image warped into a different reference space.
 
@@ -1488,17 +1488,17 @@ class Image(Vectorizable, Landmarkable, Viewable, LandmarkableViewable):
             how many points in the image should be warped at a time, which
             keeps memory usage low. If ``None``, no batching is used and all
             points are warped at once.
-        return_inverse_transform : `bool`, optional
-            If ``True``, then the pseudoinverse of the :map:`Transform`
-            object is also returned.
+        return_transform : `bool`, optional
+            This argument is for internal use only. If ``True``, then the
+            :map:`Transform` object is also returned.
 
         Returns
         -------
         warped_image : :map:`MaskedImage`
             A copy of this image, warped.
-        inverse_transform : :map:`Transform`
-            The pseudoinverse of the transform that was used. It only applies if
-            `return_inverse_transform` is ``True``.
+        transform : :map:`Transform`
+            The transform that was used. It only applies if
+            `return_transform` is ``True``.
         """
         if self.n_dims != transform.n_dims:
             raise ValueError(
@@ -1513,16 +1513,15 @@ class Image(Vectorizable, Landmarkable, Viewable, LandmarkableViewable):
         # set any nan values to 0
         sampled[np.isnan(sampled)] = 0
         # build a warped version of the image
-        inv_transform = transform.pseudoinverse()
         warped_image = self._build_warp_to_mask(template_mask, sampled)
         if warp_landmarks and self.has_landmarks:
             warped_image.landmarks = self.landmarks
-            inv_transform.apply_inplace(warped_image.landmarks)
+            transform.pseudoinverse().apply_inplace(warped_image.landmarks)
         if hasattr(self, 'path'):
             warped_image.path = self.path
-        # optionally return the pseudoinverse transform
-        if return_inverse_transform:
-            return warped_image, inv_transform
+        # optionally return the transform
+        if return_transform:
+            return warped_image, transform
         else:
             return warped_image
 
@@ -1585,7 +1584,7 @@ class Image(Vectorizable, Landmarkable, Viewable, LandmarkableViewable):
 
     def warp_to_shape(self, template_shape, transform, warp_landmarks=True,
                       order=1, mode='constant', cval=0.0, batch_size=None,
-                      return_inverse_transform=False):
+                      return_transform=False):
         """
         Return a copy of this image warped into a different reference space.
 
@@ -1628,17 +1627,17 @@ class Image(Vectorizable, Landmarkable, Viewable, LandmarkableViewable):
             how many points in the image should be warped at a time, which
             keeps memory usage low. If ``None``, no batching is used and all
             points are warped at once.
-        return_inverse_transform : `bool`, optional
-            If ``True``, then the pseudoinverse of the :map:`Transform`
-            object is also returned.
+        return_transform : `bool`, optional
+            This argument is for internal use only. If ``True``, then the
+            :map:`Transform` object is also returned.
 
         Returns
         -------
         warped_image : `type(self)`
             A copy of this image, warped.
-        inverse_transform : :map:`Transform`
-            The pseudoinverse of the transform that was used. It only applies if
-            `return_inverse_transform` is ``True``.
+        transform : :map:`Transform`
+            The transform that was used. It only applies if
+            `return_transform` is ``True``.
         """
         template_shape = np.array(template_shape, dtype=np.int)
         if (isinstance(transform, Affine) and order in range(4) and
@@ -1662,9 +1661,9 @@ class Image(Vectorizable, Landmarkable, Viewable, LandmarkableViewable):
                     warped_pixels = self.pixels[:,
                                     int(min_[0]):int(max_[0]),
                                     int(min_[1]):int(max_[1])].copy()
-                    return self._build_warp_to_shape(
-                        warped_pixels, transform, warp_landmarks,
-                        return_inverse_transform)
+                    return self._build_warp_to_shape(warped_pixels, transform,
+                                                     warp_landmarks,
+                                                     return_transform)
             # we couldn't do the crop, but skimage has an optimised Cython
             # interpolation for 2D affine warps - let's use that
             sampled = cython_interpolation(self.pixels, template_shape,
@@ -1683,32 +1682,31 @@ class Image(Vectorizable, Landmarkable, Viewable, LandmarkableViewable):
         warped_pixels = sampled.reshape(
             (self.n_channels,) + tuple(template_shape))
 
-        return self._build_warp_to_shape(
-            warped_pixels, transform, warp_landmarks, return_inverse_transform)
+        return self._build_warp_to_shape(warped_pixels, transform,
+                                         warp_landmarks, return_transform)
 
     def _build_warp_to_shape(self, warped_pixels, transform, warp_landmarks,
-                             return_inverse_transform):
+                             return_transform):
         # factored out common logic from the different paths we can take in
         # warp_to_shape. Rebuilds an image post-warp, adjusting landmarks
         # as necessary.
         warped_image = Image(warped_pixels, copy=False)
 
         # warp landmarks if requested.
-        inv_transform = transform.pseudoinverse()
         if warp_landmarks and self.has_landmarks:
             warped_image.landmarks = self.landmarks
-            inv_transform.apply_inplace(warped_image.landmarks)
+            transform.pseudoinverse().apply_inplace(warped_image.landmarks)
         if hasattr(self, 'path'):
             warped_image.path = self.path
 
-        # optionally return the inverse transform
-        if return_inverse_transform:
-            return warped_image, inv_transform
+        # optionally return the transform
+        if return_transform:
+            return warped_image, transform
         else:
             return warped_image
 
     def rescale(self, scale, round='ceil', order=1,
-                return_inverse_transform=False):
+                return_transform=False):
         r"""
         Return a copy of this image, rescaled by a given factor.
         Landmarks are rescaled appropriately.
@@ -1735,17 +1733,17 @@ class Image(Vectorizable, Landmarkable, Viewable, LandmarkableViewable):
             5         Bi-quintic
             ========= ====================
 
-        return_inverse_transform : `bool`, optional
-            If ``True``, then the pseudoinverse of the :map:`Transform`
-            object that was used to perform the rescale is also returned.
+        return_transform : `bool`, optional
+            If ``True``, then the :map:`Transform` object that was used to
+            perform the rescale is also returned.
 
         Returns
         -------
         rescaled_image : ``type(self)``
             A copy of this image, rescaled.
-        inverse_transform : :map:`Transform`
-            The pseudoinverse of the transform that was used. It only applies if
-            `return_inverse_transform` is ``True``.
+        transform : :map:`Transform`
+            The transform that was used. It only applies if
+            `return_transform` is ``True``.
 
         Raises
         ------
@@ -1788,13 +1786,13 @@ class Image(Vectorizable, Landmarkable, Viewable, LandmarkableViewable):
         scale_factors = (scale * shape - 1) / (shape - 1)
         inverse_transform = NonUniformScale(scale_factors).pseudoinverse()
         # for rescaling we enforce that mode is nearest to avoid num. errors
-        return self.warp_to_shape(
-            template_shape, inverse_transform, warp_landmarks=True,
-            order=order, mode='nearest',
-            return_inverse_transform=return_inverse_transform)
+        return self.warp_to_shape(template_shape, inverse_transform,
+                                  warp_landmarks=True, order=order,
+                                  mode='nearest',
+                                  return_transform=return_transform)
 
     def rescale_to_diagonal(self, diagonal, round='ceil',
-                            return_inverse_transform=False):
+                            return_transform=False):
         r"""
         Return a copy of this image, rescaled so that the it's diagonal is a
         new size.
@@ -1805,20 +1803,20 @@ class Image(Vectorizable, Landmarkable, Viewable, LandmarkableViewable):
             The diagonal size of the new image.
         round: ``{ceil, floor, round}``, optional
             Rounding function to be applied to floating point shapes.
-        return_inverse_transform : `bool`, optional
-            If ``True``, then the pseudoinverse of the :map:`Transform`
-            object that was used to perform the rescale is also returned.
+        return_transform : `bool`, optional
+            If ``True``, then the :map:`Transform` object that was used to
+            perform the rescale is also returned.
 
         Returns
         -------
         rescaled_image : type(self)
             A copy of this image, rescaled.
-        inverse_transform : :map:`Transform`
-            The pseudoinverse of the transform that was used. It only applies if
-            `return_inverse_transform` is ``True``.
+        transform : :map:`Transform`
+            The transform that was used. It only applies if
+            `return_transform` is ``True``.
         """
         return self.rescale(diagonal / self.diagonal(), round=round,
-                            return_inverse_transform=return_inverse_transform)
+                            return_transform=return_transform)
 
     def rescale_to_reference_shape(self, reference_shape, group=None,
                                    label=None, round='ceil', order=1):
@@ -1834,7 +1832,7 @@ class Image(Vectorizable, Landmarkable, Viewable, LandmarkableViewable):
 
     def rescale_to_pointcloud(self, pointcloud, group=None, label=None,
                               round='ceil', order=1,
-                              return_inverse_transform=False):
+                              return_transform=False):
         r"""
         Return a copy of this image, rescaled so that the scale of a
         particular group of landmarks matches the scale of the passed
@@ -1867,26 +1865,26 @@ class Image(Vectorizable, Landmarkable, Viewable, LandmarkableViewable):
             5         Bi-quintic
             ========= ====================
 
-        return_inverse_transform : `bool`, optional
-            If ``True``, then the pseudoinverse of the :map:`Transform`
-            object that was used to perform the rescale is also returned.
+        return_transform : `bool`, optional
+            If ``True``, then the :map:`Transform` object that was used to
+            perform the rescale is also returned.
 
         Returns
         -------
         rescaled_image : ``type(self)``
             A copy of this image, rescaled.
-        inverse_transform : :map:`Transform`
-            The pseudoinverse of the transform that was used. It only applies if
-            `return_inverse_transform` is ``True``.
+        transform : :map:`Transform`
+            The transform that was used. It only applies if
+            `return_transform` is ``True``.
         """
         pc = self.landmarks[group][label]
         scale = AlignmentUniformScale(pc, pointcloud).as_vector().copy()
         return self.rescale(scale, round=round, order=order,
-                            return_inverse_transform=return_inverse_transform)
+                            return_transform=return_transform)
 
     def rescale_landmarks_to_diagonal_range(self, diagonal_range, group=None,
                                             label=None, round='ceil', order=1,
-                                            return_inverse_transform=False):
+                                            return_transform=False):
         r"""
         Return a copy of this image, rescaled so that the ``diagonal_range`` of
         the bounding box containing its landmarks matches the specified
@@ -1919,24 +1917,24 @@ class Image(Vectorizable, Landmarkable, Viewable, LandmarkableViewable):
             5         Bi-quintic
             ========= =====================
 
-        return_inverse_transform : `bool`, optional
-            If ``True``, then the pseudoinverse of the :map:`Transform`
-            object that was used to perform the rescale is also returned.
+        return_transform : `bool`, optional
+            If ``True``, then the :map:`Transform` object that was used to
+            perform the rescale is also returned.
 
         Returns
         -------
         rescaled_image : ``type(self)``
             A copy of this image, rescaled.
-        inverse_transform : :map:`Transform`
-            The pseudoinverse of the transform that was used. It only applies if
-            `return_inverse_transform` is ``True``.
+        transform : :map:`Transform`
+            The transform that was used. It only applies if
+            `return_transform` is ``True``.
         """
         x, y = self.landmarks[group][label].range()
         scale = diagonal_range / np.sqrt(x ** 2 + y ** 2)
         return self.rescale(scale, round=round, order=order,
-                            return_inverse_transform=return_inverse_transform)
+                            return_transform=return_transform)
 
-    def resize(self, shape, order=1, return_inverse_transform=False):
+    def resize(self, shape, order=1, return_transform=False):
         r"""
         Return a copy of this image, resized to a particular shape.
         All image information (landmarks, and mask in the case of
@@ -1960,17 +1958,17 @@ class Image(Vectorizable, Landmarkable, Viewable, LandmarkableViewable):
             5         Bi-quintic
             ========= =====================
 
-        return_inverse_transform : `bool`, optional
-            If ``True``, then the pseudoinverse of the :map:`Transform`
-            object that was used to perform the resize is also returned.
+        return_transform : `bool`, optional
+            If ``True``, then the :map:`Transform` object that was used to
+            perform the resize is also returned.
 
         Returns
         -------
         resized_image : ``type(self)``
             A copy of this image, resized.
-        inverse_transform : :map:`Transform`
-            The pseudoinverse of the transform that was used. It only applies if
-            `return_inverse_transform` is ``True``.
+        transform : :map:`Transform`
+            The transform that was used. It only applies if
+            `return_transform` is ``True``.
 
         Raises
         ------
@@ -1990,9 +1988,9 @@ class Image(Vectorizable, Landmarkable, Viewable, LandmarkableViewable):
         # we get (250, 250) even if the number we obtain is 250 to some
         # floating point inaccuracy.
         return self.rescale(scales, round='round', order=order,
-                            return_inverse_transform=return_inverse_transform)
+                            return_transform=return_transform)
 
-    def zoom(self, scale, cval=0.0, return_inverse_transform=False):
+    def zoom(self, scale, cval=0.0, return_transform=False):
         r"""
         Return a copy of this image, zoomed about the centre point. ``scale``
         values greater than 1.0 denote zooming **in** to the image and values
@@ -2009,26 +2007,25 @@ class Image(Vectorizable, Landmarkable, Viewable, LandmarkableViewable):
             by the value of ``cval``.
         cval : ``float``, optional
             The value to be set outside the rotated image boundaries.
-        return_inverse_transform : `bool`, optional
-            If ``True``, then the pseudoinverse of the :map:`Transform`
-            object that was used to perform the zooming is also returned.
+        return_transform : `bool`, optional
+            If ``True``, then the :map:`Transform` object that was used to
+            perform the zooming is also returned.
 
         Returns
         -------
         zoomed_image : ``type(self)``
             A copy of this image, zoomed.
-        inverse_transform : :map:`Transform`
-            The pseudoinverse of the transform that was used. It only applies if
-            `return_inverse_transform` is ``True``.
+        transform : :map:`Transform`
+            The transform that was used. It only applies if
+            `return_transform` is ``True``.
         """
         t = scale_about_centre(self, 1.0 / scale)
-        return self.warp_to_shape(
-            self.shape, t, cval=cval,
-            return_inverse_transform=return_inverse_transform)
+        return self.warp_to_shape(self.shape, t, cval=cval,
+                                  return_transform=return_transform)
 
     def rotate_ccw_about_centre(self, theta, degrees=True, retain_shape=False,
                                 cval=0.0, round='round', order=1,
-                                return_inverse_transform=False):
+                                return_transform=False):
         r"""
         Return a copy of this image, rotated counter-clockwise about its centre.
 
@@ -2071,17 +2068,17 @@ class Image(Vectorizable, Landmarkable, Viewable, LandmarkableViewable):
             5         Bi-quintic
             ========= ====================
 
-        return_inverse_transform : `bool`, optional
-            If ``True``, then the pseudoinverse of the :map:`Transform`
-            object that was used to perform the rotation is also returned.
+        return_transform : `bool`, optional
+            If ``True``, then the :map:`Transform` object that was used to
+            perform the rotation is also returned.
 
         Returns
         -------
         rotated_image : ``type(self)``
             The rotated image.
-        inverse_transform : :map:`Transform`
-            The pseudoinverse of the transform that was used. It only applies if
-            `return_inverse_transform` is ``True``.
+        transform : :map:`Transform`
+            The transform that was used. It only applies if
+            `return_transform` is ``True``.
 
         Raises
         ------
@@ -2116,9 +2113,9 @@ class Image(Vectorizable, Landmarkable, Viewable, LandmarkableViewable):
         # Warp image
         return self.warp_to_shape(
             shape, trans.pseudoinverse(), order=order, warp_landmarks=True,
-            cval=cval, return_inverse_transform=return_inverse_transform)
+            cval=cval, return_transform=return_transform)
 
-    def mirror(self, axis=1, return_inverse_transform=False):
+    def mirror(self, axis=1, return_transform=False):
         r"""
         Return a copy of this image, mirrored/flipped about a certain axis.
 
@@ -2126,17 +2123,17 @@ class Image(Vectorizable, Landmarkable, Viewable, LandmarkableViewable):
         ----------
         axis : `int`, optional
             The axis about which to mirror the image.
-        return_inverse_transform : `bool`, optional
-            If ``True``, then the pseudoinverse of the :map:`Transform`
-            object that was used to perform the mirroring is also returned.
+        return_transform : `bool`, optional
+            If ``True``, then the :map:`Transform` object that was used to
+            perform the mirroring is also returned.
 
         Returns
         -------
         mirrored_image : ``type(self)``
             The mirrored image.
-        inverse_transform : :map:`Transform`
-            The pseudoinverse of the transform that was used. It only applies if
-            `return_inverse_transform` is ``True``.
+        transform : :map:`Transform`
+            The transform that was used. It only applies if
+            `return_transform` is ``True``.
 
         Raises
         ------
@@ -2165,9 +2162,9 @@ class Image(Vectorizable, Landmarkable, Viewable, LandmarkableViewable):
             Translation(tr_matrix, skip_checks=True))
 
         # Warp image
-        return self.warp_to_shape(
-            self.shape, trans.pseudoinverse(), warp_landmarks=True,
-            return_inverse_transform=return_inverse_transform)
+        return self.warp_to_shape(self.shape, trans.pseudoinverse(),
+                                  warp_landmarks=True,
+                                  return_transform=return_transform)
 
     def pyramid(self, n_levels=3, downscale=2):
         r"""

--- a/menpo/image/boolean.py
+++ b/menpo/image/boolean.py
@@ -541,7 +541,7 @@ class BooleanImage(Image):
             points are checked at once.
         """
         self.constrain_to_pointcloud(self.landmarks[group][label],
-                                     trilist=trilist)
+                                     trilist=trilist, batch_size=batch_size)
 
     def constrain_to_pointcloud(self, pointcloud, batch_size=None,
                                 point_in_pointcloud='pwa', trilist=None,):

--- a/menpo/image/boolean.py
+++ b/menpo/image/boolean.py
@@ -378,7 +378,8 @@ class BooleanImage(Image):
 
     # noinspection PyMethodOverriding
     def warp_to_mask(self, template_mask, transform, warp_landmarks=True,
-                     mode='constant', cval=False, batch_size=None):
+                     mode='constant', cval=False, batch_size=None,
+                     return_transform=False):
         r"""
         Return a copy of this :map:`BooleanImage` warped into a different
         reference space.
@@ -411,6 +412,8 @@ class BooleanImage(Image):
             how many points in the image should be warped at a time, which
             keeps memory usage low. If ``None``, no batching is used and all
             points are warped at once.
+        return_transform : `bool`, optional
+            If ``True``, then the :map:`Transform` object is also returned.
 
         Returns
         -------
@@ -421,11 +424,13 @@ class BooleanImage(Image):
         return Image.warp_to_mask(self, template_mask, transform,
                                   warp_landmarks=warp_landmarks,
                                   order=0, mode=mode, cval=cval,
-                                  batch_size=batch_size)
+                                  batch_size=batch_size,
+                                  return_transform=return_transform)
 
     # noinspection PyMethodOverriding
     def warp_to_shape(self, template_shape, transform, warp_landmarks=True,
-                      mode='constant', cval=False, order=None, batch_size=None):
+                      mode='constant', cval=False, order=None,
+                      batch_size=None, return_transform=False):
         """
         Return a copy of this :map:`BooleanImage` warped into a different
         reference space.
@@ -459,11 +464,16 @@ class BooleanImage(Image):
             how many points in the image should be warped at a time, which
             keeps memory usage low. If ``None``, no batching is used and all
             points are warped at once.
+        return_transform : `bool`, optional
+            If ``True``, then the :map:`Transform` object is also returned.
 
         Returns
         -------
         warped_image : :map:`BooleanImage`
             A copy of this image, warped.
+        transform : :map:`Transform`
+            The transform that was used. It only applies if
+            `return_transform` is ``True``.
         """
         # call the super variant and get ourselves an Image back
         # note that we force the use of order=0 for BooleanImages.
@@ -478,7 +488,11 @@ class BooleanImage(Image):
             boolean_image.landmarks = warped.landmarks
         if hasattr(warped, 'path'):
             boolean_image.path = warped.path
-        return boolean_image
+        # optionally return the transform
+        if return_transform:
+            return boolean_image, transform
+        else:
+            return boolean_image
 
     def _build_warped_to_mask(self, template_mask, sampled_pixel_values,
                               **kwargs):

--- a/menpo/image/boolean.py
+++ b/menpo/image/boolean.py
@@ -379,7 +379,7 @@ class BooleanImage(Image):
     # noinspection PyMethodOverriding
     def warp_to_mask(self, template_mask, transform, warp_landmarks=True,
                      mode='constant', cval=False, batch_size=None,
-                     return_inverse_transform=False):
+                     return_transform=False):
         r"""
         Return a copy of this :map:`BooleanImage` warped into a different
         reference space.
@@ -412,28 +412,28 @@ class BooleanImage(Image):
             how many points in the image should be warped at a time, which
             keeps memory usage low. If ``None``, no batching is used and all
             points are warped at once.
-        return_inverse_transform : `bool`, optional
-            If ``True``, then the pseudoinverse of the :map:`Transform`
-            object is also returned.
+        return_transform : `bool`, optional
+            This argument is for internal use only. If ``True``, then the
+            :map:`Transform` object is also returned.
 
         Returns
         -------
         warped_image : :map:`BooleanImage`
             A copy of this image, warped.
-        inverse_transform : :map:`Transform`
-            The pseudoinverse of the transform that was used. It only applies if
-            `return_inverse_transform` is ``True``.
+        transform : :map:`Transform`
+            The transform that was used. It only applies if
+            `return_transform` is ``True``.
         """
         # enforce the order as 0, as this is boolean data, then call super
         return Image.warp_to_mask(
             self, template_mask, transform, warp_landmarks=warp_landmarks,
             order=0, mode=mode, cval=cval, batch_size=batch_size,
-            return_inverse_transform=return_inverse_transform)
+            return_transform=return_transform)
 
     # noinspection PyMethodOverriding
     def warp_to_shape(self, template_shape, transform, warp_landmarks=True,
                       mode='constant', cval=False, order=None,
-                      batch_size=None, return_inverse_transform=False):
+                      batch_size=None, return_transform=False):
         """
         Return a copy of this :map:`BooleanImage` warped into a different
         reference space.
@@ -467,24 +467,24 @@ class BooleanImage(Image):
             how many points in the image should be warped at a time, which
             keeps memory usage low. If ``None``, no batching is used and all
             points are warped at once.
-        return_inverse_transform : `bool`, optional
-            If ``True``, then the pseudoinverse of the :map:`Transform`
-            object is also returned.
+        return_transform : `bool`, optional
+            This argument is for internal use only. If ``True``, then the
+            :map:`Transform` object is also returned.
 
         Returns
         -------
         warped_image : :map:`BooleanImage`
             A copy of this image, warped.
-        inverse_transform : :map:`Transform`
-            The pseudoinverse of the transform that was used. It only applies if
-            `return_inverse_transform` is ``True``.
+        transform : :map:`Transform`
+            The transform that was used. It only applies if
+            `return_transform` is ``True``.
         """
         # call the super variant and get ourselves an Image back
         # note that we force the use of order=0 for BooleanImages.
-        warped, inv_transform = Image.warp_to_shape(
-            self, template_shape, transform, warp_landmarks=warp_landmarks,
-            order=0, mode=mode, cval=cval, batch_size=batch_size,
-            return_inverse_transform=True)
+        warped = Image.warp_to_shape(self, template_shape, transform,
+                                     warp_landmarks=warp_landmarks, order=0,
+                                     mode=mode, cval=cval,
+                                     batch_size=batch_size)
         # unfortunately we can't escape copying here, let BooleanImage
         # convert us to np.bool
         boolean_image = BooleanImage(warped.pixels.reshape(template_shape))
@@ -492,9 +492,9 @@ class BooleanImage(Image):
             boolean_image.landmarks = warped.landmarks
         if hasattr(warped, 'path'):
             boolean_image.path = warped.path
-        # optionally return the inverse transform
-        if return_inverse_transform:
-            return boolean_image, inv_transform
+        # optionally return the transform
+        if return_transform:
+            return boolean_image, transform
         else:
             return boolean_image
 

--- a/menpo/image/masked.py
+++ b/menpo/image/masked.py
@@ -782,7 +782,8 @@ class MaskedImage(Image):
 
     # noinspection PyMethodOverriding
     def warp_to_mask(self, template_mask, transform, warp_landmarks=False,
-                     order=1, mode='constant', cval=0., batch_size=None):
+                     order=1, mode='constant', cval=0., batch_size=None,
+                     return_transform=False):
         r"""
         Warps this image into a different reference space.
 
@@ -824,11 +825,16 @@ class MaskedImage(Image):
             how many points in the image should be warped at a time, which
             keeps memory usage low. If ``None``, no batching is used and all
             points are warped at once.
+        return_transform : `bool`, optional
+            If ``True``, then the :map:`Transform` object is also returned.
 
         Returns
         -------
         warped_image : ``type(self)``
             A copy of this image, warped.
+        transform : :map:`Transform`
+            The transform that was used. It only applies if
+            `return_transform` is ``True``.
         """
         # call the super variant and get ourselves a MaskedImage back
         # with a blank mask
@@ -838,11 +844,16 @@ class MaskedImage(Image):
                                           batch_size=batch_size)
         # Set the template mask as our mask
         warped_image.mask = template_mask
-        return warped_image
+        # optionally return the transform
+        if return_transform:
+            return warped_image, transform
+        else:
+            return warped_image
 
     # noinspection PyMethodOverriding
     def warp_to_shape(self, template_shape, transform, warp_landmarks=False,
-                      order=1, mode='constant', cval=0., batch_size=None):
+                      order=1, mode='constant', cval=0., batch_size=None,
+                      return_transform=False):
         """
         Return a copy of this :map:`MaskedImage` warped into a different
         reference space.
@@ -886,11 +897,16 @@ class MaskedImage(Image):
             how many points in the image should be warped at a time, which
             keeps memory usage low. If ``None``, no batching is used and all
             points are warped at once.
+        return_transform : `bool`, optional
+            If ``True``, then the :map:`Transform` object is also returned.
 
         Returns
         -------
         warped_image : :map:`MaskedImage`
             A copy of this image, warped.
+        transform : :map:`Transform`
+            The transform that was used. It only applies if
+            `return_transform` is ``True``.
         """
         # call the super variant and get ourselves an Image back
         warped_image = Image.warp_to_shape(self, template_shape, transform,
@@ -906,7 +922,11 @@ class MaskedImage(Image):
         masked_warped_image = warped_image.as_masked(mask=mask, copy=False)
         if hasattr(warped_image, 'path'):
             masked_warped_image.path = warped_image.path
-        return masked_warped_image
+        # optionally return the transform
+        if return_transform:
+            return masked_warped_image, transform
+        else:
+            return masked_warped_image
 
     def normalize_std_inplace(self, mode='all', limit_to_mask=True):
         r"""

--- a/menpo/image/masked.py
+++ b/menpo/image/masked.py
@@ -700,25 +700,31 @@ class MaskedImage(Image):
             axes_font_size, axes_font_style, axes_font_weight, axes_x_limits,
             axes_y_limits, figure_size)
 
-    def crop_to_true_mask(self, boundary=0, constrain_to_boundary=True):
+    def crop_to_true_mask(self, boundary=0, constrain_to_boundary=True,
+                          return_inverse_transform=False):
         r"""
         Crop this image to be bounded just the `True` values of it's mask.
 
         Parameters
         ----------
-
-        boundary: `int`, optional
+        boundary : `int`, optional
             An extra padding to be added all around the true mask region.
         constrain_to_boundary : `bool`, optional
             If ``True`` the crop will be snapped to not go beyond this images
             boundary. If ``False``, an :map:`ImageBoundaryError` will be raised
             if an attempt is made to go beyond the edge of the image. Note that
             is only possible if ``boundary != 0``.
+        return_inverse_transform : `bool`, optional
+            If ``True``, then the pseudoinverse of the :map:`Transform`
+            object that was used to perform the cropping is also returned.
 
         Returns
         -------
         cropped_image : ``type(self)``
             A copy of this image, cropped to the true mask.
+        inverse_transform : :map:`Transform`
+            The pseudoinverse of the transform that was used. It only applies if
+            `return_inverse_transform` is ``True``.
 
         Raises
         ------
@@ -730,7 +736,8 @@ class MaskedImage(Image):
             boundary=boundary, constrain_to_bounds=False)
         # no point doing the bounds check twice - let the crop do it only.
         return self.crop(min_indices, max_indices,
-                         constrain_to_boundary=constrain_to_boundary)
+                         constrain_to_boundary=constrain_to_boundary,
+                         return_inverse_transform=return_inverse_transform)
 
     def sample(self, points_to_sample, order=1, mode='constant', cval=0.0):
         r"""
@@ -1073,7 +1080,7 @@ class MaskedImage(Image):
         # create a patches array of the correct size, full of True values
         patches = np.ones((pc.n_points, 1, 1, int(patch_shape[0]),
                            int(patch_shape[1])), dtype=np.bool)
-        # set Truepatches around pointcloud centers
+        # set True patches around pointcloud centers
         self.mask.set_patches(patches, pc)
 
     def set_boundary_pixels(self, value=0.0, n_pixels=1):

--- a/menpo/image/masked.py
+++ b/menpo/image/masked.py
@@ -783,7 +783,7 @@ class MaskedImage(Image):
     # noinspection PyMethodOverriding
     def warp_to_mask(self, template_mask, transform, warp_landmarks=False,
                      order=1, mode='constant', cval=0., batch_size=None,
-                     return_transform=False):
+                     return_inverse_transform=False):
         r"""
         Warps this image into a different reference space.
 
@@ -825,35 +825,36 @@ class MaskedImage(Image):
             how many points in the image should be warped at a time, which
             keeps memory usage low. If ``None``, no batching is used and all
             points are warped at once.
-        return_transform : `bool`, optional
-            If ``True``, then the :map:`Transform` object is also returned.
+        return_inverse_transform : `bool`, optional
+            If ``True``, then the pseudoinverse of the :map:`Transform`
+            object is also returned.
 
         Returns
         -------
         warped_image : ``type(self)``
             A copy of this image, warped.
-        transform : :map:`Transform`
-            The transform that was used. It only applies if
-            `return_transform` is ``True``.
+        inverse_transform : :map:`Transform`
+            The pseudoinverse of the transform that was used. It only applies if
+            `return_inverse_transform` is ``True``.
         """
         # call the super variant and get ourselves a MaskedImage back
         # with a blank mask
-        warped_image = Image.warp_to_mask(self, template_mask, transform,
-                                          warp_landmarks=warp_landmarks,
-                                          order=order, mode=mode, cval=cval,
-                                          batch_size=batch_size)
+        warped_image, inv_transform = Image.warp_to_mask(
+            self, template_mask, transform, warp_landmarks=warp_landmarks,
+            order=order, mode=mode, cval=cval, batch_size=batch_size,
+            return_inverse_transform=True)
         # Set the template mask as our mask
         warped_image.mask = template_mask
-        # optionally return the transform
-        if return_transform:
-            return warped_image, transform
+        # optionally return the pseudoinverse transform
+        if return_inverse_transform:
+            return warped_image, inv_transform
         else:
             return warped_image
 
     # noinspection PyMethodOverriding
     def warp_to_shape(self, template_shape, transform, warp_landmarks=False,
                       order=1, mode='constant', cval=0., batch_size=None,
-                      return_transform=False):
+                      return_inverse_transform=False):
         """
         Return a copy of this :map:`MaskedImage` warped into a different
         reference space.
@@ -897,22 +898,23 @@ class MaskedImage(Image):
             how many points in the image should be warped at a time, which
             keeps memory usage low. If ``None``, no batching is used and all
             points are warped at once.
-        return_transform : `bool`, optional
-            If ``True``, then the :map:`Transform` object is also returned.
+        return_inverse_transform : `bool`, optional
+            If ``True``, then the pseudoinverse of the :map:`Transform`
+            object is also returned.
 
         Returns
         -------
         warped_image : :map:`MaskedImage`
             A copy of this image, warped.
-        transform : :map:`Transform`
-            The transform that was used. It only applies if
-            `return_transform` is ``True``.
+        inverse_transform : :map:`Transform`
+            The pseudoinverse of the transform that was used. It only applies if
+            `return_inverse_transform` is ``True``.
         """
         # call the super variant and get ourselves an Image back
-        warped_image = Image.warp_to_shape(self, template_shape, transform,
-                                           warp_landmarks=warp_landmarks,
-                                           order=order, mode=mode, cval=cval,
-                                           batch_size=batch_size)
+        warped_image, inv_transform = Image.warp_to_shape(
+            self, template_shape, transform, warp_landmarks=warp_landmarks,
+            order=order, mode=mode, cval=cval, batch_size=batch_size,
+            return_inverse_transform=True)
         # warp the mask separately and reattach.
         mask = self.mask.warp_to_shape(template_shape, transform,
                                        warp_landmarks=warp_landmarks,
@@ -922,9 +924,9 @@ class MaskedImage(Image):
         masked_warped_image = warped_image.as_masked(mask=mask, copy=False)
         if hasattr(warped_image, 'path'):
             masked_warped_image.path = warped_image.path
-        # optionally return the transform
-        if return_transform:
-            return masked_warped_image, transform
+        # optionally return the pseudoinverse transform
+        if return_inverse_transform:
+            return masked_warped_image, inv_transform
         else:
             return masked_warped_image
 

--- a/menpo/image/masked.py
+++ b/menpo/image/masked.py
@@ -701,7 +701,7 @@ class MaskedImage(Image):
             axes_y_limits, figure_size)
 
     def crop_to_true_mask(self, boundary=0, constrain_to_boundary=True,
-                          return_inverse_transform=False):
+                          return_transform=False):
         r"""
         Crop this image to be bounded just the `True` values of it's mask.
 
@@ -714,17 +714,17 @@ class MaskedImage(Image):
             boundary. If ``False``, an :map:`ImageBoundaryError` will be raised
             if an attempt is made to go beyond the edge of the image. Note that
             is only possible if ``boundary != 0``.
-        return_inverse_transform : `bool`, optional
-            If ``True``, then the pseudoinverse of the :map:`Transform`
-            object that was used to perform the cropping is also returned.
+        return_transform : `bool`, optional
+            If ``True``, then the :map:`Transform` object that was used to
+            perform the cropping is also returned.
 
         Returns
         -------
         cropped_image : ``type(self)``
             A copy of this image, cropped to the true mask.
-        inverse_transform : :map:`Transform`
-            The pseudoinverse of the transform that was used. It only applies if
-            `return_inverse_transform` is ``True``.
+        transform : :map:`Transform`
+            The transform that was used. It only applies if
+            `return_transform` is ``True``.
 
         Raises
         ------
@@ -737,7 +737,7 @@ class MaskedImage(Image):
         # no point doing the bounds check twice - let the crop do it only.
         return self.crop(min_indices, max_indices,
                          constrain_to_boundary=constrain_to_boundary,
-                         return_inverse_transform=return_inverse_transform)
+                         return_transform=return_transform)
 
     def sample(self, points_to_sample, order=1, mode='constant', cval=0.0):
         r"""
@@ -790,7 +790,7 @@ class MaskedImage(Image):
     # noinspection PyMethodOverriding
     def warp_to_mask(self, template_mask, transform, warp_landmarks=False,
                      order=1, mode='constant', cval=0., batch_size=None,
-                     return_inverse_transform=False):
+                     return_transform=False):
         r"""
         Warps this image into a different reference space.
 
@@ -832,36 +832,36 @@ class MaskedImage(Image):
             how many points in the image should be warped at a time, which
             keeps memory usage low. If ``None``, no batching is used and all
             points are warped at once.
-        return_inverse_transform : `bool`, optional
-            If ``True``, then the pseudoinverse of the :map:`Transform`
-            object is also returned.
+        return_transform : `bool`, optional
+            This argument is for internal use only. If ``True``, then the
+            :map:`Transform` object is also returned.
 
         Returns
         -------
         warped_image : ``type(self)``
             A copy of this image, warped.
-        inverse_transform : :map:`Transform`
-            The pseudoinverse of the transform that was used. It only applies if
-            `return_inverse_transform` is ``True``.
+        transform : :map:`Transform`
+            The transform that was used. It only applies if
+            `return_transform` is ``True``.
         """
         # call the super variant and get ourselves a MaskedImage back
         # with a blank mask
-        warped_image, inv_transform = Image.warp_to_mask(
-            self, template_mask, transform, warp_landmarks=warp_landmarks,
-            order=order, mode=mode, cval=cval, batch_size=batch_size,
-            return_inverse_transform=True)
+        warped_image = Image.warp_to_mask(self, template_mask, transform,
+                                          warp_landmarks=warp_landmarks,
+                                          order=order, mode=mode, cval=cval,
+                                          batch_size=batch_size)
         # Set the template mask as our mask
         warped_image.mask = template_mask
-        # optionally return the pseudoinverse transform
-        if return_inverse_transform:
-            return warped_image, inv_transform
+        # optionally return the transform
+        if return_transform:
+            return warped_image, transform
         else:
             return warped_image
 
     # noinspection PyMethodOverriding
     def warp_to_shape(self, template_shape, transform, warp_landmarks=False,
                       order=1, mode='constant', cval=0., batch_size=None,
-                      return_inverse_transform=False):
+                      return_transform=False):
         """
         Return a copy of this :map:`MaskedImage` warped into a different
         reference space.
@@ -905,23 +905,23 @@ class MaskedImage(Image):
             how many points in the image should be warped at a time, which
             keeps memory usage low. If ``None``, no batching is used and all
             points are warped at once.
-        return_inverse_transform : `bool`, optional
-            If ``True``, then the pseudoinverse of the :map:`Transform`
-            object is also returned.
+        return_transform : `bool`, optional
+            This argument is for internal use only. If ``True``, then the
+            :map:`Transform` object is also returned.
 
         Returns
         -------
         warped_image : :map:`MaskedImage`
             A copy of this image, warped.
-        inverse_transform : :map:`Transform`
-            The pseudoinverse of the transform that was used. It only applies if
-            `return_inverse_transform` is ``True``.
+        transform : :map:`Transform`
+            The transform that was used. It only applies if
+            `return_transform` is ``True``.
         """
         # call the super variant and get ourselves an Image back
-        warped_image, inv_transform = Image.warp_to_shape(
-            self, template_shape, transform, warp_landmarks=warp_landmarks,
-            order=order, mode=mode, cval=cval, batch_size=batch_size,
-            return_inverse_transform=True)
+        warped_image = Image.warp_to_shape(self, template_shape, transform,
+                                           warp_landmarks=warp_landmarks,
+                                           order=order, mode=mode, cval=cval,
+                                           batch_size=batch_size)
         # warp the mask separately and reattach.
         mask = self.mask.warp_to_shape(template_shape, transform,
                                        warp_landmarks=warp_landmarks,
@@ -931,9 +931,9 @@ class MaskedImage(Image):
         masked_warped_image = warped_image.as_masked(mask=mask, copy=False)
         if hasattr(warped_image, 'path'):
             masked_warped_image.path = warped_image.path
-        # optionally return the pseudoinverse transform
-        if return_inverse_transform:
-            return masked_warped_image, inv_transform
+        # optionally return the transform
+        if return_transform:
+            return masked_warped_image, transform
         else:
             return masked_warped_image
 

--- a/menpo/image/test/image_pointcloud_rescale_crop_test.py
+++ b/menpo/image/test/image_pointcloud_rescale_crop_test.py
@@ -28,6 +28,18 @@ def test_rescale_to_pointcloud():
     assert_allclose(img_rescaled.shape, (250, 250))
 
 
+def test_rescale_to_diagonal_return_inverse_transform():
+    img = Image.init_blank((100, 100), n_channels=1)
+    img.landmarks['test'] = bounding_box([40, 40], [80, 80])
+    cropped_img, inv_transform = img.rescale_to_diagonal(
+        100, return_inverse_transform=True)
+    img_back = cropped_img.warp_to_shape(img.shape, inv_transform)
+    assert_allclose(img_back.shape, img.shape)
+    assert_allclose(img_back.pixels, img.pixels)
+    assert_allclose(img_back.landmarks['test'].lms.points,
+                    img.landmarks['test'].lms.points)
+
+
 def test_crop_to_pointcloud():
     img = Image.init_blank((100, 100), n_channels=1)
     pcloud = bounding_box([0, 0], [50, 50])
@@ -42,7 +54,6 @@ def test_crop_to_landmarks():
 
     img_cropped = img.crop_to_landmarks()
     assert_allclose(img_cropped.shape, (10, 10))
-    assert 1
 
 
 def test_crop_to_pointcloud_proportion():
@@ -59,3 +70,15 @@ def test_crop_to_landmarks_proportion():
 
     img_cropped = img.crop_to_landmarks_proportion(0.1)
     assert_allclose(img_cropped.shape, (11, 11))
+
+
+def test_crop_to_landmarks_return_inverse_transform():
+    img = Image.init_blank((100, 100), n_channels=1)
+    img.landmarks['test'] = bounding_box([40, 40], [80, 80])
+    cropped_img, inv_transform = img.crop(
+        np.array([20, 30]), np.array([90, 95]), return_inverse_transform=True)
+    img_back = cropped_img.warp_to_shape(img.shape, inv_transform)
+    assert_allclose(img_back.shape, img.shape)
+    assert_allclose(img_back.pixels, img.pixels)
+    assert_allclose(img_back.landmarks['test'].lms.points,
+                    img.landmarks['test'].lms.points)

--- a/menpo/image/test/image_pointcloud_rescale_crop_test.py
+++ b/menpo/image/test/image_pointcloud_rescale_crop_test.py
@@ -28,12 +28,11 @@ def test_rescale_to_pointcloud():
     assert_allclose(img_rescaled.shape, (250, 250))
 
 
-def test_rescale_to_diagonal_return_inverse_transform():
+def test_rescale_to_diagonal_return_transform():
     img = Image.init_blank((100, 100), n_channels=1)
     img.landmarks['test'] = bounding_box([40, 40], [80, 80])
-    cropped_img, inv_transform = img.rescale_to_diagonal(
-        100, return_inverse_transform=True)
-    img_back = cropped_img.warp_to_shape(img.shape, inv_transform)
+    cropped_img, transform = img.rescale_to_diagonal(100, return_transform=True)
+    img_back = cropped_img.warp_to_shape(img.shape, transform.pseudoinverse())
     assert_allclose(img_back.shape, img.shape)
     assert_allclose(img_back.pixels, img.pixels)
     assert_allclose(img_back.landmarks['test'].lms.points,
@@ -72,12 +71,12 @@ def test_crop_to_landmarks_proportion():
     assert_allclose(img_cropped.shape, (11, 11))
 
 
-def test_crop_to_landmarks_return_inverse_transform():
+def test_crop_to_landmarks_return_transform():
     img = Image.init_blank((100, 100), n_channels=1)
     img.landmarks['test'] = bounding_box([40, 40], [80, 80])
-    cropped_img, inv_transform = img.crop(
-        np.array([20, 30]), np.array([90, 95]), return_inverse_transform=True)
-    img_back = cropped_img.warp_to_shape(img.shape, inv_transform)
+    cropped_img, transform = img.crop(np.array([20, 30]), np.array([90, 95]),
+                                      return_transform=True)
+    img_back = cropped_img.warp_to_shape(img.shape, transform.pseudoinverse())
     assert_allclose(img_back.shape, img.shape)
     assert_allclose(img_back.pixels, img.pixels)
     assert_allclose(img_back.landmarks['test'].lms.points,

--- a/menpo/image/test/image_warp_test.py
+++ b/menpo/image/test/image_warp_test.py
@@ -131,11 +131,11 @@ def test_rescale_boolean():
     mask.resize((10, 10))
 
 
-def test_rescale_return_inverse_transform():
+def test_rescale_return_transform():
     img = Image.init_blank((100, 100), n_channels=1)
     img.landmarks['test'] = bounding_box([40, 40], [80, 80])
-    cropped_img, inv_transform = img.rescale(1.5, return_inverse_transform=True)
-    img_back = cropped_img.warp_to_shape(img.shape, inv_transform)
+    cropped_img, transform = img.rescale(1.5, return_transform=True)
+    img_back = cropped_img.warp_to_shape(img.shape, transform.pseudoinverse())
     assert_allclose(img_back.shape, img.shape)
     assert_allclose(img_back.pixels, img.pixels)
     assert_allclose(img_back.landmarks['test'].lms.points,
@@ -253,11 +253,11 @@ def test_mirror_masked_image():
     assert(type(mirrored_img) == MaskedImage)
 
 
-def test_mirror_return_inverse_transform():
+def test_mirror_return_transform():
     img = Image.init_blank((100, 100), n_channels=1)
     img.landmarks['test'] = bounding_box([40, 40], [80, 80])
-    cropped_img, inv_transform = img.mirror(return_inverse_transform=True)
-    img_back = cropped_img.warp_to_shape(img.shape, inv_transform)
+    cropped_img, transform = img.mirror(return_transform=True)
+    img_back = cropped_img.warp_to_shape(img.shape, transform.pseudoinverse())
     assert_allclose(img_back.shape, img.shape)
     assert_allclose(img_back.pixels, img.pixels)
     assert_allclose(img_back.landmarks['test'].lms.points,
@@ -309,12 +309,12 @@ def test_rotate_image_45():
                                   [2.828, 2.121], [2.121, 2.828]]), decimal=3)
 
 
-def test_rotate_return_inverse_transform():
+def test_rotate_return_transform():
     img = Image.init_blank((100, 100), n_channels=1)
     img.landmarks['test'] = bounding_box([40, 40], [80, 80])
-    cropped_img, inv_transform = img.rotate_ccw_about_centre(
-        60, return_inverse_transform=True)
-    img_back = cropped_img.warp_to_shape(img.shape, inv_transform)
+    cropped_img, transform = img.rotate_ccw_about_centre(60,
+                                                         return_transform=True)
+    img_back = cropped_img.warp_to_shape(img.shape, transform.pseudoinverse())
     assert_allclose(img_back.shape, img.shape)
     assert_allclose(img_back.pixels, img.pixels)
     assert_allclose(img_back.landmarks['test'].lms.points,

--- a/menpo/image/test/image_warp_test.py
+++ b/menpo/image/test/image_warp_test.py
@@ -3,7 +3,7 @@ import menpo
 from nose.tools import raises
 from numpy.testing import assert_allclose, assert_almost_equal
 from menpo.image import BooleanImage, Image, MaskedImage, OutOfMaskSampleError
-from menpo.shape import PointCloud
+from menpo.shape import PointCloud, bounding_box
 from menpo.transform import Affine
 import menpo.io as mio
 
@@ -131,6 +131,17 @@ def test_rescale_boolean():
     mask.resize((10, 10))
 
 
+def test_rescale_return_inverse_transform():
+    img = Image.init_blank((100, 100), n_channels=1)
+    img.landmarks['test'] = bounding_box([40, 40], [80, 80])
+    cropped_img, inv_transform = img.rescale(1.5, return_inverse_transform=True)
+    img_back = cropped_img.warp_to_shape(img.shape, inv_transform)
+    assert_allclose(img_back.shape, img.shape)
+    assert_allclose(img_back.pixels, img.pixels)
+    assert_allclose(img_back.landmarks['test'].lms.points,
+                    img.landmarks['test'].lms.points)
+
+
 def test_sample_image():
     im = Image.init_blank((100, 100), fill=2)
     p = PointCloud(np.array([[0, 0], [1, 0]]))
@@ -242,6 +253,17 @@ def test_mirror_masked_image():
     assert(type(mirrored_img) == MaskedImage)
 
 
+def test_mirror_return_inverse_transform():
+    img = Image.init_blank((100, 100), n_channels=1)
+    img.landmarks['test'] = bounding_box([40, 40], [80, 80])
+    cropped_img, inv_transform = img.mirror(return_inverse_transform=True)
+    img_back = cropped_img.warp_to_shape(img.shape, inv_transform)
+    assert_allclose(img_back.shape, img.shape)
+    assert_allclose(img_back.pixels, img.pixels)
+    assert_allclose(img_back.landmarks['test'].lms.points,
+                    img.landmarks['test'].lms.points)
+
+
 def test_rotate_image_90_180():
     image = Image(np.array([[1., 2., 3., 4.],
                             [5., 6., 7., 8.],
@@ -285,6 +307,18 @@ def test_rotate_image_45():
     assert_almost_equal(rotated_img.landmarks['temp'].lms.points,
                         np.array([[2.121, 1.414], [1.414, 2.121],
                                   [2.828, 2.121], [2.121, 2.828]]), decimal=3)
+
+
+def test_rotate_return_inverse_transform():
+    img = Image.init_blank((100, 100), n_channels=1)
+    img.landmarks['test'] = bounding_box([40, 40], [80, 80])
+    cropped_img, inv_transform = img.rotate_ccw_about_centre(
+        60, return_inverse_transform=True)
+    img_back = cropped_img.warp_to_shape(img.shape, inv_transform)
+    assert_allclose(img_back.shape, img.shape)
+    assert_allclose(img_back.pixels, img.pixels)
+    assert_allclose(img_back.landmarks['test'].lms.points,
+                    img.landmarks['test'].lms.points)
 
 
 def test_maskedimage_retain_shape():


### PR DESCRIPTION
This PR adds an extra `return_inverse_transform` to all the methods of `Image`, `MaskedImage` and `BooleanImage` that utilize a `Transform`. If `return_inverse_transform` is ``True``, then the `self.pseudoinverse()` of the `Transform` is returned along with the transformed image. This logic is basically encoded in the `warp_to_shape()` and `warp_to_mask()` methods, since all the rest (e.g. `crop*`, `rescale*`, etc.) return calls of those two. There are also some tests added to examine this behaviour.