### PR TITLE
Add cca math method

### DIFF
--- a/docs/source/api/menpo/math/cca.rst
+++ b/docs/source/api/menpo/math/cca.rst
@@ -1,0 +1,7 @@
+.. _menpo-math-cca:
+
+.. currentmodule:: menpo.math
+
+cca
+===
+.. autofunction:: cca

--- a/docs/source/api/menpo/math/index.rst
+++ b/docs/source/api/menpo/math/index.rst
@@ -16,6 +16,7 @@ Decomposition
   eigenvalue_decomposition
   pca
   ipca
+  cca
 
 
 Linear Algebra

--- a/menpo/math/__init__.py
+++ b/menpo/math/__init__.py
@@ -1,3 +1,3 @@
 from .convolution import log_gabor
-from .decomposition import eigenvalue_decomposition, pca, ipca
+from .decomposition import eigenvalue_decomposition, pca, ipca, cca
 from .linalg import dot_inplace_left, dot_inplace_right, as_matrix, from_matrix

--- a/menpo/math/decomposition.py
+++ b/menpo/math/decomposition.py
@@ -3,6 +3,69 @@ import numpy as np
 from .linalg import dot_inplace_right
 
 
+def cca(X, Y, inplace=False):
+    """
+    Calculate Canonical Correlation Analysis (CCA) on the two given matrices.
+    That is, find the linear subspaces that maximally correlate X and Y.
+    In the case where the ``X`` or ``Y`` matrices is very large, it is advisable
+    to set ``inplace = True``. However, note this destructively edits the
+    matrices by subtracting their means inplace.
+
+    The resulting linear projection matrices will have a number of dimensions
+    corresponding to the minimum rank of the correlations e.g.
+
+        d = min(rank(X), rank(Y))
+
+    Parameters
+    ----------
+    X : ``(n_samples, n_dims1)`` `ndarray`
+        Data matrix one.
+    Y : ``(n_samples, n_dims2)`` `ndarray`
+        Data matrix two. May have a different number of columns than ``X``.
+    inplace : `bool`, optional
+        Whether to do the mean subtracting inplace or not.
+
+    Returns
+    -------
+    Wx : ``(n_dims1, d)`` `ndarray`
+        Linear subspace for the ``X`` matrix that maximally correlates
+        ``X`` with ``Y``.
+    Wy : ``(n_dims2, d)`` `ndarray`
+        Linear subspace for the ``Y`` matrix that maximally correlates
+        ``Y`` with ``X``.
+    mx : ``(n_dims1,)`` `ndarray`
+        The mean of ``X``.
+    my : ``(n_dims2,)`` `ndarray`
+        The mean of ``Y``.
+    C : ``(d,)`` `ndarray`
+        The canonical correlations (the eigenvalues of the cross-correlation).
+    """
+    # compute means
+    mx = np.mean(X, axis=0)
+    my = np.mean(Y, axis=0)
+
+    # mean center views
+    if inplace:
+        X -= mx
+        Y -= my
+    else:
+        X = X - mx
+        Y = Y - my
+
+    Ux, Sx, Vx = np.linalg.svd(X, full_matrices=False)
+    Uy, Sy, Vy = np.linalg.svd(Y, full_matrices=False)
+
+    # Compute cross-correlation in U-bases
+    Cxy = Ux.T.dot(Uy)
+
+    Fx, C, Fy = np.linalg.svd(Cxy, full_matrices=False)
+
+    Wx = Vx.T.dot(1 / Sx[..., None] * Fx)
+    Wy = Vy.T.dot(1 / Sy[..., None] * Fy.T)
+
+    return Wx, Wy, mx, my, C
+
+
 def eigenvalue_decomposition(C, eps=1e-10):
     r"""
     Eigenvalue decomposition of a given covariance (or scatter) matrix.


### PR DESCRIPTION
This is needed for some of the new SDM methods in menpofit. It just performs a very basic CCA on numpy arrays.