### PR TITLE
Deprecate a number of inplace methods

### DIFF
--- a/menpo/base.py
+++ b/menpo/base.py
@@ -87,10 +87,10 @@ class Vectorizable(Copyable):
 
     def from_vector_inplace(self, vector):
         """
-        Deprecated. Use hte non-mutating API, :map:`from_vector`.
+        Deprecated. Use the non-mutating API, :map:`from_vector`.
 
         For internal usage in performance-sensitive spots,
-        use, see `_from_vector_inplace()`
+        see `_from_vector_inplace()`
 
         Parameters
         ----------

--- a/menpo/base.py
+++ b/menpo/base.py
@@ -1,5 +1,6 @@
 from functools import partial, wraps
 import os.path
+import warnings
 
 
 class Copyable(object):
@@ -90,6 +91,23 @@ class Vectorizable(Copyable):
 
     def from_vector_inplace(self, vector):
         """
+        Deprecated. Use hte non-mutating API, :map:`from_vector`.
+
+        For internal usage in performance-sensitive spots,
+        use, see `_from_vector_inplace()`
+
+        Parameters
+        ----------
+        vector : ``(n_parameters,)`` `ndarray`
+            Flattened representation of this object
+        """
+        warnings.warn('the public API for inplace operations is deprecated '
+                      'and will be removed in a future version of Menpo. '
+                      'Use .from_vector() instead.', MenpoDeprecationWarning)
+        return self._from_vector_inplace(vector)
+
+    def _from_vector_inplace(self, vector):
+        """
         Update the state of this object from a vector form.
 
         Parameters
@@ -120,7 +138,7 @@ class Vectorizable(Copyable):
             An new instance of this class.
         """
         new = self.copy()
-        new.from_vector_inplace(vector)
+        new._from_vector_inplace(vector)
         return new
 
     def has_nan_values(self):

--- a/menpo/base.py
+++ b/menpo/base.py
@@ -29,16 +29,12 @@ class Copyable(object):
             A copy of this object
 
         """
-        # print('copy called on {}'.format(type(self).__name__))
         new = self.__class__.__new__(self.__class__)
         for k, v in self.__dict__.items():
             try:
                 new.__dict__[k] = v.copy()
-                # if not isinstance(v, Copyable):
-                #     alien_copies[type(v).__name__].add(type(self).__name__)
             except AttributeError:
                 new.__dict__[k] = v
-                # non_copies[type(v).__name__].add(type(self).__name__)
         return new
 
 

--- a/menpo/image/base.py
+++ b/menpo/image/base.py
@@ -6,7 +6,7 @@ import numpy as np
 import PIL.Image as PILImage
 
 from menpo.compatibility import basestring
-from menpo.base import Vectorizable
+from menpo.base import Vectorizable, MenpoDeprecationWarning
 from menpo.shape import PointCloud, bounding_box
 from menpo.landmark import Landmarkable
 from menpo.transform import (Translation, NonUniformScale,
@@ -2298,8 +2298,17 @@ class Image(Vectorizable, Landmarkable, Viewable, LandmarkableViewable):
 
     def normalize_std_inplace(self, mode='all', **kwargs):
         r"""
-        Normalizes this image such that its pixel values have zero mean and
-        unit variance.
+        Deprecated. See the non-mutating API, `normalize_std()`.
+        """
+        warn('the public API for inplace operations is deprecated '
+             'and will be removed in a future version of Menpo. '
+             'Use .normalize_std() instead.', MenpoDeprecationWarning)
+        self._normalize_inplace(np.std, mode=mode)
+
+    def normalize_std(self, mode='all', **kwargs):
+        r"""
+        Returns a copy of this image normalized such that its
+        pixel values have zero mean and unit variance.
 
         Parameters
         ----------
@@ -2308,24 +2317,47 @@ class Image(Vectorizable, Landmarkable, Viewable, LandmarkableViewable):
             ``per_channel``, each channel individually is mean centred and
             normalized in variance.
         """
-        self._normalize_inplace(np.std, mode=mode)
+        return self._normalize(np.std, mode=mode)
 
     def normalize_norm_inplace(self, mode='all', **kwargs):
         r"""
-        Normalizes this image such that its pixel values have zero mean and
-        its norm equals 1.
-
-        Parameters
-        ----------
-        mode : ``{all, per_channel}``, optional
-            If ``all``, the normalization is over all channels. If
-            ``per_channel``, each channel individually is mean centred and
-            normalized in variance.
+        Deprecated. See the non-mutating API, `normalize_norm()`.
         """
+        warn('the public API for inplace operations is deprecated '
+             'and will be removed in a future version of Menpo. '
+             'Use .normalize_norm() instead.', MenpoDeprecationWarning)
+
         def scale_func(pixels, axis=None):
             return np.linalg.norm(pixels, axis=axis, **kwargs)
 
         self._normalize_inplace(scale_func, mode=mode)
+
+    def normalize_norm(self, mode='all', **kwargs):
+        r"""
+        Returns a copy of this image normalized such that its pixel values
+        have zero mean and its norm equals 1.
+
+        Parameters
+        ----------
+        mode : ``{all, per_channel}``, optional
+            If ``all``, the normalization is over all channels. If
+            ``per_channel``, each channel individually is mean centred and
+            normalized in variance.
+
+        Returns
+        -------
+        image : ``type(self)``
+            A copy of this image, normalized.
+        """
+        def scale_func(pixels, axis=None):
+            return np.linalg.norm(pixels, axis=axis, **kwargs)
+
+        return self._normalize(scale_func, mode=mode)
+
+    def _normalize(self, scale_func, mode='all'):
+        new = self.copy()
+        new._normalize_inplace(scale_func, mode=mode)
+        return new
 
     def _normalize_inplace(self, scale_func, mode='all'):
         pixels = self.as_vector(keep_channels=True)

--- a/menpo/image/base.py
+++ b/menpo/image/base.py
@@ -1510,7 +1510,7 @@ class Image(Vectorizable, Landmarkable, Viewable, LandmarkableViewable):
         warped_image = self._build_warp_to_mask(template_mask, sampled)
         if warp_landmarks and self.has_landmarks:
             warped_image.landmarks = self.landmarks
-            transform.pseudoinverse().apply_inplace(warped_image.landmarks)
+            transform.pseudoinverse()._apply_inplace(warped_image.landmarks)
         if hasattr(self, 'path'):
             warped_image.path = self.path
         # optionally return the transform
@@ -1689,7 +1689,7 @@ class Image(Vectorizable, Landmarkable, Viewable, LandmarkableViewable):
         # warp landmarks if requested.
         if warp_landmarks and self.has_landmarks:
             warped_image.landmarks = self.landmarks
-            transform.pseudoinverse().apply_inplace(warped_image.landmarks)
+            transform.pseudoinverse()._apply_inplace(warped_image.landmarks)
         if hasattr(self, 'path'):
             warped_image.path = self.path
 

--- a/menpo/image/base.py
+++ b/menpo/image/base.py
@@ -401,7 +401,7 @@ class Image(Vectorizable, Landmarkable, Viewable, LandmarkableViewable):
         new_image.landmarks = self.landmarks
         return new_image
 
-    def from_vector_inplace(self, vector, copy=True):
+    def _from_vector_inplace(self, vector, copy=True):
         r"""
         Takes a flattened vector and update this image by
         reshaping the vector to the correct dimensions.
@@ -1537,7 +1537,7 @@ class Image(Vectorizable, Landmarkable, Viewable, LandmarkableViewable):
         warped_image = MaskedImage.init_blank(template_mask.shape,
                                               n_channels=self.n_channels,
                                               mask=template_mask)
-        warped_image.from_vector_inplace(sampled_pixel_values.ravel())
+        warped_image._from_vector_inplace(sampled_pixel_values.ravel())
         return warped_image
 
     def sample(self, points_to_sample, order=1, mode='constant', cval=0.0):
@@ -2417,7 +2417,7 @@ class Image(Vectorizable, Landmarkable, Viewable, LandmarkableViewable):
             raise ValueError("Image has 0 variance - can't be "
                              "normalized")
         else:
-            self.from_vector_inplace(centered_pixels / scale_factor)
+            self._from_vector_inplace(centered_pixels / scale_factor)
 
     def rescale_pixels(self, minimum, maximum, per_channel=True):
         r"""A copy of this image with pixels linearly rescaled to fit a range.

--- a/menpo/image/boolean.py
+++ b/menpo/image/boolean.py
@@ -259,12 +259,6 @@ class BooleanImage(Image):
             mask.path = self.path
         return mask
 
-    def invert_inplace(self):
-        r"""
-        Inverts this Boolean Image inplace.
-        """
-        self.pixels = ~self.pixels
-
     def invert(self):
         r"""
         Returns a copy of this boolean image, which is inverted.
@@ -276,7 +270,7 @@ class BooleanImage(Image):
             and all ``False`` values are ``True``.
         """
         inverse = self.copy()
-        inverse.invert_inplace()
+        inverse.pixels = ~self.pixels
         return inverse
 
     def bounds_true(self, boundary=0, constrain_to_bounds=True):

--- a/menpo/image/masked.py
+++ b/menpo/image/masked.py
@@ -346,7 +346,7 @@ class MaskedImage(Image):
         new_image.landmarks = self.landmarks
         return new_image
 
-    def from_vector_inplace(self, vector, copy=True):
+    def _from_vector_inplace(self, vector, copy=True):
         r"""
         Takes a flattened vector and updates this image by reshaping
         the vector to the correct pixels and channels. Note that the only
@@ -1004,10 +1004,10 @@ class MaskedImage(Image):
             normalized_pixels = centered_pixels / scale_factor
 
         if limit_to_mask:
-            self.from_vector_inplace(normalized_pixels.flatten())
+            self._from_vector_inplace(normalized_pixels.flatten())
         else:
-            Image.from_vector_inplace(self,
-                                      normalized_pixels.flatten())
+            Image._from_vector_inplace(self,
+                                       normalized_pixels.flatten())
 
     def constrain_mask_to_landmarks(self, group=None,
                                     batch_size=None, point_in_pointcloud='pwa',

--- a/menpo/image/masked.py
+++ b/menpo/image/masked.py
@@ -4,6 +4,7 @@ import numpy as np
 binary_erosion = None  # expensive, from scipy.ndimage
 binary_dilation = None  # expensive, from scipy.ndimage
 
+from menpo.base import MenpoDeprecationWarning
 from menpo.visualize.base import ImageViewer
 
 from .base import Image
@@ -954,8 +955,31 @@ class MaskedImage(Image):
             If ``False``, the normalization is wrt all pixels, regardless of
             their masking value.
         """
+        warn('the public API for inplace operations is deprecated '
+             'and will be removed in a future version of Menpo. '
+             'Use .normalize_std() instead.', MenpoDeprecationWarning)
         self._normalize_inplace(np.std, mode=mode,
                                 limit_to_mask=limit_to_mask)
+
+    def normalize_std(self, mode='all', limit_to_mask=True):
+        r"""
+        Returns a copy of this image normalized such that it's pixel values
+        have zero mean and unit variance.
+
+        Parameters
+        ----------
+        mode : ``{all, per_channel}``, optional
+            If ``all``, the normalization is over all channels. If
+            ``per_channel``, each channel individually is mean centred and
+            normalized in variance.
+        limit_to_mask : `bool`, optional
+            If ``True``, the normalization is only performed wrt the masked
+            pixels.
+            If ``False``, the normalization is wrt all pixels, regardless of
+            their masking value.
+        """
+        return self._normalize(np.std, mode=mode,
+                               limit_to_mask=limit_to_mask)
 
     def normalize_norm_inplace(self, mode='all', limit_to_mask=True,
                                **kwargs):
@@ -975,12 +999,45 @@ class MaskedImage(Image):
             If ``False``, the normalization is wrt all pixels, regardless of
             their masking value.
         """
+        warn('the public API for inplace operations is deprecated '
+             'and will be removed in a future version of Menpo. '
+             'Use .normalize_norm() instead.', MenpoDeprecationWarning)
 
         def scale_func(pixels, axis=None):
             return np.linalg.norm(pixels, axis=axis, **kwargs)
 
         self._normalize_inplace(scale_func, mode=mode,
                                 limit_to_mask=limit_to_mask)
+
+    def normalize_norm(self, mode='all', limit_to_mask=True, **kwargs):
+        r"""
+        Returns a copy of this imaage normalized such that it's pixel values
+        have zero mean and its norm equals 1.
+
+        Parameters
+        ----------
+        mode : ``{all, per_channel}``, optional
+            If ``all``, the normalization is over all channels. If
+            ``per_channel``, each channel individually is mean centred and
+            normalized in variance.
+        limit_to_mask : `bool`, optional
+            If ``True``, the normalization is only performed wrt the masked
+            pixels.
+            If ``False``, the normalization is wrt all pixels, regardless of
+            their masking value.
+        """
+
+        def scale_func(pixels, axis=None):
+            return np.linalg.norm(pixels, axis=axis, **kwargs)
+
+        return self._normalize(scale_func, mode=mode,
+                               limit_to_mask=limit_to_mask)
+
+    def _normalize(self, scale_func, mode='all', limit_to_mask=True):
+        new = self.copy()
+        new._normalize_inplace(scale_func, mode=mode,
+                               limit_to_mask=limit_to_mask)
+        return new
 
     def _normalize_inplace(self, scale_func, mode='all', limit_to_mask=True):
         if limit_to_mask:

--- a/menpo/image/test/image_test.py
+++ b/menpo/image/test/image_test.py
@@ -103,7 +103,7 @@ def test_image_from_vector_inplace_no_copy():
     pixels = np.random.rand(2, 10, 20)
     pixels2 = np.random.rand(2, 10, 20)
     image = Image(pixels)
-    image.from_vector_inplace(pixels2.ravel(), copy=False)
+    image._from_vector_inplace(pixels2.ravel(), copy=False)
     assert(is_same_array(image.pixels, pixels2))
 
 
@@ -113,7 +113,7 @@ def test_image_from_vector_inplace_no_copy_warning():
         image = Image(pixels)
         with warnings.catch_warnings(record=True) as w:
             warnings.simplefilter("always")
-            image.from_vector_inplace(pixels2.ravel()[::-1], copy=False)
+            image._from_vector_inplace(pixels2.ravel()[::-1], copy=False)
             assert len(w) == 1
 
 
@@ -121,7 +121,7 @@ def test_image_from_vector_inplace_copy_default():
     pixels = np.random.rand(2, 10, 20)
     pixels2 = np.random.rand(2, 10, 20)
     image = Image(pixels)
-    image.from_vector_inplace(pixels2.ravel())
+    image._from_vector_inplace(pixels2.ravel())
     assert(not is_same_array(image.pixels, pixels2))
 
 
@@ -129,7 +129,7 @@ def test_image_from_vector_inplace_copy_explicit():
     pixels = np.random.rand(2, 10, 20)
     pixels2 = np.random.rand(2, 10, 20)
     image = Image(pixels)
-    image.from_vector_inplace(pixels2.ravel(), copy=True)
+    image._from_vector_inplace(pixels2.ravel(), copy=True)
     assert(not is_same_array(image.pixels, pixels2))
 
 

--- a/menpo/image/test/image_test.py
+++ b/menpo/image/test/image_test.py
@@ -200,17 +200,9 @@ def test_boolean_image_from_vector_no_copy_raises():
         assert len(w) == 1
 
 
-def test_boolean_image_invert_inplace():
+def test_boolean_image_invert_double_noop():
     image = BooleanImage.init_blank((4, 4))
-    image.invert_inplace()
-    assert(np.all(~image.pixels))
-
-
-def test_boolean_image_invert_inplace_double_noop():
-    image = BooleanImage.init_blank((4, 4))
-    image.invert_inplace()
-    image.invert_inplace()
-    assert(np.all(image.pixels))
+    assert(np.all(image.invert().invert().pixels))
 
 
 def test_boolean_image_invert():

--- a/menpo/image/test/image_test.py
+++ b/menpo/image/test/image_test.py
@@ -417,9 +417,9 @@ def test_normalize_std_image():
     pixels[0] = 0.5
     pixels[1] = 0.2345
     image = Image(pixels)
-    image.normalize_std_inplace()
-    assert_allclose(np.mean(image.pixels), 0, atol=1e-10)
-    assert_allclose(np.std(image.pixels), 1)
+    new_image = image.normalize_std()
+    assert_allclose(np.mean(new_image.pixels), 0, atol=1e-10)
+    assert_allclose(np.std(new_image.pixels), 1)
 
 
 def test_normalize_norm_image():
@@ -427,9 +427,9 @@ def test_normalize_norm_image():
     pixels[0] = 0.5
     pixels[1] = 0.2345
     image = Image(pixels)
-    image.normalize_norm_inplace()
-    assert_allclose(np.mean(image.pixels), 0, atol=1e-10)
-    assert_allclose(np.linalg.norm(image.pixels), 1)
+    new_image = image.normalize_norm()
+    assert_allclose(np.mean(new_image.pixels), 0, atol=1e-10)
+    assert_allclose(np.linalg.norm(new_image.pixels), 1)
 
 
 @raises(ValueError)
@@ -438,14 +438,14 @@ def test_normalize_std_no_variance_exception():
     pixels[0] = 0.5
     pixels[1] = 0.2345
     image = MaskedImage(pixels)
-    image.normalize_std_inplace(mode='per_channel')
+    image.normalize_std(mode='per_channel')
 
 
 @raises(ValueError)
 def test_normalize_norm_zero_norm_exception():
     pixels = np.zeros((3, 120, 120))
     image = MaskedImage(pixels)
-    image.normalize_norm_inplace(mode='per_channel')
+    image.normalize_norm(mode='per_channel')
 
 
 def test_normalize_std_masked_per_channel():
@@ -454,11 +454,11 @@ def test_normalize_std_masked_per_channel():
     pixels[1] += -14
     pixels[2] /= 130
     image = MaskedImage(pixels)
-    image.normalize_std_inplace(mode='per_channel')
+    new_image = image.normalize_std(mode='per_channel')
     assert_allclose(
-        np.mean(image.as_vector(keep_channels=True), axis=1), 0, atol=1e-10)
+        np.mean(new_image.as_vector(keep_channels=True), axis=1), 0, atol=1e-10)
     assert_allclose(
-        np.std(image.as_vector(keep_channels=True), axis=1), 1)
+        np.std(new_image.as_vector(keep_channels=True), axis=1), 1)
 
 
 def test_normalize_std_image_per_channel():
@@ -467,11 +467,12 @@ def test_normalize_std_image_per_channel():
     pixels[0] += -3
     pixels[2] /= 140
     image = Image(pixels)
-    image.normalize_std_inplace(mode='per_channel')
+    new_image = image.normalize_std(mode='per_channel')
     assert_allclose(
-        np.mean(image.as_vector(keep_channels=True), axis=1), 0, atol=1e-10)
+        np.mean(new_image.as_vector(keep_channels=True), axis=1), 0,
+        atol=1e-10)
     assert_allclose(
-        np.std(image.as_vector(keep_channels=True), axis=1), 1)
+        np.std(new_image.as_vector(keep_channels=True), axis=1), 1)
 
 
 def test_normalize_norm_image_per_channel():
@@ -480,11 +481,12 @@ def test_normalize_norm_image_per_channel():
     pixels[0] += -114
     pixels[2] /= 30
     image = Image(pixels)
-    image.normalize_norm_inplace(mode='per_channel')
+    new_image = image.normalize_norm(mode='per_channel')
     assert_allclose(
-        np.mean(image.as_vector(keep_channels=True), axis=1), 0, atol=1e-10)
+        np.mean(new_image.as_vector(keep_channels=True), axis=1), 0,
+        atol=1e-10)
     assert_allclose(
-        np.linalg.norm(image.as_vector(keep_channels=True), axis=1), 1)
+        np.linalg.norm(new_image.as_vector(keep_channels=True), axis=1), 1)
 
 
 def test_normalize_norm_masked_per_channel():
@@ -493,11 +495,12 @@ def test_normalize_norm_masked_per_channel():
     pixels[0] += -14
     pixels[2] /= 130
     image = MaskedImage(pixels)
-    image.normalize_norm_inplace(mode='per_channel')
+    new_image = image.normalize_norm(mode='per_channel')
     assert_allclose(
-        np.mean(image.as_vector(keep_channels=True), axis=1), 0, atol=1e-10)
+        np.mean(new_image.as_vector(keep_channels=True), axis=1), 0,
+        atol=1e-10)
     assert_allclose(
-        np.linalg.norm(image.as_vector(keep_channels=True), axis=1), 1)
+        np.linalg.norm(new_image.as_vector(keep_channels=True), axis=1), 1)
 
 
 def test_normalize_std_masked():
@@ -508,11 +511,12 @@ def test_normalize_std_masked():
     mask = np.zeros((120, 120))
     mask[30:50, 20:30] = 1
     image = MaskedImage(pixels, mask=mask)
-    image.normalize_std_inplace(mode='per_channel', limit_to_mask=True)
+    new_image = image.normalize_std(mode='per_channel', limit_to_mask=True)
     assert_allclose(
-        np.mean(image.as_vector(keep_channels=True), axis=1), 0, atol=1e-10)
+        np.mean(new_image.as_vector(keep_channels=True), axis=1), 0,
+        atol=1e-10)
     assert_allclose(
-        np.std(image.as_vector(keep_channels=True), axis=1), 1)
+        np.std(new_image.as_vector(keep_channels=True), axis=1), 1)
 
 
 def test_normalize_norm_masked():
@@ -523,11 +527,12 @@ def test_normalize_norm_masked():
     mask = np.zeros((120, 120))
     mask[30:50, 20:30] = 1
     image = MaskedImage(pixels, mask=mask)
-    image.normalize_norm_inplace(mode='per_channel', limit_to_mask=True)
+    new_image = image.normalize_norm(mode='per_channel', limit_to_mask=True)
     assert_allclose(
-        np.mean(image.as_vector(keep_channels=True), axis=1), 0, atol=1e-10)
+        np.mean(new_image.as_vector(keep_channels=True), axis=1), 0,
+        atol=1e-10)
     assert_allclose(
-        np.linalg.norm(image.as_vector(keep_channels=True), axis=1), 1)
+        np.linalg.norm(new_image.as_vector(keep_channels=True), axis=1), 1)
 
 
 def test_rescale_single_num():

--- a/menpo/image/test/image_update_from_vector_test.py
+++ b/menpo/image/test/image_update_from_vector_test.py
@@ -4,7 +4,7 @@ from menpo.image import *
 
 def update_im_from_vector(im):
     new_values = np.random.random(im.pixels.shape)
-    im.from_vector_inplace(new_values.flatten())
+    im._from_vector_inplace(new_values.flatten())
     assert im.pixels.shape == new_values.shape
     return new_values
 

--- a/menpo/shape/pointcloud.py
+++ b/menpo/shape/pointcloud.py
@@ -171,7 +171,7 @@ class PointCloud(Shape):
         """
         return {'points': self.points.tolist()}
 
-    def from_vector_inplace(self, vector):
+    def _from_vector_inplace(self, vector):
         r"""
         Updates the points of this PointCloud in-place with the reshaped points
         from the provided vector. Note that the vector should have the form

--- a/menpo/transform/base/__init__.py
+++ b/menpo/transform/base/__init__.py
@@ -1,6 +1,7 @@
+import warnings
 import numpy as np
 
-from menpo.base import Copyable
+from menpo.base import Copyable, MenpoDeprecationWarning
 
 
 class Transform(Copyable):
@@ -103,6 +104,9 @@ class Transform(Copyable):
         For internal performance-specific uses, see `_apply_inplace()`.
 
         """
+        warnings.warn('the public API for inplace operations is deprecated '
+                      'and will be removed in a future version of Menpo. '
+                      'Use .apply() instead.', MenpoDeprecationWarning)
         return self._apply_inplace(x, **args)
 
     def _apply_inplace(self, x, **kwargs):

--- a/menpo/transform/base/__init__.py
+++ b/menpo/transform/base/__init__.py
@@ -95,12 +95,26 @@ class Transform(Copyable):
         """
         raise NotImplementedError()
 
-    def apply_inplace(self, x, **kwargs):
+    def apply_inplace(self, *args, **kwargs):
+        r"""
+        Deprecated as public supported API, use the non-mutating `apply()`
+        instead.
+
+        For internal performance-specific uses, see `_apply_inplace()`.
+
+        """
+        return self._apply_inplace(x, **args)
+
+    def _apply_inplace(self, x, **kwargs):
         r"""
         Applies this transform to a :map:`Transformable` ``x`` destructively.
 
         Any ``kwargs`` will be passed to the specific transform :meth:`_apply`
         method.
+
+        Note that this is an inplace operation that should be used sparingly,
+        by internal API's where creating a copy of the transformed object is
+        expensive. It does not return anything, as the operation is inplace.
 
         Parameters
         ----------
@@ -108,11 +122,6 @@ class Transform(Copyable):
             The :map:`Transformable` object to be transformed.
         kwargs : `dict`
             Passed through to :meth:`_apply`.
-
-        Returns
-        -------
-        transformed : ``type(x)``
-            The transformed object
         """
 
         def transform(x_):

--- a/menpo/transform/base/composable.py
+++ b/menpo/transform/base/composable.py
@@ -228,6 +228,7 @@ class ComposableTransform(Transform):
         """
         raise NotImplementedError()
 
+
 class VComposable(object):
     r"""
     Mix-in for :map:`Vectorizable` :map:`ComposableTransform` s.
@@ -251,6 +252,7 @@ class VComposable(object):
             Vector to update the transform state with.
         """
         raise NotImplementedError()
+
 
 class TransformChain(ComposableTransform):
     r"""

--- a/menpo/transform/groupalign/procrustes.py
+++ b/menpo/transform/groupalign/procrustes.py
@@ -66,7 +66,7 @@ class GeneralizedProcrustesAnalysis(MultipleAlignment):
         # it's centre
         rescale = scale_about_centre(new_tgt,
                                      self.initial_target_scale / new_tgt.norm())
-        rescale.apply_inplace(new_tgt)
+        rescale._apply_inplace(new_tgt)
         # check to see if we have converged yet
         delta_target = np.linalg.norm(self.target.points - new_tgt.points)
         if delta_target < 1e-6:

--- a/menpo/transform/homogeneous/affine.py
+++ b/menpo/transform/homogeneous/affine.py
@@ -206,7 +206,7 @@ class Affine(Homogeneous):
         params = self.h_matrix - np.eye(self.n_dims + 1)
         return params[:self.n_dims, :].ravel(order='F')
 
-    def from_vector_inplace(self, p):
+    def _from_vector_inplace(self, p):
         r"""
         Updates this Affine in-place from the new parameters. See
         from_vector for details of the parameter format

--- a/menpo/transform/homogeneous/base.py
+++ b/menpo/transform/homogeneous/base.py
@@ -137,7 +137,7 @@ class Homogeneous(ComposableTransform, Vectorizable, VComposable, VInvertible):
         """
         # avoid the deepcopy with an efficient copy
         self_copy = self.copy()
-        self_copy.from_vector_inplace(vector)
+        self_copy._from_vector_inplace(vector)
         return self_copy
 
     def __str__(self):
@@ -250,7 +250,7 @@ class Homogeneous(ComposableTransform, Vectorizable, VComposable, VInvertible):
     def _as_vector(self):
         return self.h_matrix.ravel()
 
-    def from_vector_inplace(self, vector):
+    def _from_vector_inplace(self, vector):
         """
         Update the state of this object from a vector form.
 

--- a/menpo/transform/homogeneous/rotation.py
+++ b/menpo/transform/homogeneous/rotation.py
@@ -258,7 +258,7 @@ class Rotation(DiscreteAffine, Similarity):
         # TODO vectorizable rotations
         raise NotImplementedError("Rotations are not yet vectorizable")
 
-    def from_vector_inplace(self, p):
+    def _from_vector_inplace(self, p):
         r"""
         Returns an instance of the transform from the given parameters,
         expected to be in Fortran ordering.

--- a/menpo/transform/homogeneous/scale.py
+++ b/menpo/transform/homogeneous/scale.py
@@ -154,7 +154,7 @@ class NonUniformScale(DiscreteAffine, Affine):
         """
         return self.scale
 
-    def from_vector_inplace(self, vector):
+    def _from_vector_inplace(self, vector):
         r"""
         Updates the :class:`NonUniformScale` inplace.
 
@@ -268,7 +268,7 @@ class UniformScale(DiscreteAffine, Similarity):
         """
         return np.asarray(self.scale)
 
-    def from_vector_inplace(self, p):
+    def _from_vector_inplace(self, p):
         r"""
         Returns an instance of the transform from the given parameters,
         expected to be in Fortran ordering.
@@ -316,7 +316,7 @@ class AlignmentUniformScale(HomogFamilyAlignment, UniformScale):
         UniformScale.__init__(self, target.norm() / source.norm(),
                               source.n_dims)
 
-    def from_vector_inplace(self, p):
+    def _from_vector_inplace(self, p):
         r"""
         Returns an instance of the transform from the given parameters,
         expected to be in Fortran ordering.
@@ -326,7 +326,7 @@ class AlignmentUniformScale(HomogFamilyAlignment, UniformScale):
         p : `float`
             The parameter
         """
-        UniformScale.from_vector_inplace(self, p)
+        UniformScale._from_vector_inplace(self, p)
         self._sync_target_from_state()
 
     def _sync_state_from_target(self):

--- a/menpo/transform/homogeneous/similarity.py
+++ b/menpo/transform/homogeneous/similarity.py
@@ -138,7 +138,7 @@ class Similarity(Affine):
             raise ValueError("Only 2D and 3D Similarity transforms "
                              "are currently supported.")
 
-    def from_vector_inplace(self, p):
+    def _from_vector_inplace(self, p):
         r"""
         Returns an instance of the transform from the given parameters,
         expected to be in Fortran ordering.
@@ -218,7 +218,7 @@ class AlignmentSimilarity(HomogFamilyAlignment, Similarity):
         """
         return Similarity(self.h_matrix, skip_checks=True)
 
-    def from_vector_inplace(self, p):
+    def _from_vector_inplace(self, p):
         r"""
         Returns an instance of the transform from the given parameters,
         expected to be in Fortran ordering.
@@ -239,7 +239,7 @@ class AlignmentSimilarity(HomogFamilyAlignment, Similarity):
         DimensionalityError, NotImplementedError
             Only 2D transforms are supported.
         """
-        Similarity.from_vector_inplace(self, p)
+        Similarity._from_vector_inplace(self, p)
         self._sync_target_from_state()
 
 

--- a/menpo/transform/homogeneous/translation.py
+++ b/menpo/transform/homogeneous/translation.py
@@ -76,7 +76,7 @@ class Translation(DiscreteAffine, Similarity):
         """
         return self.h_matrix[:-1, -1]
 
-    def from_vector_inplace(self, p):
+    def _from_vector_inplace(self, p):
         r"""
         Updates the :class:`Translation` inplace.
 
@@ -113,7 +113,7 @@ class AlignmentTranslation(HomogFamilyAlignment, Translation):
         HomogFamilyAlignment.__init__(self, source, target)
         Translation.__init__(self, target.centre() - source.centre())
 
-    def from_vector_inplace(self, p):
+    def _from_vector_inplace(self, p):
         r"""
         Updates the :class:`Translation` inplace.
 
@@ -122,7 +122,7 @@ class AlignmentTranslation(HomogFamilyAlignment, Translation):
         vector : ``(n_dims,)`` `ndarray`
             The array of parameters.
         """
-        Translation.from_vector_inplace(self, p)
+        Translation._from_vector_inplace(self, p)
         self._sync_target_from_state()
 
     def _sync_state_from_target(self):

--- a/menpo/transform/test/base_invertable_test.py
+++ b/menpo/transform/test/base_invertable_test.py
@@ -12,7 +12,7 @@ class MockedVInvertable(VInvertible, Vectorizable):
     def __init__(self):
         self.vector = ones_vector
 
-    def from_vector_inplace(self, vector):
+    def _from_vector_inplace(self, vector):
         self.vector = vector
 
     def _as_vector(self):

--- a/menpo/transform/test/base_transform_test.py
+++ b/menpo/transform/test/base_transform_test.py
@@ -48,7 +48,7 @@ def transform_apply_inplace_x_transformable_test():
     mocked = Mock()
     mocked._transform_inplace.return_value = mocked
     tr = MockTransform()
-    no_return = tr.apply_inplace(mocked)
+    no_return = tr._apply_inplace(mocked)
 
     assert (no_return is None)
     assert mocked._transform_inplace.called
@@ -57,7 +57,7 @@ def transform_apply_inplace_x_transformable_test():
 @raises(ValueError)
 def transform_apply_inplace_x_not_transformable_test():
     tr = MockTransform()
-    tr.apply_inplace(x)
+    tr._apply_inplace(x)
 
 
 def transform_compose_before_test():

--- a/menpo/transform/test/h_align_test.py
+++ b/menpo/transform/test/h_align_test.py
@@ -350,7 +350,7 @@ def test_align_2d_translation_from_vector_inplace():
     # estimate the transform from source to source..
     estimate = AlignmentTranslation(source, source)
     # and update from_vector
-    estimate.from_vector_inplace(t_vec)
+    estimate._from_vector_inplace(t_vec)
     # check the estimates is correct
     assert_allclose(target.points,
                     estimate.target.points)

--- a/menpo/transform/test/h_scale_test.py
+++ b/menpo/transform/test/h_scale_test.py
@@ -49,7 +49,7 @@ def test_uniformscale2d_update_from_vector():
                      [0, new_scale, 0],
                      [0, 0, 1]])
 
-    uniform_scale.from_vector_inplace(new_scale)
+    uniform_scale._from_vector_inplace(new_scale)
     assert_almost_equal(uniform_scale.h_matrix, homo)
 
 
@@ -76,7 +76,7 @@ def test_nonuniformscale2d_update_from_vector():
                      [0, scale[1], 0],
                      [0, 0, 1]])
     tr = NonUniformScale(np.array([1, 2]))
-    tr.from_vector_inplace(scale)
+    tr._from_vector_inplace(scale)
     assert_almost_equal(tr.h_matrix, homo)
 
 

--- a/menpo/transform/test/homogeneous_test.py
+++ b/menpo/transform/test/homogeneous_test.py
@@ -227,7 +227,7 @@ def test_uniformscale2d_update_from_vector():
                      [0, new_scale, 0],
                      [0, 0, 1]])
 
-    uniform_scale.from_vector_inplace(new_scale)
+    uniform_scale._from_vector_inplace(new_scale)
     assert_equal(uniform_scale.h_matrix, homo)
 
 
@@ -254,7 +254,7 @@ def test_nonuniformscale2d_update_from_vector():
                      [0, scale[1], 0],
                      [0, 0, 1]])
     tr = NonUniformScale(np.array([1, 2]))
-    tr.from_vector_inplace(scale)
+    tr._from_vector_inplace(scale)
     assert_equal(tr.h_matrix, homo)
 
 
@@ -540,5 +540,5 @@ def test_homogeneous_from_vector_inplace():
     h = Homogeneous(np.eye(3))
     e = np.eye(3) * 2
     e[2, 2] = 1
-    h.from_vector_inplace(e.ravel())
+    h._from_vector_inplace(e.ravel())
     assert_allclose(h.h_matrix, e)


### PR DESCRIPTION
We've steadily been moving away from mutating our objects in place, prefering to, where possible, return new objects with the desired state:
```py
a = ...
a.foo()
# a is changed!
```
```py
a = ...
b = a.foo()
# a is unchanged!
```
We try and mark mutating operations with having `inplace` in the method name. This PR deprecates a number of these:

- `apply_inplace()*`
- `from_vector_inplace()*` 
- `normalize_std_inplace()`
- `normalize_norm_inplace()`

`*` in these cases the inplace variant still exists, but is now a private (`_`-prepended) method. We still use these methods in performance critical sections of menpo, but we are now strongly discouraging others from using them. 

This PR should be brought in after #651.