### PR TITLE
Bugfix and improvements in visualize package

### DIFF
--- a/conda/meta.yaml
+++ b/conda/meta.yaml
@@ -22,7 +22,7 @@ requirements:
     - cyvlfeat >=0.4.2,<0.5
 
     # Visualization
-    - matplotlib 1.4.*
+    - matplotlib >=1.4,<1.6
 
     # Test dependencies
     - mock 1.3.*

--- a/docs/source/api/menpo/visualize/index.rst
+++ b/docs/source/api/menpo/visualize/index.rst
@@ -46,4 +46,5 @@ Various
 .. toctree::
   :maxdepth: 1
 
+  plot_curve
   plot_gaussian_ellipses

--- a/docs/source/api/menpo/visualize/plot_curve.rst
+++ b/docs/source/api/menpo/visualize/plot_curve.rst
@@ -1,0 +1,7 @@
+.. _menpo-visualize-plot_curve:
+
+.. currentmodule:: menpo.visualize
+
+plot_curve
+==========
+.. autofunction:: plot_curve

--- a/menpo/image/base.py
+++ b/menpo/image/base.py
@@ -583,10 +583,16 @@ class Image(Vectorizable, Landmarkable, Viewable, LandmarkableViewable):
                 {ultralight, light, normal, regular, book, medium, roman,
                 semibold, demibold, demi, bold, heavy, extra bold, black}
 
-        axes_x_limits : (`float`, `float`) `tuple` or ``None``, optional
-            The limits of the x axis.
+        axes_x_limits : `float` or (`float`, `float`) or ``None``, optional
+            The limits of the x axis. If `float`, then it sets padding on the
+            right and left of the Image as a percentage of the Image's width. If
+            `tuple` or `list`, then it defines the axis limits. If ``None``, then
+            the limits are set automatically.
         axes_y_limits : (`float`, `float`) `tuple` or ``None``, optional
-            The limits of the y axis.
+            The limits of the y axis. If `float`, then it sets padding on the
+            top and bottom of the Image as a percentage of the Image's height. If
+            `tuple` or `list`, then it defines the axis limits. If ``None``, then
+            the limits are set automatically.
         axes_x_ticks : `list` or `tuple` or ``None``, optional
             The ticks of the x axis.
         axes_y_ticks : `list` or `tuple` or ``None``, optional
@@ -847,10 +853,16 @@ class Image(Vectorizable, Landmarkable, Viewable, LandmarkableViewable):
                 {ultralight, light, normal, regular, book, medium, roman,
                 semibold,demibold, demi, bold, heavy, extra bold, black}
 
-        axes_x_limits : (`float`, `float`) `tuple` or ``None`` optional
-            The limits of the x axis.
-        axes_y_limits : (`float`, `float`) `tuple` or ``None`` optional
-            The limits of the y axis.
+        axes_x_limits : `float` or (`float`, `float`) or ``None``, optional
+            The limits of the x axis. If `float`, then it sets padding on the
+            right and left of the Image as a percentage of the Image's width. If
+            `tuple` or `list`, then it defines the axis limits. If ``None``, then
+            the limits are set automatically.
+        axes_y_limits : (`float`, `float`) `tuple` or ``None``, optional
+            The limits of the y axis. If `float`, then it sets padding on the
+            top and bottom of the Image as a percentage of the Image's height. If
+            `tuple` or `list`, then it defines the axis limits. If ``None``, then
+            the limits are set automatically.
         axes_x_ticks : `list` or `tuple` or ``None``, optional
             The ticks of the x axis.
         axes_y_ticks : `list` or `tuple` or ``None``, optional

--- a/menpo/image/base.py
+++ b/menpo/image/base.py
@@ -533,7 +533,8 @@ class Image(Vectorizable, Landmarkable, Viewable, LandmarkableViewable):
                  render_axes=False, axes_font_name='sans-serif',
                  axes_font_size=10, axes_font_style='normal',
                  axes_font_weight='normal', axes_x_limits=None,
-                 axes_y_limits=None, figure_size=(10, 8)):
+                 axes_y_limits=None, axes_x_ticks=None, axes_y_ticks=None,
+                 figure_size=(10, 8)):
         r"""
         View the image using the default image viewer. This method will appear 
         on the Image as ``view`` if the Image is 2D.
@@ -586,6 +587,10 @@ class Image(Vectorizable, Landmarkable, Viewable, LandmarkableViewable):
             The limits of the x axis.
         axes_y_limits : (`float`, `float`) `tuple` or ``None``, optional
             The limits of the y axis.
+        axes_x_ticks : `list` or `tuple` or ``None``, optional
+            The ticks of the x axis.
+        axes_y_ticks : `list` or `tuple` or ``None``, optional
+            The ticks of the y axis.
         figure_size : (`float`, `float`) `tuple` or ``None``, optional
             The size of the figure in inches.
 
@@ -600,7 +605,8 @@ class Image(Vectorizable, Landmarkable, Viewable, LandmarkableViewable):
             render_axes=render_axes, axes_font_name=axes_font_name,
             axes_font_size=axes_font_size, axes_font_style=axes_font_style,
             axes_font_weight=axes_font_weight, axes_x_limits=axes_x_limits,
-            axes_y_limits=axes_y_limits, figure_size=figure_size)
+            axes_y_limits=axes_y_limits, axes_x_ticks=axes_x_ticks,
+            axes_y_ticks=axes_y_ticks, figure_size=figure_size)
 
     def view_widget(self, browser_style='buttons', figure_size=(10, 8),
                     style='coloured'):
@@ -655,6 +661,7 @@ class Image(Vectorizable, Landmarkable, Viewable, LandmarkableViewable):
                            axes_font_name='sans-serif', axes_font_size=10,
                            axes_font_style='normal', axes_font_weight='normal',
                            axes_x_limits=None, axes_y_limits=None,
+                           axes_x_ticks=None, axes_y_ticks=None,
                            figure_size=(10, 8)):
         """
         Visualize the landmarks. This method will appear on the Image as
@@ -844,6 +851,10 @@ class Image(Vectorizable, Landmarkable, Viewable, LandmarkableViewable):
             The limits of the x axis.
         axes_y_limits : (`float`, `float`) `tuple` or ``None`` optional
             The limits of the y axis.
+        axes_x_ticks : `list` or `tuple` or ``None``, optional
+            The ticks of the x axis.
+        axes_y_ticks : `list` or `tuple` or ``None``, optional
+            The ticks of the y axis.
         figure_size : (`float`, `float`) `tuple` or ``None`` optional
             The size of the figure in inches.
 
@@ -871,7 +882,7 @@ class Image(Vectorizable, Landmarkable, Viewable, LandmarkableViewable):
             legend_vertical_spacing, legend_border, legend_border_padding,
             legend_shadow, legend_rounded_corners, render_axes, axes_font_name,
             axes_font_size, axes_font_style, axes_font_weight, axes_x_limits,
-            axes_y_limits, figure_size)
+            axes_y_limits, axes_x_ticks, axes_y_ticks, figure_size)
 
     def crop(self, min_indices, max_indices, constrain_to_boundary=False,
              return_transform=False):

--- a/menpo/image/masked.py
+++ b/menpo/image/masked.py
@@ -428,10 +428,16 @@ class MaskedImage(Image):
                 {ultralight, light, normal, regular, book, medium, roman,
                 semibold, demibold, demi, bold, heavy, extra bold, black}
 
-        axes_x_limits : (`float`, `float`) `tuple` or ``None``, optional
-            The limits of the x axis.
+        axes_x_limits : `float` or (`float`, `float`) or ``None``, optional
+            The limits of the x axis. If `float`, then it sets padding on the
+            right and left of the Image as a percentage of the Image's width. If
+            `tuple` or `list`, then it defines the axis limits. If ``None``, then
+            the limits are set automatically.
         axes_y_limits : (`float`, `float`) `tuple` or ``None``, optional
-            The limits of the y axis.
+            The limits of the y axis. If `float`, then it sets padding on the
+            top and bottom of the Image as a percentage of the Image's height. If
+            `tuple` or `list`, then it defines the axis limits. If ``None``, then
+            the limits are set automatically.
         axes_x_ticks : `list` or `tuple` or ``None``, optional
             The ticks of the x axis.
         axes_y_ticks : `list` or `tuple` or ``None``, optional
@@ -671,10 +677,16 @@ class MaskedImage(Image):
                 {ultralight, light, normal, regular, book, medium, roman,
                 semibold,demibold, demi, bold, heavy, extra bold, black}
 
-        axes_x_limits : (`float`, `float`) `tuple` or ``None`` optional
-            The limits of the x axis.
-        axes_y_limits : (`float`, `float`) `tuple` or ``None`` optional
-            The limits of the y axis.
+        axes_x_limits : `float` or (`float`, `float`) or ``None``, optional
+            The limits of the x axis. If `float`, then it sets padding on the
+            right and left of the Image as a percentage of the Image's width. If
+            `tuple` or `list`, then it defines the axis limits. If ``None``, then
+            the limits are set automatically.
+        axes_y_limits : (`float`, `float`) `tuple` or ``None``, optional
+            The limits of the y axis. If `float`, then it sets padding on the
+            top and bottom of the Image as a percentage of the Image's height. If
+            `tuple` or `list`, then it defines the axis limits. If ``None``, then
+            the limits are set automatically.
         axes_x_ticks : `list` or `tuple` or ``None``, optional
             The ticks of the x axis.
         axes_y_ticks : `list` or `tuple` or ``None``, optional

--- a/menpo/image/masked.py
+++ b/menpo/image/masked.py
@@ -375,7 +375,8 @@ class MaskedImage(Image):
                  alpha=1., render_axes=False, axes_font_name='sans-serif',
                  axes_font_size=10, axes_font_style='normal',
                  axes_font_weight='normal', axes_x_limits=None,
-                 axes_y_limits=None, figure_size=(10, 8)):
+                 axes_y_limits=None, axes_x_ticks=None, axes_y_ticks=None,
+                 figure_size=(10, 8)):
         r"""
         View the image using the default image viewer. This method will appear
         on the Image as ``view`` if the Image is 2D.
@@ -431,6 +432,10 @@ class MaskedImage(Image):
             The limits of the x axis.
         axes_y_limits : (`float`, `float`) `tuple` or ``None``, optional
             The limits of the y axis.
+        axes_x_ticks : `list` or `tuple` or ``None``, optional
+            The ticks of the x axis.
+        axes_y_ticks : `list` or `tuple` or ``None``, optional
+            The ticks of the y axis.
         figure_size : (`float`, `float`) `tuple` or ``None``, optional
             The size of the figure in inches.
 
@@ -442,17 +447,13 @@ class MaskedImage(Image):
         mask = self.mask.mask if masked else None
         return ImageViewer(figure_id, new_figure, self.n_dims,
                            self.pixels, channels=channels,
-                           mask=mask).render(render_axes=render_axes,
-                                             axes_font_name=axes_font_name,
-                                             axes_font_size=axes_font_size,
-                                             axes_font_style=axes_font_style,
-                                             axes_font_weight=axes_font_weight,
-                                             axes_x_limits=axes_x_limits,
-                                             axes_y_limits=axes_y_limits,
-                                             figure_size=figure_size,
-                                             interpolation=interpolation,
-                                             cmap_name=cmap_name,
-                                             alpha=alpha)
+                           mask=mask).render(
+            interpolation=interpolation, cmap_name=cmap_name, alpha=alpha,
+            render_axes=render_axes, axes_font_name=axes_font_name,
+            axes_font_size=axes_font_size, axes_font_style=axes_font_style,
+            axes_font_weight=axes_font_weight, axes_x_limits=axes_x_limits,
+            axes_y_limits=axes_y_limits, axes_x_ticks=axes_x_ticks,
+            axes_y_ticks=axes_y_ticks, figure_size=figure_size)
 
     def _view_landmarks_2d(self, channels=None, masked=True, group=None,
                            with_labels=None, without_labels=None,
@@ -482,6 +483,7 @@ class MaskedImage(Image):
                            axes_font_name='sans-serif', axes_font_size=10,
                            axes_font_style='normal', axes_font_weight='normal',
                            axes_x_limits=None, axes_y_limits=None,
+                           axes_x_ticks=None, axes_y_ticks=None,
                            figure_size=(10, 8)):
         """
         Visualize the landmarks. This method will appear on the Image as
@@ -673,6 +675,10 @@ class MaskedImage(Image):
             The limits of the x axis.
         axes_y_limits : (`float`, `float`) `tuple` or ``None`` optional
             The limits of the y axis.
+        axes_x_ticks : `list` or `tuple` or ``None``, optional
+            The ticks of the x axis.
+        axes_y_ticks : `list` or `tuple` or ``None``, optional
+            The ticks of the y axis.
         figure_size : (`float`, `float`) `tuple` or ``None`` optional
             The size of the figure in inches.
 
@@ -699,7 +705,7 @@ class MaskedImage(Image):
             legend_vertical_spacing, legend_border, legend_border_padding,
             legend_shadow, legend_rounded_corners, render_axes, axes_font_name,
             axes_font_size, axes_font_style, axes_font_weight, axes_x_limits,
-            axes_y_limits, figure_size)
+            axes_y_limits, axes_x_ticks, axes_y_ticks, figure_size)
 
     def crop_to_true_mask(self, boundary=0, constrain_to_boundary=True,
                           return_transform=False):

--- a/menpo/landmark/base.py
+++ b/menpo/landmark/base.py
@@ -858,10 +858,16 @@ class LandmarkGroup(MutableMapping, Copyable, Viewable):
                             ``demibold``, ``demi``, ``bold``, ``heavy``,
                             ``extra bold``, ``black``}, optional
             The font weight of the axes.
-        axes_x_limits : (`float`, `float`) or `None`, optional
-            The limits of the x axis.
-        axes_y_limits : (`float`, `float`) or `None`, optional
-            The limits of the y axis.
+        axes_x_limits : `float` or (`float`, `float`) or ``None``, optional
+            The limits of the x axis. If `float`, then it sets padding on the
+            right and left of the LandmarkGroup as a percentage of the
+            LandmarkGroup's width. If `tuple` or `list`, then it defines the axis
+            limits. If ``None``, then the limits are set automatically.
+        axes_y_limits : (`float`, `float`) `tuple` or ``None``, optional
+            The limits of the y axis. If `float`, then it sets padding on the
+            top and bottom of the LandmarkGroup as a percentage of the
+            LandmarkGroup's height. If `tuple` or `list`, then it defines the
+            axis limits. If ``None``, then the limits are set automatically.
         axes_x_ticks : `list` or `tuple` or ``None``, optional
             The ticks of the x axis.
         axes_y_ticks : `list` or `tuple` or ``None``, optional

--- a/menpo/landmark/base.py
+++ b/menpo/landmark/base.py
@@ -721,7 +721,8 @@ class LandmarkGroup(MutableMapping, Copyable, Viewable):
                  legend_rounded_corners=False, render_axes=True,
                  axes_font_name='sans-serif', axes_font_size=10,
                  axes_font_style='normal', axes_font_weight='normal',
-                 axes_x_limits=None, axes_y_limits=None, figure_size=(10, 8)):
+                 axes_x_limits=None, axes_y_limits=None, axes_x_ticks=None,
+                 axes_y_ticks=None, figure_size=(10, 8)):
         """
         Visualize the landmark group.
 
@@ -861,6 +862,10 @@ class LandmarkGroup(MutableMapping, Copyable, Viewable):
             The limits of the x axis.
         axes_y_limits : (`float`, `float`) or `None`, optional
             The limits of the y axis.
+        axes_x_ticks : `list` or `tuple` or ``None``, optional
+            The ticks of the x axis.
+        axes_y_ticks : `list` or `tuple` or ``None``, optional
+            The ticks of the y axis.
         figure_size : (`float`, `float`) or `None`, optional
             The size of the figure in inches.
 
@@ -917,7 +922,8 @@ class LandmarkGroup(MutableMapping, Copyable, Viewable):
             render_axes=render_axes, axes_font_name=axes_font_name,
             axes_font_size=axes_font_size, axes_font_style=axes_font_style,
             axes_font_weight=axes_font_weight, axes_x_limits=axes_x_limits,
-            axes_y_limits=axes_y_limits, figure_size=figure_size)
+            axes_y_limits=axes_y_limits, axes_x_ticks=axes_x_ticks,
+            axes_y_ticks=axes_y_ticks, figure_size=figure_size)
 
     def _view_3d(self, figure_id=None, new_figure=False, **kwargs):
         try:

--- a/menpo/model/pca.py
+++ b/menpo/model/pca.py
@@ -791,13 +791,14 @@ class PCAVectorModel(MeanLinearModel):
         viewer : :map:`MatplotlibRenderer`
             The viewer object.
         """
-        from menpo.visualize import GraphPlotter
-        return GraphPlotter(figure_id=figure_id, new_figure=new_figure,
-                            x_axis=range(self.n_active_components),
-                            y_axis=[self.eigenvalues], title='Eigenvalues',
-                            x_label='Component Number', y_label='Eigenvalue',
-                            x_axis_limits=(0, self.n_active_components - 1),
-                            y_axis_limits=None).render(
+        from menpo.visualize import plot_curve
+        return plot_curve(
+            range(self.n_active_components), [self.eigenvalues],
+            figure_id=figure_id, new_figure=new_figure, legend_entries=None,
+            title='Eigenvalues', x_label='Component Number',
+            y_label='Eigenvalue',
+            axes_x_limits=[0, self.n_active_components - 1],
+            axes_y_limits=None, axes_x_ticks=None, axes_y_ticks=None,
             render_lines=render_lines, line_colour=line_colour,
             line_style=line_style, line_width=line_width,
             render_markers=render_markers, marker_style=marker_style,
@@ -806,9 +807,9 @@ class PCAVectorModel(MeanLinearModel):
             marker_edge_width=marker_edge_width, render_legend=False,
             render_axes=render_axes, axes_font_name=axes_font_name,
             axes_font_size=axes_font_size, axes_font_style=axes_font_style,
-            axes_font_weight=axes_font_weight, render_grid=render_grid,
-            grid_line_style=grid_line_style, grid_line_width=grid_line_width,
-            figure_size=figure_size)
+            axes_font_weight=axes_font_weight, figure_size=figure_size,
+            render_grid=render_grid, grid_line_style=grid_line_style,
+            grid_line_width=grid_line_width)
 
     def plot_eigenvalues_widget(self, figure_size=(10, 6), style='coloured'):
         r"""
@@ -940,15 +941,14 @@ class PCAVectorModel(MeanLinearModel):
         viewer : :map:`MatplotlibRenderer`
             The viewer object.
         """
-        from menpo.visualize import GraphPlotter
-        return GraphPlotter(figure_id=figure_id, new_figure=new_figure,
-                            x_axis=range(self.n_active_components),
-                            y_axis=[self.eigenvalues_ratio()],
-                            title='Variance Ratio of Eigenvalues',
-                            x_label='Component Number',
-                            y_label='Variance Ratio',
-                            x_axis_limits=(0, self.n_active_components - 1),
-                            y_axis_limits=None).render(
+        from menpo.visualize import plot_curve
+        return plot_curve(
+            range(self.n_active_components), [self.eigenvalues_ratio()],
+            figure_id=figure_id, new_figure=new_figure, legend_entries=None,
+            title='Variance Ratio of Eigenvalues', x_label='Component Number',
+            y_label='Variance Ratio',
+            axes_x_limits=[0, self.n_active_components - 1],
+            axes_y_limits=None, axes_x_ticks=None, axes_y_ticks=None,
             render_lines=render_lines, line_colour=line_colour,
             line_style=line_style, line_width=line_width,
             render_markers=render_markers, marker_style=marker_style,
@@ -957,9 +957,9 @@ class PCAVectorModel(MeanLinearModel):
             marker_edge_width=marker_edge_width, render_legend=False,
             render_axes=render_axes, axes_font_name=axes_font_name,
             axes_font_size=axes_font_size, axes_font_style=axes_font_style,
-            axes_font_weight=axes_font_weight, render_grid=render_grid,
-            grid_line_style=grid_line_style, grid_line_width=grid_line_width,
-            figure_size=figure_size)
+            axes_font_weight=axes_font_weight, figure_size=figure_size,
+            render_grid=render_grid, grid_line_style=grid_line_style,
+            grid_line_width=grid_line_width)
 
     def plot_eigenvalues_ratio_widget(self, figure_size=(10, 6),
                                       style='coloured'):
@@ -1099,15 +1099,15 @@ class PCAVectorModel(MeanLinearModel):
         viewer : :map:`MatplotlibRenderer`
             The viewer object.
         """
-        from menpo.visualize import GraphPlotter
-        return GraphPlotter(figure_id=figure_id, new_figure=new_figure,
-                            x_axis=range(self.n_active_components),
-                            y_axis=[self.eigenvalues_cumulative_ratio()],
-                            title='Cumulative Variance Ratio of Eigenvalues',
-                            x_label='Component Number',
-                            y_label='Cumulative Variance Ratio',
-                            x_axis_limits=(0, self.n_active_components - 1),
-                            y_axis_limits=None).render(
+        from menpo.visualize import plot_curve
+        return plot_curve(
+            range(self.n_active_components),
+            [self.eigenvalues_cumulative_ratio()], figure_id=figure_id,
+            new_figure=new_figure, legend_entries=None,
+            title='Cumulative Variance Ratio of Eigenvalues',
+            x_label='Component Number', y_label='Cumulative Variance Ratio',
+            axes_x_limits=[0, self.n_active_components - 1],
+            axes_y_limits=None, axes_x_ticks=None, axes_y_ticks=None,
             render_lines=render_lines, line_colour=line_colour,
             line_style=line_style, line_width=line_width,
             render_markers=render_markers, marker_style=marker_style,
@@ -1116,9 +1116,9 @@ class PCAVectorModel(MeanLinearModel):
             marker_edge_width=marker_edge_width, render_legend=False,
             render_axes=render_axes, axes_font_name=axes_font_name,
             axes_font_size=axes_font_size, axes_font_style=axes_font_style,
-            axes_font_weight=axes_font_weight, render_grid=render_grid,
-            grid_line_style=grid_line_style, grid_line_width=grid_line_width,
-            figure_size=figure_size)
+            axes_font_weight=axes_font_weight, figure_size=figure_size,
+            render_grid=render_grid, grid_line_style=grid_line_style,
+            grid_line_width=grid_line_width)
 
     def plot_eigenvalues_cumulative_ratio_widget(self, figure_size=(10, 6),
                                                  style='coloured'):

--- a/menpo/shape/graph.py
+++ b/menpo/shape/graph.py
@@ -1794,10 +1794,16 @@ class PointGraph(Graph, PointCloud):
                 {ultralight, light, normal, regular, book, medium, roman,
                 semibold, demibold, demi, bold, heavy, extra bold, black}
 
-        axes_x_limits : (`float`, `float`) `tuple` or ``None``, optional
-            The limits of the x axis.
+        axes_x_limits : `float` or (`float`, `float`) or ``None``, optional
+            The limits of the x axis. If `float`, then it sets padding on the
+            right and left of the PointGraph as a percentage of the PointGraph's
+            width. If `tuple` or `list`, then it defines the axis limits. If
+            ``None``, then the limits are set automatically.
         axes_y_limits : (`float`, `float`) `tuple` or ``None``, optional
-            The limits of the y axis.
+            The limits of the y axis. If `float`, then it sets padding on the
+            top and bottom of the PointGraph as a percentage of the PointGraph's
+            height. If `tuple` or `list`, then it defines the axis limits. If
+            ``None``, then the limits are set automatically.
         axes_x_ticks : `list` or `tuple` or ``None``, optional
             The ticks of the x axis.
         axes_y_ticks : `list` or `tuple` or ``None``, optional

--- a/menpo/shape/graph.py
+++ b/menpo/shape/graph.py
@@ -1714,7 +1714,7 @@ class PointGraph(Graph, PointCloud):
                 or
                 (3, ) ndarray
 
-        line_style : ``{-, --, -., :}``, optional
+        line_style : ``{'-', '--', '-.', ':'}``, optional
             The style of the lines.
         line_width : `float`, optional
             The width of the lines.

--- a/menpo/shape/graph.py
+++ b/menpo/shape/graph.py
@@ -1630,11 +1630,16 @@ class PointGraph(Graph, PointCloud):
                  line_style='-', line_width=1.,
                  render_markers=True, marker_style='o', marker_size=20,
                  marker_face_colour='k', marker_edge_colour='k',
-                 marker_edge_width=1., render_axes=True,
+                 marker_edge_width=1., render_numbering=False,
+                 numbers_horizontal_align='center',
+                 numbers_vertical_align='bottom',
+                 numbers_font_name='sans-serif', numbers_font_size=10,
+                 numbers_font_style='normal', numbers_font_weight='normal',
+                 numbers_font_colour='k', render_axes=True,
                  axes_font_name='sans-serif', axes_font_size=10,
                  axes_font_style='normal', axes_font_weight='normal',
-                 axes_x_limits=None, axes_y_limits=None, figure_size=(10, 8),
-                 label=None):
+                 axes_x_limits=None, axes_y_limits=None, axes_x_ticks=None,
+                 axes_y_ticks=None, figure_size=(10, 8), label=None):
         r"""
         Visualization of the PointGraph in 2D.
 
@@ -1688,6 +1693,36 @@ class PointGraph(Graph, PointCloud):
 
         marker_edge_width : `float`, optional
             The width of the markers' edge.
+        render_numbering : `bool`, optional
+            If ``True``, the landmarks will be numbered.
+        numbers_horizontal_align : ``{center, right, left}``, optional
+            The horizontal alignment of the numbers' texts.
+        numbers_vertical_align : ``{center, top, bottom, baseline}``, optional
+            The vertical alignment of the numbers' texts.
+        numbers_font_name : See Below, optional
+            The font of the numbers. Example options ::
+
+                {serif, sans-serif, cursive, fantasy, monospace}
+
+        numbers_font_size : `int`, optional
+            The font size of the numbers.
+        numbers_font_style : ``{normal, italic, oblique}``, optional
+            The font style of the numbers.
+        numbers_font_weight : See Below, optional
+            The font weight of the numbers.
+            Example options ::
+
+                {ultralight, light, normal, regular, book, medium, roman,
+                semibold, demibold, demi, bold, heavy, extra bold, black}
+
+        numbers_font_colour : See Below, optional
+            The font colour of the numbers.
+            Example options ::
+
+                {r, g, b, c, m, k, w}
+                or
+                (3, ) ndarray
+
         render_axes : `bool`, optional
             If ``True``, the axes will be rendered.
         axes_font_name : See Below, optional
@@ -1711,6 +1746,10 @@ class PointGraph(Graph, PointCloud):
             The limits of the x axis.
         axes_y_limits : (`float`, `float`) `tuple` or ``None``, optional
             The limits of the y axis.
+        axes_x_ticks : `list` or `tuple` or ``None``, optional
+            The ticks of the x axis.
+        axes_y_ticks : `list` or `tuple` or ``None``, optional
+            The ticks of the y axis.
         figure_size : (`float`, `float`) `tuple` or ``None``, optional
             The size of the figure in inches.
         label : `str`, optional
@@ -1731,10 +1770,19 @@ class PointGraph(Graph, PointCloud):
             marker_style=marker_style, marker_size=marker_size,
             marker_face_colour=marker_face_colour,
             marker_edge_colour=marker_edge_colour,
-            marker_edge_width=marker_edge_width, render_axes=render_axes,
+            marker_edge_width=marker_edge_width,
+            render_numbering=render_numbering,
+            numbers_horizontal_align=numbers_horizontal_align,
+            numbers_vertical_align=numbers_vertical_align,
+            numbers_font_name=numbers_font_name,
+            numbers_font_size=numbers_font_size,
+            numbers_font_style=numbers_font_style,
+            numbers_font_weight=numbers_font_weight,
+            numbers_font_colour=numbers_font_colour, render_axes=render_axes,
             axes_font_name=axes_font_name, axes_font_size=axes_font_size,
             axes_font_style=axes_font_style, axes_font_weight=axes_font_weight,
             axes_x_limits=axes_x_limits, axes_y_limits=axes_y_limits,
+            axes_x_ticks=axes_x_ticks, axes_y_ticks=axes_y_ticks,
             figure_size=figure_size, label=label)
         return renderer
 

--- a/menpo/shape/mesh/base.py
+++ b/menpo/shape/mesh/base.py
@@ -489,11 +489,16 @@ class TriMesh(PointCloud):
                  render_lines=True, line_colour='r', line_style='-',
                  line_width=1., render_markers=True, marker_style='o',
                  marker_size=20, marker_face_colour='k', marker_edge_colour='k',
-                 marker_edge_width=1., render_axes=True,
+                 marker_edge_width=1., render_numbering=False,
+                 numbers_horizontal_align='center',
+                 numbers_vertical_align='bottom',
+                 numbers_font_name='sans-serif', numbers_font_size=10,
+                 numbers_font_style='normal', numbers_font_weight='normal',
+                 numbers_font_colour='k', render_axes=True,
                  axes_font_name='sans-serif', axes_font_size=10,
                  axes_font_style='normal', axes_font_weight='normal',
-                 axes_x_limits=None, axes_y_limits=None, figure_size=(10, 8),
-                 label=None):
+                 axes_x_limits=None, axes_y_limits=None, axes_x_ticks=None,
+                 axes_y_ticks=None, figure_size=(10, 8), label=None):
         r"""
         Visualization of the TriMesh in 2D.
 
@@ -547,6 +552,36 @@ class TriMesh(PointCloud):
 
         marker_edge_width : `float`, optional
             The width of the markers' edge.
+        render_numbering : `bool`, optional
+            If ``True``, the landmarks will be numbered.
+        numbers_horizontal_align : ``{center, right, left}``, optional
+            The horizontal alignment of the numbers' texts.
+        numbers_vertical_align : ``{center, top, bottom, baseline}``, optional
+            The vertical alignment of the numbers' texts.
+        numbers_font_name : See Below, optional
+            The font of the numbers. Example options ::
+
+                {serif, sans-serif, cursive, fantasy, monospace}
+
+        numbers_font_size : `int`, optional
+            The font size of the numbers.
+        numbers_font_style : ``{normal, italic, oblique}``, optional
+            The font style of the numbers.
+        numbers_font_weight : See Below, optional
+            The font weight of the numbers.
+            Example options ::
+
+                {ultralight, light, normal, regular, book, medium, roman,
+                semibold, demibold, demi, bold, heavy, extra bold, black}
+
+        numbers_font_colour : See Below, optional
+            The font colour of the numbers.
+            Example options ::
+
+                {r, g, b, c, m, k, w}
+                or
+                (3, ) ndarray
+
         render_axes : `bool`, optional
             If ``True``, the axes will be rendered.
         axes_font_name : See Below, optional
@@ -570,6 +605,10 @@ class TriMesh(PointCloud):
             The limits of the x axis.
         axes_y_limits : (`float`, `float`) `tuple` or ``None``, optional
             The limits of the y axis.
+        axes_x_ticks : `list` or `tuple` or ``None``, optional
+            The ticks of the x axis.
+        axes_y_ticks : `list` or `tuple` or ``None``, optional
+            The ticks of the y axis.
         figure_size : (`float`, `float`) `tuple` or ``None``, optional
             The size of the figure in inches.
         label : `str`, optional
@@ -591,12 +630,20 @@ class TriMesh(PointCloud):
                 marker_style=marker_style, marker_size=marker_size,
                 marker_face_colour=marker_face_colour,
                 marker_edge_colour=marker_edge_colour,
-                marker_edge_width=marker_edge_width, render_axes=render_axes,
+                marker_edge_width=marker_edge_width,
+                render_numbering=render_numbering,
+                numbers_horizontal_align=numbers_horizontal_align,
+                numbers_vertical_align=numbers_vertical_align,
+                numbers_font_name=numbers_font_name,
+                numbers_font_size=numbers_font_size,
+                numbers_font_style=numbers_font_style,
+                numbers_font_weight=numbers_font_weight,
+                numbers_font_colour=numbers_font_colour, render_axes=render_axes,
                 axes_font_name=axes_font_name, axes_font_size=axes_font_size,
                 axes_font_style=axes_font_style,
                 axes_font_weight=axes_font_weight, axes_x_limits=axes_x_limits,
-                axes_y_limits=axes_y_limits, figure_size=figure_size,
-                label=label)
+                axes_y_limits=axes_y_limits, axes_x_ticks=axes_x_ticks,
+                axes_y_ticks=axes_y_ticks, figure_size=figure_size, label=label)
 
     def _view_3d(self, figure_id=None, new_figure=False, **kwargs):
         r"""

--- a/menpo/shape/mesh/base.py
+++ b/menpo/shape/mesh/base.py
@@ -601,10 +601,16 @@ class TriMesh(PointCloud):
                 {ultralight, light, normal, regular, book, medium, roman,
                 semibold, demibold, demi, bold, heavy, extra bold, black}
 
-        axes_x_limits : (`float`, `float`) `tuple` or ``None``, optional
-            The limits of the x axis.
+        axes_x_limits : `float` or (`float`, `float`) or ``None``, optional
+            The limits of the x axis. If `float`, then it sets padding on the
+            right and left of the TriMesh as a percentage of the TriMesh's
+            width. If `tuple` or `list`, then it defines the axis limits. If
+            ``None``, then the limits are set automatically.
         axes_y_limits : (`float`, `float`) `tuple` or ``None``, optional
-            The limits of the y axis.
+            The limits of the y axis. If `float`, then it sets padding on the
+            top and bottom of the TriMesh as a percentage of the TriMesh's
+            height. If `tuple` or `list`, then it defines the axis limits. If
+            ``None``, then the limits are set automatically.
         axes_x_ticks : `list` or `tuple` or ``None``, optional
             The ticks of the x axis.
         axes_y_ticks : `list` or `tuple` or ``None``, optional

--- a/menpo/shape/mesh/coloured.py
+++ b/menpo/shape/mesh/coloured.py
@@ -117,11 +117,16 @@ class ColouredTriMesh(TriMesh):
                  render_lines=True, line_colour='r', line_style='-',
                  line_width=1., render_markers=True, marker_style='o',
                  marker_size=20, marker_face_colour='k', marker_edge_colour='k',
-                 marker_edge_width=1., render_axes=True,
+                 marker_edge_width=1., render_numbering=False,
+                 numbers_horizontal_align='center',
+                 numbers_vertical_align='bottom',
+                 numbers_font_name='sans-serif', numbers_font_size=10,
+                 numbers_font_style='normal', numbers_font_weight='normal',
+                 numbers_font_colour='k', render_axes=True,
                  axes_font_name='sans-serif', axes_font_size=10,
                  axes_font_style='normal', axes_font_weight='normal',
-                 axes_x_limits=None, axes_y_limits=None, figure_size=(10, 8),
-                 label=None):
+                 axes_x_limits=None, axes_y_limits=None, axes_x_ticks=None,
+                 axes_y_ticks=None, figure_size=(10, 8), label=None):
         r"""
         Visualization of the TriMesh in 2D. Currently, explicit coloured TriMesh
         viewing is not supported, and therefore viewing falls back to uncoloured
@@ -177,6 +182,36 @@ class ColouredTriMesh(TriMesh):
 
         marker_edge_width : `float`, optional
             The width of the markers' edge.
+        render_numbering : `bool`, optional
+            If ``True``, the landmarks will be numbered.
+        numbers_horizontal_align : ``{center, right, left}``, optional
+            The horizontal alignment of the numbers' texts.
+        numbers_vertical_align : ``{center, top, bottom, baseline}``, optional
+            The vertical alignment of the numbers' texts.
+        numbers_font_name : See Below, optional
+            The font of the numbers. Example options ::
+
+                {serif, sans-serif, cursive, fantasy, monospace}
+
+        numbers_font_size : `int`, optional
+            The font size of the numbers.
+        numbers_font_style : ``{normal, italic, oblique}``, optional
+            The font style of the numbers.
+        numbers_font_weight : See Below, optional
+            The font weight of the numbers.
+            Example options ::
+
+                {ultralight, light, normal, regular, book, medium, roman,
+                semibold, demibold, demi, bold, heavy, extra bold, black}
+
+        numbers_font_colour : See Below, optional
+            The font colour of the numbers.
+            Example options ::
+
+                {r, g, b, c, m, k, w}
+                or
+                (3, ) ndarray
+
         render_axes : `bool`, optional
             If ``True``, the axes will be rendered.
         axes_font_name : See Below, optional
@@ -200,6 +235,10 @@ class ColouredTriMesh(TriMesh):
             The limits of the x axis.
         axes_y_limits : (`float`, `float`) `tuple` or ``None``, optional
             The limits of the y axis.
+        axes_x_ticks : `list` or `tuple` or ``None``, optional
+            The ticks of the x axis.
+        axes_y_ticks : `list` or `tuple` or ``None``, optional
+            The ticks of the y axis.
         figure_size : (`float`, `float`) `tuple` or ``None``, optional
             The size of the figure in inches.
         label : `str`, optional
@@ -227,8 +266,17 @@ class ColouredTriMesh(TriMesh):
             marker_style=marker_style, marker_size=marker_size,
             marker_face_colour=marker_face_colour,
             marker_edge_colour=marker_edge_colour,
-            marker_edge_width=marker_edge_width, render_axes=render_axes,
+            marker_edge_width=marker_edge_width,
+            render_numbering=render_numbering,
+            numbers_horizontal_align=numbers_horizontal_align,
+            numbers_vertical_align=numbers_vertical_align,
+            numbers_font_name=numbers_font_name,
+            numbers_font_size=numbers_font_size,
+            numbers_font_style=numbers_font_style,
+            numbers_font_weight=numbers_font_weight,
+            numbers_font_colour=numbers_font_colour, render_axes=render_axes,
             axes_font_name=axes_font_name, axes_font_size=axes_font_size,
             axes_font_style=axes_font_style, axes_font_weight=axes_font_weight,
             axes_x_limits=axes_x_limits, axes_y_limits=axes_y_limits,
+            axes_x_ticks=axes_x_ticks, axes_y_ticks=axes_y_ticks,
             figure_size=figure_size, label=label)

--- a/menpo/shape/mesh/coloured.py
+++ b/menpo/shape/mesh/coloured.py
@@ -231,10 +231,16 @@ class ColouredTriMesh(TriMesh):
                 {ultralight, light, normal, regular, book, medium, roman,
                 semibold, demibold, demi, bold, heavy, extra bold, black}
 
-        axes_x_limits : (`float`, `float`) `tuple` or ``None``, optional
-            The limits of the x axis.
+        axes_x_limits : `float` or (`float`, `float`) or ``None``, optional
+            The limits of the x axis. If `float`, then it sets padding on the
+            right and left of the TriMesh as a percentage of the TriMesh's
+            width. If `tuple` or `list`, then it defines the axis limits. If
+            ``None``, then the limits are set automatically.
         axes_y_limits : (`float`, `float`) `tuple` or ``None``, optional
-            The limits of the y axis.
+            The limits of the y axis. If `float`, then it sets padding on the
+            top and bottom of the TriMesh as a percentage of the TriMesh's
+            height. If `tuple` or `list`, then it defines the axis limits. If
+            ``None``, then the limits are set automatically.
         axes_x_ticks : `list` or `tuple` or ``None``, optional
             The ticks of the x axis.
         axes_y_ticks : `list` or `tuple` or ``None``, optional

--- a/menpo/shape/mesh/textured.py
+++ b/menpo/shape/mesh/textured.py
@@ -166,10 +166,16 @@ class TexturedTriMesh(TriMesh):
                  render_lines=True, line_colour='r', line_style='-',
                  line_width=1., render_markers=True, marker_style='o',
                  marker_size=20, marker_face_colour='k', marker_edge_colour='k',
-                 marker_edge_width=1., render_axes=True,
+                 marker_edge_width=1., render_numbering=False,
+                 numbers_horizontal_align='center',
+                 numbers_vertical_align='bottom',
+                 numbers_font_name='sans-serif', numbers_font_size=10,
+                 numbers_font_style='normal', numbers_font_weight='normal',
+                 numbers_font_colour='k', render_axes=True,
                  axes_font_name='sans-serif', axes_font_size=10,
                  axes_font_style='normal', axes_font_weight='normal',
-                 axes_x_limits=None, axes_y_limits=None, figure_size=(10, 8),
+                 axes_x_limits=None, axes_y_limits=None, axes_x_ticks=None,
+                 axes_y_ticks=None, figure_size=(10, 8),
                  label=None):
         r"""
         Visualization of the TriMesh in 2D. Currently, explicit textured TriMesh
@@ -226,6 +232,36 @@ class TexturedTriMesh(TriMesh):
 
         marker_edge_width : `float`, optional
             The width of the markers' edge.
+        render_numbering : `bool`, optional
+            If ``True``, the landmarks will be numbered.
+        numbers_horizontal_align : ``{center, right, left}``, optional
+            The horizontal alignment of the numbers' texts.
+        numbers_vertical_align : ``{center, top, bottom, baseline}``, optional
+            The vertical alignment of the numbers' texts.
+        numbers_font_name : See Below, optional
+            The font of the numbers. Example options ::
+
+                {serif, sans-serif, cursive, fantasy, monospace}
+
+        numbers_font_size : `int`, optional
+            The font size of the numbers.
+        numbers_font_style : ``{normal, italic, oblique}``, optional
+            The font style of the numbers.
+        numbers_font_weight : See Below, optional
+            The font weight of the numbers.
+            Example options ::
+
+                {ultralight, light, normal, regular, book, medium, roman,
+                semibold, demibold, demi, bold, heavy, extra bold, black}
+
+        numbers_font_colour : See Below, optional
+            The font colour of the numbers.
+            Example options ::
+
+                {r, g, b, c, m, k, w}
+                or
+                (3, ) ndarray
+
         render_axes : `bool`, optional
             If ``True``, the axes will be rendered.
         axes_font_name : See Below, optional
@@ -249,6 +285,10 @@ class TexturedTriMesh(TriMesh):
             The limits of the x axis.
         axes_y_limits : (`float`, `float`) `tuple` or ``None``, optional
             The limits of the y axis.
+        axes_x_ticks : `list` or `tuple` or ``None``, optional
+            The ticks of the x axis.
+        axes_y_ticks : `list` or `tuple` or ``None``, optional
+            The ticks of the y axis.
         figure_size : (`float`, `float`) `tuple` or ``None``, optional
             The size of the figure in inches.
         label : `str`, optional
@@ -276,10 +316,19 @@ class TexturedTriMesh(TriMesh):
             marker_style=marker_style, marker_size=marker_size,
             marker_face_colour=marker_face_colour,
             marker_edge_colour=marker_edge_colour,
-            marker_edge_width=marker_edge_width, render_axes=render_axes,
+            marker_edge_width=marker_edge_width,
+            render_numbering=render_numbering,
+            numbers_horizontal_align=numbers_horizontal_align,
+            numbers_vertical_align=numbers_vertical_align,
+            numbers_font_name=numbers_font_name,
+            numbers_font_size=numbers_font_size,
+            numbers_font_style=numbers_font_style,
+            numbers_font_weight=numbers_font_weight,
+            numbers_font_colour=numbers_font_colour, render_axes=render_axes,
             axes_font_name=axes_font_name, axes_font_size=axes_font_size,
             axes_font_style=axes_font_style, axes_font_weight=axes_font_weight,
             axes_x_limits=axes_x_limits, axes_y_limits=axes_y_limits,
+            axes_x_ticks=axes_x_ticks, axes_y_ticks=axes_y_ticks,
             figure_size=figure_size, label=label)
 
     def __str__(self):

--- a/menpo/shape/mesh/textured.py
+++ b/menpo/shape/mesh/textured.py
@@ -281,10 +281,16 @@ class TexturedTriMesh(TriMesh):
                 {ultralight, light, normal, regular, book, medium, roman,
                 semibold, demibold, demi, bold, heavy, extra bold, black}
 
-        axes_x_limits : (`float`, `float`) `tuple` or ``None``, optional
-            The limits of the x axis.
+        axes_x_limits : `float` or (`float`, `float`) or ``None``, optional
+            The limits of the x axis. If `float`, then it sets padding on the
+            right and left of the TriMesh as a percentage of the TriMesh's
+            width. If `tuple` or `list`, then it defines the axis limits. If
+            ``None``, then the limits are set automatically.
         axes_y_limits : (`float`, `float`) `tuple` or ``None``, optional
-            The limits of the y axis.
+            The limits of the y axis. If `float`, then it sets padding on the
+            top and bottom of the TriMesh as a percentage of the TriMesh's
+            height. If `tuple` or `list`, then it defines the axis limits. If
+            ``None``, then the limits are set automatically.
         axes_x_ticks : `list` or `tuple` or ``None``, optional
             The ticks of the x axis.
         axes_y_ticks : `list` or `tuple` or ``None``, optional

--- a/menpo/shape/pointcloud.py
+++ b/menpo/shape/pointcloud.py
@@ -320,11 +320,16 @@ class PointCloud(Shape):
     def _view_2d(self, figure_id=None, new_figure=False, image_view=True,
                  render_markers=True, marker_style='o', marker_size=20,
                  marker_face_colour='r', marker_edge_colour='k',
-                 marker_edge_width=1., render_axes=True,
+                 marker_edge_width=1., render_numbering=False,
+                 numbers_horizontal_align='center',
+                 numbers_vertical_align='bottom',
+                 numbers_font_name='sans-serif', numbers_font_size=10,
+                 numbers_font_style='normal', numbers_font_weight='normal',
+                 numbers_font_colour='k', render_axes=True,
                  axes_font_name='sans-serif', axes_font_size=10,
                  axes_font_style='normal', axes_font_weight='normal',
-                 axes_x_limits=None, axes_y_limits=None, figure_size=(10, 8),
-                 label=None, **kwargs):
+                 axes_x_limits=None, axes_y_limits=None, axes_x_ticks=None,
+                 axes_y_ticks=None, figure_size=(10, 8), label=None, **kwargs):
         r"""
         Visualization of the PointCloud in 2D.
 
@@ -337,20 +342,6 @@ class PointCloud(Shape):
         image_view : `bool`, optional
             If ``True`` the PointCloud will be viewed as if it is in the image
             coordinate system.
-        render_lines : `bool`, optional
-            If ``True``, the edges will be rendered.
-        line_colour : See Below, optional
-            The colour of the lines.
-            Example options::
-
-                {r, g, b, c, m, k, w}
-                or
-                (3, ) ndarray
-
-        line_style : ``{-, --, -., :}``, optional
-            The style of the lines.
-        line_width : `float`, optional
-            The width of the lines.
         render_markers : `bool`, optional
             If ``True``, the markers will be rendered.
         marker_style : See Below, optional
@@ -378,6 +369,36 @@ class PointCloud(Shape):
 
         marker_edge_width : `float`, optional
             The width of the markers' edge.
+        render_numbering : `bool`, optional
+            If ``True``, the landmarks will be numbered.
+        numbers_horizontal_align : ``{center, right, left}``, optional
+            The horizontal alignment of the numbers' texts.
+        numbers_vertical_align : ``{center, top, bottom, baseline}``, optional
+            The vertical alignment of the numbers' texts.
+        numbers_font_name : See Below, optional
+            The font of the numbers. Example options ::
+
+                {serif, sans-serif, cursive, fantasy, monospace}
+
+        numbers_font_size : `int`, optional
+            The font size of the numbers.
+        numbers_font_style : ``{normal, italic, oblique}``, optional
+            The font style of the numbers.
+        numbers_font_weight : See Below, optional
+            The font weight of the numbers.
+            Example options ::
+
+                {ultralight, light, normal, regular, book, medium, roman,
+                semibold, demibold, demi, bold, heavy, extra bold, black}
+
+        numbers_font_colour : See Below, optional
+            The font colour of the numbers.
+            Example options ::
+
+                {r, g, b, c, m, k, w}
+                or
+                (3, ) ndarray
+
         render_axes : `bool`, optional
             If ``True``, the axes will be rendered.
         axes_font_name : See Below, optional
@@ -401,6 +422,10 @@ class PointCloud(Shape):
             The limits of the x axis.
         axes_y_limits : (`float`, `float`) `tuple` or ``None``, optional
             The limits of the y axis.
+        axes_x_ticks : `list` or `tuple` or ``None``, optional
+            The ticks of the x axis.
+        axes_y_ticks : `list` or `tuple` or ``None``, optional
+            The ticks of the y axis.
         figure_size : (`float`, `float`) `tuple` or ``None``, optional
             The size of the figure in inches.
         label : `str`, optional
@@ -422,10 +447,19 @@ class PointCloud(Shape):
             marker_style=marker_style, marker_size=marker_size,
             marker_face_colour=marker_face_colour,
             marker_edge_colour=marker_edge_colour,
-            marker_edge_width=marker_edge_width, render_axes=render_axes,
+            marker_edge_width=marker_edge_width,
+            render_numbering=render_numbering,
+            numbers_horizontal_align=numbers_horizontal_align,
+            numbers_vertical_align=numbers_vertical_align,
+            numbers_font_name=numbers_font_name,
+            numbers_font_size=numbers_font_size,
+            numbers_font_style=numbers_font_style,
+            numbers_font_weight=numbers_font_weight,
+            numbers_font_colour=numbers_font_colour, render_axes=render_axes,
             axes_font_name=axes_font_name, axes_font_size=axes_font_size,
             axes_font_style=axes_font_style, axes_font_weight=axes_font_weight,
             axes_x_limits=axes_x_limits, axes_y_limits=axes_y_limits,
+            axes_x_ticks=axes_x_ticks, axes_y_ticks=axes_y_ticks,
             figure_size=figure_size, label=label)
         return renderer
 
@@ -456,6 +490,7 @@ class PointCloud(Shape):
                            axes_font_name='sans-serif', axes_font_size=10,
                            axes_font_style='normal', axes_font_weight='normal',
                            axes_x_limits=None, axes_y_limits=None,
+                           axes_x_ticks=None, axes_y_ticks=None,
                            figure_size=(10, 8)):
         """
         Visualize the landmarks. This method will appear on the Image as
@@ -629,6 +664,10 @@ class PointCloud(Shape):
             The limits of the x axis.
         axes_y_limits : (`float`, `float`) `tuple` or ``None`` optional
             The limits of the y axis.
+        axes_x_ticks : `list` or `tuple` or ``None``, optional
+            The ticks of the x axis.
+        axes_y_ticks : `list` or `tuple` or ``None``, optional
+            The ticks of the y axis.
         figure_size : (`float`, `float`) `tuple` or ``None`` optional
             The size of the figure in inches.
 
@@ -681,7 +720,8 @@ class PointCloud(Shape):
             render_axes=render_axes, axes_font_name=axes_font_name,
             axes_font_size=axes_font_size, axes_font_style=axes_font_style,
             axes_font_weight=axes_font_weight, axes_x_limits=axes_x_limits,
-            axes_y_limits=axes_y_limits, figure_size=figure_size)
+            axes_y_limits=axes_y_limits, axes_x_ticks=axes_x_ticks,
+            axes_y_ticks=axes_y_ticks, figure_size=figure_size)
 
         return landmark_view
 

--- a/menpo/shape/pointcloud.py
+++ b/menpo/shape/pointcloud.py
@@ -418,10 +418,16 @@ class PointCloud(Shape):
                 {ultralight, light, normal, regular, book, medium, roman,
                 semibold, demibold, demi, bold, heavy, extra bold, black}
 
-        axes_x_limits : (`float`, `float`) `tuple` or ``None``, optional
-            The limits of the x axis.
+        axes_x_limits : `float` or (`float`, `float`) or ``None``, optional
+            The limits of the x axis. If `float`, then it sets padding on the
+            right and left of the PointCloud as a percentage of the PointCloud's
+            width. If `tuple` or `list`, then it defines the axis limits. If
+            ``None``, then the limits are set automatically.
         axes_y_limits : (`float`, `float`) `tuple` or ``None``, optional
-            The limits of the y axis.
+            The limits of the y axis. If `float`, then it sets padding on the
+            top and bottom of the PointCloud as a percentage of the PointCloud's
+            height. If `tuple` or `list`, then it defines the axis limits. If
+            ``None``, then the limits are set automatically.
         axes_x_ticks : `list` or `tuple` or ``None``, optional
             The ticks of the x axis.
         axes_y_ticks : `list` or `tuple` or ``None``, optional
@@ -660,10 +666,16 @@ class PointCloud(Shape):
                 {ultralight, light, normal, regular, book, medium, roman,
                 semibold,demibold, demi, bold, heavy, extra bold, black}
 
-        axes_x_limits : (`float`, `float`) `tuple` or ``None`` optional
-            The limits of the x axis.
-        axes_y_limits : (`float`, `float`) `tuple` or ``None`` optional
-            The limits of the y axis.
+        axes_x_limits : `float` or (`float`, `float`) or ``None``, optional
+            The limits of the x axis. If `float`, then it sets padding on the
+            right and left of the PointCloud as a percentage of the PointCloud's
+            width. If `tuple` or `list`, then it defines the axis limits. If
+            ``None``, then the limits are set automatically.
+        axes_y_limits : (`float`, `float`) `tuple` or ``None``, optional
+            The limits of the y axis. If `float`, then it sets padding on the
+            top and bottom of the PointCloud as a percentage of the PointCloud's
+            height. If `tuple` or `list`, then it defines the axis limits. If
+            ``None``, then the limits are set automatically.
         axes_x_ticks : `list` or `tuple` or ``None``, optional
             The ticks of the x axis.
         axes_y_ticks : `list` or `tuple` or ``None``, optional

--- a/menpo/visualize/__init__.py
+++ b/menpo/visualize/__init__.py
@@ -2,7 +2,7 @@ from .base import (
     Renderer, Viewable, LandmarkableViewable, viewwrapper, Menpo3dMissingError,
     MenpowidgetsMissingError, PointGraphViewer2d, LandmarkViewer2d,
     ImageViewer2d, ImageViewer, AlignmentViewer2d, GraphPlotter,
-    view_image_landmarks, view_patches, plot_gaussian_ellipses)
+    view_image_landmarks, view_patches, plot_gaussian_ellipses, plot_curve)
 from .textutils import (print_progress, progress_bar_str, print_dynamic,
                         bytes_str)
 from .viewmatplotlib import MatplotlibRenderer

--- a/menpo/visualize/base.py
+++ b/menpo/visualize/base.py
@@ -380,24 +380,32 @@ def view_image_landmarks(image, channels, masked, group,
         raise ValueError('Image does not have landmarks attached, unable '
                          'to view landmarks.')
 
-    # Render self
+    # Parse axes limits
+    image_axes_x_limits = None
+    landmarks_axes_x_limits = axes_x_limits
+    if axes_x_limits is None:
+        image_axes_x_limits = landmarks_axes_x_limits = [0, image.width - 1]
+    image_axes_y_limits = None
+    landmarks_axes_y_limits = axes_y_limits
+    if axes_y_limits is None:
+        image_axes_y_limits = landmarks_axes_y_limits = [0, image.height - 1]
+
+    # Render image
     from menpo.image import MaskedImage
     if isinstance(image, MaskedImage):
         self_view = image.view(figure_id=figure_id, new_figure=new_figure,
                                channels=channels, masked=masked,
                                interpolation=interpolation, cmap_name=cmap_name,
-                               alpha=alpha, render_axes=render_axes)
+                               alpha=alpha, render_axes=render_axes,
+                               axes_x_limits=image_axes_x_limits,
+                               axes_y_limits=image_axes_y_limits)
     else:
         self_view = image.view(figure_id=figure_id, new_figure=new_figure,
                                channels=channels, interpolation=interpolation,
                                cmap_name=cmap_name, alpha=alpha,
-                               render_axes=render_axes)
-
-    # Make sure axes are constrained to the image size
-    if axes_x_limits is None:
-        axes_x_limits = [0, image.width - 1]
-    if axes_y_limits is None:
-        axes_y_limits = [0, image.height - 1]
+                               render_axes=render_axes,
+                               axes_x_limits=image_axes_x_limits,
+                               axes_y_limits=image_axes_y_limits)
 
     # Render landmarks
     # correct group label in legend
@@ -450,8 +458,9 @@ def view_image_landmarks(image, channels, masked, group,
             legend_rounded_corners=legend_rounded_corners,
             render_axes=render_axes, axes_font_name=axes_font_name,
             axes_font_size=axes_font_size, axes_font_style=axes_font_style,
-            axes_font_weight=axes_font_weight, axes_x_limits=axes_x_limits,
-            axes_y_limits=axes_y_limits, axes_x_ticks=axes_x_ticks,
+            axes_font_weight=axes_font_weight,
+            axes_x_limits=landmarks_axes_x_limits,
+            axes_y_limits=landmarks_axes_y_limits, axes_x_ticks=axes_x_ticks,
             axes_y_ticks=axes_y_ticks, figure_size=figure_size)
 
     return landmark_view
@@ -479,6 +488,7 @@ class MultipleImageViewer(ImageViewer):
                                           self.pixels_list).render(**kwargs)
         else:
             raise ValueError("Only 2D images are currently supported")
+
 
 # Patches visualization methods
 def render_rectangles_around_patches(centers, patch_shape, axes=None,
@@ -748,10 +758,16 @@ def view_patches(patches, patch_centers, patches_indices=None,
             {ultralight, light, normal, regular, book, medium, roman,
             semibold,demibold, demi, bold, heavy, extra bold, black}
 
-    axes_x_limits : (`float`, `float`) `tuple` or ``None`` optional
-        The limits of the x axis.
-    axes_y_limits : (`float`, `float`) `tuple` or ``None`` optional
-        The limits of the y axis.
+    axes_x_limits : `float` or (`float`, `float`) or ``None``, optional
+        The limits of the x axis. If `float`, then it sets padding on the
+        right and left of the shape as a percentage of the shape's width. If
+        `tuple` or `list`, then it defines the axis limits. If ``None``, then the
+        limits are set automatically.
+    axes_y_limits : (`float`, `float`) `tuple` or ``None``, optional
+        The limits of the y axis. If `float`, then it sets padding on the
+        top and bottom of the shape as a percentage of the shape's height. If
+        `tuple` or `list`, then it defines the axis limits. If ``None``, then the
+        limits are set automatically.
     figure_size : (`float`, `float`) `tuple` or ``None`` optional
         The size of the figure in inches.
 

--- a/menpo/visualize/base.py
+++ b/menpo/visualize/base.py
@@ -363,7 +363,8 @@ def view_image_landmarks(image, channels, masked, group,
                          legend_border, legend_border_padding, legend_shadow,
                          legend_rounded_corners, render_axes, axes_font_name,
                          axes_font_size, axes_font_style, axes_font_weight,
-                         axes_x_limits, axes_y_limits, figure_size):
+                         axes_x_limits, axes_y_limits, axes_x_ticks,
+                         axes_y_ticks, figure_size):
     r"""
     This is a helper method that abstracts away the fact that viewing
     images and masked images is identical apart from the mask. Therefore,
@@ -384,15 +385,13 @@ def view_image_landmarks(image, channels, masked, group,
     if isinstance(image, MaskedImage):
         self_view = image.view(figure_id=figure_id, new_figure=new_figure,
                                channels=channels, masked=masked,
-                               interpolation=interpolation,
-                               cmap_name=cmap_name,
-                               alpha=alpha)
+                               interpolation=interpolation, cmap_name=cmap_name,
+                               alpha=alpha, render_axes=render_axes)
     else:
         self_view = image.view(figure_id=figure_id, new_figure=new_figure,
-                               channels=channels,
-                               interpolation=interpolation,
-                               cmap_name=cmap_name,
-                               alpha=alpha)
+                               channels=channels, interpolation=interpolation,
+                               cmap_name=cmap_name, alpha=alpha,
+                               render_axes=render_axes)
 
     # Make sure axes are constrained to the image size
     if axes_x_limits is None:
@@ -401,6 +400,9 @@ def view_image_landmarks(image, channels, masked, group,
         axes_y_limits = [0, image.height - 1]
 
     # Render landmarks
+    # correct group label in legend
+    if group is None and image.landmarks.n_groups == 1:
+        group = image.landmarks.group_labels[0]
     landmark_view = None  # initialize viewer object
     # useful in order to visualize the legend only for the last axis object
     render_legend_tmp = False
@@ -414,7 +416,7 @@ def view_image_landmarks(image, channels, masked, group,
         # viewer
         landmark_view = image.landmarks[group].view(
             with_labels=with_labels, without_labels=without_labels,
-            figure_id=self_view.figure_id, new_figure=False,
+            group=group, figure_id=self_view.figure_id, new_figure=False,
             image_view=True, render_lines=render_lines,
             line_colour=line_colour, line_style=line_style,
             line_width=line_width, render_markers=render_markers,
@@ -449,7 +451,8 @@ def view_image_landmarks(image, channels, masked, group,
             render_axes=render_axes, axes_font_name=axes_font_name,
             axes_font_size=axes_font_size, axes_font_style=axes_font_style,
             axes_font_weight=axes_font_weight, axes_x_limits=axes_x_limits,
-            axes_y_limits=axes_y_limits, figure_size=figure_size)
+            axes_y_limits=axes_y_limits, axes_x_ticks=axes_x_ticks,
+            axes_y_ticks=axes_y_ticks, figure_size=figure_size)
 
     return landmark_view
 

--- a/menpo/visualize/base.py
+++ b/menpo/visualize/base.py
@@ -490,7 +490,271 @@ class MultipleImageViewer(ImageViewer):
             raise ValueError("Only 2D images are currently supported")
 
 
-# Patches visualization methods
+def plot_curve(x_axis, y_axis, figure_id=None, new_figure=True,
+               legend_entries=None, title='', x_label='', y_label='',
+               axes_x_limits=0., axes_y_limits=None, axes_x_ticks=None,
+               axes_y_ticks=None, render_lines=True, line_colour=None,
+               line_style='-', line_width=1, render_markers=True,
+               marker_style='o', marker_size=6, marker_face_colour=None,
+               marker_edge_colour='k', marker_edge_width=1., render_legend=True,
+               legend_title='', legend_font_name='sans-serif',
+               legend_font_style='normal', legend_font_size=10,
+               legend_font_weight='normal', legend_marker_scale=None,
+               legend_location=2, legend_bbox_to_anchor=(1.05, 1.),
+               legend_border_axes_pad=None, legend_n_columns=1,
+               legend_horizontal_spacing=None, legend_vertical_spacing=None,
+               legend_border=True, legend_border_padding=None,
+               legend_shadow=False, legend_rounded_corners=False,
+               render_axes=True, axes_font_name='sans-serif', axes_font_size=10,
+               axes_font_style='normal', axes_font_weight='normal',
+               figure_size=(10, 8), render_grid=True, grid_line_style='--',
+               grid_line_width=1):
+    r"""
+    Plot a single or multiple curves on the same figure.
+
+    Parameters
+    ----------
+    x_axis : `list` or `array`
+        The values of the horizontal axis. They are common for all curves.
+    y_axis : `list` of `lists` or `arrays`
+        A `list` with `lists` or `arrays` with the values of the vertical axis
+        for each curve.
+    figure_id : `object`, optional
+        The id of the figure to be used.
+    new_figure : `bool`, optional
+        If ``True``, a new figure is created.
+    legend_entries : `list of `str` or ``None``, optional
+        If `list` of `str`, it must have the same length as `errors` `list` and
+        each `str` will be used to name each curve. If ``None``, the CED curves
+        will be named as `'Curve %d'`.
+    title : `str`, optional
+        The figure's title.
+    x_label : `str`, optional
+        The label of the horizontal axis.
+    y_label : `str`, optional
+        The label of the vertical axis.
+    axes_x_limits : `float` or (`float`, `float`) or ``None``, optional
+        The limits of the x axis. If `float`, then it sets padding on the
+        right and left of the graph as a percentage of the curves' width. If
+        `tuple` or `list`, then it defines the axis limits. If ``None``, then the
+        limits are set automatically.
+    axes_y_limits : (`float`, `float`) `tuple` or ``None``, optional
+        The limits of the y axis. If `float`, then it sets padding on the
+        top and bottom of the graph as a percentage of the curves' height. If
+        `tuple` or `list`, then it defines the axis limits. If ``None``, then the
+        limits are set automatically.
+    axes_x_ticks : `list` or `tuple` or ``None``, optional
+        The ticks of the x axis.
+    axes_y_ticks : `list` or `tuple` or ``None``, optional
+        The ticks of the y axis.
+    render_lines : `bool` or `list` of `bool`, optional
+        If ``True``, the line will be rendered. If `bool`, this value will be
+        used for all curves. If `list`, a value must be specified for each
+        curve, thus it must have the same length as `y_axis`.
+    line_colour : `colour` or `list` of `colour` or ``None``, optional
+        The colour of the lines. If not a `list`, this value will be
+        used for all curves. If `list`, a value must be specified for each
+        curve, thus it must have the same length as `y_axis`. If ``None``, the
+        colours will be linearly sampled from jet colormap.
+        Example `colour` options are ::
+
+                {'r', 'g', 'b', 'c', 'm', 'k', 'w'}
+                or
+                (3, ) ndarray
+
+    line_style : ``{'-', '--', '-.', ':'}`` or `list` of those, optional
+        The style of the lines. If not a `list`, this value will be used for all
+        curves. If `list`, a value must be specified for each curve, thus it must
+        have the same length as `y_axis`.
+    line_width : `float` or `list` of `float`, optional
+        The width of the lines. If `float`, this value will be used for all
+        curves. If `list`, a value must be specified for each curve, thus it must
+        have the same length as `y_axis`.
+    render_markers : `bool` or `list` of `bool`, optional
+        If ``True``, the markers will be rendered. If `bool`, this value will be
+        used for all curves. If `list`, a value must be specified for each
+        curve, thus it must have the same length as `y_axis`.
+    marker_style : `marker` or `list` of `markers`, optional
+        The style of the markers. If not a `list`, this value will be used for
+        all curves. If `list`, a value must be specified for each curve, thus it
+        must have the same length as `y_axis`.
+        Example `marker` options ::
+
+                {'.', ',', 'o', 'v', '^', '<', '>', '+', 'x', 'D', 'd', 's',
+                 'p', '*', 'h', 'H', '1', '2', '3', '4', '8'}
+
+    marker_size : `int` or `list` of `int`, optional
+        The size of the markers in points^2. If `int`, this value will be used
+        for all curves. If `list`, a value must be specified for each curve, thus
+        it must have the same length as `y_axis`.
+    marker_face_colour : `colour` or `list` of `colour` or ``None``, optional
+        The face (filling) colour of the markers. If not a `list`, this value
+        will be used for all curves. If `list`, a value must be specified for
+        each curve, thus it must have the same length as `y_axis`. If ``None``,
+        the colours will be linearly sampled from jet colormap.
+        Example `colour` options are ::
+
+                {'r', 'g', 'b', 'c', 'm', 'k', 'w'}
+                or
+                (3, ) ndarray
+
+    marker_edge_colour : `colour` or `list` of `colour` or ``None``, optional
+        The edge colour of the markers. If not a `list`, this value will be used
+        for all curves. If `list`, a value must be specified for each curve, thus
+        it must have the same length as `y_axis`. If ``None``, the colours will
+        be linearly sampled from jet colormap.
+        Example `colour` options are ::
+
+                {'r', 'g', 'b', 'c', 'm', 'k', 'w'}
+                or
+                (3, ) ndarray
+
+    marker_edge_width : `float` or `list` of `float`, optional
+        The width of the markers' edge. If `float`, this value will be used for
+        all curves. If `list`, a value must be specified for each curve, thus it
+        must have the same length as `y_axis`.
+    render_legend : `bool`, optional
+        If ``True``, the legend will be rendered.
+    legend_title : `str`, optional
+        The title of the legend.
+    legend_font_name : See below, optional
+        The font of the legend.
+        Example options ::
+
+            {'serif', 'sans-serif', 'cursive', 'fantasy', 'monospace'}
+            
+    legend_font_style : ``{'normal', 'italic', 'oblique'}``, optional
+        The font style of the legend.
+    legend_font_size : `int`, optional
+        The font size of the legend.
+    legend_font_weight : See below, optional
+        The font weight of the legend.
+        Example options ::
+
+            {'ultralight', 'light', 'normal', 'regular', 'book', 'medium',
+             'roman', 'semibold', 'demibold', 'demi', 'bold', 'heavy',
+             'extra bold', 'black'}
+
+    legend_marker_scale : `float`, optional
+        The relative size of the legend markers with respect to the original
+    legend_location : `int`, optional
+        The location of the legend. The predefined values are:
+
+        =============== ===
+        'best'          0
+        'upper right'   1
+        'upper left'    2
+        'lower left'    3
+        'lower right'   4
+        'right'         5
+        'center left'   6
+        'center right'  7
+        'lower center'  8
+        'upper center'  9
+        'center'        10
+        =============== ===
+
+    legend_bbox_to_anchor : (`float`, `float`), optional
+        The bbox that the legend will be anchored.
+    legend_border_axes_pad : `float`, optional
+        The pad between the axes and legend border.
+    legend_n_columns : `int`, optional
+        The number of the legend's columns.
+    legend_horizontal_spacing : `float`, optional
+        The spacing between the columns.
+    legend_vertical_spacing : `float`, optional
+        The vertical space between the legend entries.
+    legend_border : `bool`, optional
+        If ``True``, a frame will be drawn around the legend.
+    legend_border_padding : `float`, optional
+        The fractional whitespace inside the legend border.
+    legend_shadow : `bool`, optional
+        If ``True``, a shadow will be drawn behind legend.
+    legend_rounded_corners : `bool`, optional
+        If ``True``, the frame's corners will be rounded (fancybox).
+    render_axes : `bool`, optional
+        If ``True``, the axes will be rendered.
+    axes_font_name : See below, optional
+        The font of the axes.
+        Example options ::
+
+            {'serif', 'sans-serif', 'cursive', 'fantasy', 'monospace'}
+
+    axes_font_size : `int`, optional
+        The font size of the axes.
+    axes_font_style : ``{'normal', 'italic', 'oblique'}``, optional
+        The font style of the axes.
+    axes_font_weight : See below, optional
+        The font weight of the axes.
+        Example options ::
+
+            {'ultralight', 'light', 'normal', 'regular', 'book', 'medium',
+             'roman', 'semibold', 'demibold', 'demi', 'bold', 'heavy',
+             'extra bold', 'black'}
+
+    figure_size : (`float`, `float`) or ``None``, optional
+        The size of the figure in inches.
+    render_grid : `bool`, optional
+        If ``True``, the grid will be rendered.
+    grid_line_style : ``{'-', '--', '-.', ':'}``, optional
+        The style of the grid lines.
+    grid_line_width : `float`, optional
+        The width of the grid lines.
+
+    Raises
+    ------
+    ValueError
+        legend_entries list has different length than y_axis list
+
+    Returns
+    -------
+    viewer : :map:`GraphPlotter`
+        The viewer object.
+    """
+    from menpo.visualize import GraphPlotter
+
+    # check y_axis
+    if not isinstance(y_axis, list):
+        y_axis = [y_axis]
+
+    # check legend_entries
+    if legend_entries is not None and len(legend_entries) != len(y_axis):
+        raise ValueError('legend_entries list has different length than y_axis '
+                         'list')
+
+    # render
+    return GraphPlotter(figure_id=figure_id, new_figure=new_figure,
+                        x_axis=x_axis, y_axis=y_axis, title=title,
+                        legend_entries=legend_entries, x_label=x_label,
+                        y_label=y_label, x_axis_limits=axes_x_limits,
+                        y_axis_limits=axes_y_limits, x_axis_ticks=axes_x_ticks,
+                        y_axis_ticks=axes_y_ticks).render(
+        render_lines=render_lines, line_colour=line_colour,
+        line_style=line_style, line_width=line_width,
+        render_markers=render_markers, marker_style=marker_style,
+        marker_size=marker_size, marker_face_colour=marker_face_colour,
+        marker_edge_colour=marker_edge_colour,
+        marker_edge_width=marker_edge_width, render_legend=render_legend,
+        legend_title=legend_title, legend_font_name=legend_font_name,
+        legend_font_style=legend_font_style, legend_font_size=legend_font_size,
+        legend_font_weight=legend_font_weight,
+        legend_marker_scale=legend_marker_scale,
+        legend_location=legend_location,
+        legend_bbox_to_anchor=legend_bbox_to_anchor,
+        legend_border_axes_pad=legend_border_axes_pad,
+        legend_n_columns=legend_n_columns,
+        legend_horizontal_spacing=legend_horizontal_spacing,
+        legend_vertical_spacing=legend_vertical_spacing,
+        legend_border=legend_border,
+        legend_border_padding=legend_border_padding,
+        legend_shadow=legend_shadow,
+        legend_rounded_corners=legend_rounded_corners, render_axes=render_axes,
+        axes_font_name=axes_font_name, axes_font_size=axes_font_size,
+        axes_font_style=axes_font_style, axes_font_weight=axes_font_weight,
+        figure_size=figure_size, render_grid=render_grid,
+        grid_line_style=grid_line_style, grid_line_width=grid_line_width)
+
+
 def render_rectangles_around_patches(centers, patch_shape, axes=None,
                                      image_view=True, line_colour='r',
                                      line_style='-', line_width=1,

--- a/menpo/visualize/viewmatplotlib.py
+++ b/menpo/visualize/viewmatplotlib.py
@@ -2,6 +2,9 @@ import numpy as np
 
 from menpo.visualize.base import Renderer
 
+# GLOBAL_CMAP
+GLOBAL_CMAP = 'jet'
+
 
 class MatplotlibRenderer(Renderer):
     r"""
@@ -190,6 +193,118 @@ class MatplotlibSubplots(object):
         return True
 
 
+def _parse_cmap(cmap_name=None, image_shape_len=3):
+    import matplotlib.cm as cm
+    if cmap_name is not None:
+        return cm.get_cmap(cmap_name)
+    else:
+        if image_shape_len == 2:
+            # Single channels are viewed in Gray by default
+            return cm.gray
+        else:
+            return None
+
+
+def _correct_axes_limits(points, axes_x_limits, axes_y_limits, percentage=0.1):
+    if axes_x_limits is None:
+        min_x = np.min(points[:, 0])
+        max_x = np.max(points[:, 0])
+        pad = (max_x - min_x) * percentage
+        axes_x_limits = [min_x - pad, max_x + pad]
+    if axes_y_limits is None:
+        min_y = np.min(points[:, 1])
+        max_y = np.max(points[:, 1])
+        pad = (max_y - min_y) * percentage
+        axes_y_limits = [min_y - pad, max_y + pad]
+    return axes_x_limits, axes_y_limits
+
+
+def _set_axes_options(ax, render_axes=True, inverted_y_axis=False,
+                      axes_font_name='sans-serif', axes_font_size=10,
+                      axes_font_style='normal', axes_font_weight='normal',
+                      axes_x_limits=None, axes_y_limits=None, axes_x_ticks=None,
+                      axes_y_ticks=None):
+    if render_axes:
+        # render axes
+        ax.set_axis_on()
+        # set font options
+        for l in (ax.get_xticklabels() + ax.get_yticklabels()):
+            l.set_fontsize(axes_font_size)
+            l.set_fontname(axes_font_name)
+            l.set_fontstyle(axes_font_style)
+            l.set_fontweight(axes_font_weight)
+        # set ticks
+        if axes_x_ticks is not None:
+            ax.set_xticks(axes_x_ticks)
+        if axes_y_ticks is not None:
+            ax.set_yticks(axes_y_ticks)
+    else:
+        # do not render axes
+        ax.set_axis_off()
+        # also remove the ticks to get rid of the white area
+        ax.set_xticks([])
+        ax.set_yticks([])
+
+    # set axes limits
+    if axes_x_limits is not None:
+        ax.set_xlim(np.sort(axes_x_limits))
+    if axes_y_limits is None:
+        axes_y_limits = ax.get_ylim()
+    if inverted_y_axis:
+        ax.set_ylim(np.sort(axes_y_limits)[::-1])
+    else:
+        ax.set_ylim(np.sort(axes_y_limits))
+
+
+def _set_figure_size(fig, figure_size=(10, 8)):
+    if figure_size is not None:
+        fig.set_size_inches(np.asarray(figure_size))
+
+
+def _set_numbering(ax, centers, render_numbering=True,
+                   numbers_horizontal_align='center',
+                   numbers_vertical_align='bottom',
+                   numbers_font_name='sans-serif', numbers_font_size=10,
+                   numbers_font_style='normal', numbers_font_weight='normal',
+                   numbers_font_colour='k'):
+    if render_numbering:
+        for k, p in enumerate(centers):
+            ax.annotate(
+                str(k), xy=(p[0], p[1]),
+                horizontalalignment=numbers_horizontal_align,
+                verticalalignment=numbers_vertical_align,
+                size=numbers_font_size, family=numbers_font_name,
+                fontstyle=numbers_font_style, fontweight=numbers_font_weight,
+                color=numbers_font_colour)
+
+
+def _set_legend(ax, legend_handles, render_legend=True, legend_title='',
+                legend_font_name='sans-serif',
+                legend_font_style='normal', legend_font_size=10,
+                legend_font_weight='normal', legend_marker_scale=None,
+                legend_location=2, legend_bbox_to_anchor=(1.05, 1.),
+                legend_border_axes_pad=None, legend_n_columns=1,
+                legend_horizontal_spacing=None,
+                legend_vertical_spacing=None, legend_border=True,
+                legend_border_padding=None, legend_shadow=False,
+                legend_rounded_corners=False):
+    if render_legend:
+        # Options related to legend's font
+        prop = {'family': legend_font_name, 'size': legend_font_size,
+                'style': legend_font_style,
+                'weight': legend_font_weight}
+
+        # Render legend
+        ax.legend(
+            handles=legend_handles, title=legend_title, prop=prop,
+            loc=legend_location, bbox_to_anchor=legend_bbox_to_anchor,
+            borderaxespad=legend_border_axes_pad, ncol=legend_n_columns,
+            columnspacing=legend_horizontal_spacing,
+            labelspacing=legend_vertical_spacing, frameon=legend_border,
+            borderpad=legend_border_padding, shadow=legend_shadow,
+            fancybox=legend_rounded_corners, markerscale=legend_marker_scale)
+
+
 class MatplotlibImageViewer2d(MatplotlibRenderer):
     def __init__(self, figure_id, new_figure, image):
         super(MatplotlibImageViewer2d, self).__init__(figure_id, new_figure)
@@ -200,49 +315,32 @@ class MatplotlibImageViewer2d(MatplotlibRenderer):
                render_axes=False, axes_font_name='sans-serif',
                axes_font_size=10, axes_font_style='normal',
                axes_font_weight='normal', axes_x_limits=None,
-               axes_y_limits=None, figure_size=(10, 8)):
-        import matplotlib.cm as cm
+               axes_y_limits=None, axes_x_ticks=None, axes_y_ticks=None,
+               figure_size=(10, 8)):
         import matplotlib.pyplot as plt
 
-        if cmap_name is not None:
-            cmap = cm.get_cmap(cmap_name)
-        elif len(self.image.shape) == 2:
-            # Single channels are viewed in Gray by default
-            cmap = cm.Greys_r
-        else:
-            cmap = None
+        # parse colour map argument
+        cmap = _parse_cmap(cmap_name=cmap_name,
+                           image_shape_len=len(self.image.shape))
 
+        # render image
         plt.imshow(self.image, cmap=cmap, interpolation=interpolation,
                    alpha=alpha)
 
-        # render axes options
-        if render_axes:
-            plt.axis('on')
-            # set font options
-            for l in (plt.gca().get_xticklabels() +
-                      plt.gca().get_yticklabels()):
-                l.set_fontsize(axes_font_size)
-                l.set_fontname(axes_font_name)
-                l.set_fontstyle(axes_font_style)
-                l.set_fontweight(axes_font_weight)
-        else:
-            plt.axis('off')
-            plt.xticks([])
-            plt.yticks([])
-
-        # Set axes limits
-        if axes_x_limits is not None:
-            plt.xlim(axes_x_limits)
-        if axes_y_limits is not None:
-            plt.ylim(axes_y_limits[::-1])
-
-        # Set figure size
-        if figure_size is not None:
-            self.figure.set_size_inches(np.asarray(figure_size))
-
-        # Store axes object
+        # store axes object
         ax = plt.gca()
         self.axes_list = [ax]
+
+        # set axes options
+        _set_axes_options(
+            ax, render_axes=render_axes, inverted_y_axis=True,
+            axes_font_name=axes_font_name, axes_font_size=axes_font_size,
+            axes_font_style=axes_font_style, axes_font_weight=axes_font_weight,
+            axes_x_limits=axes_x_limits, axes_y_limits=axes_y_limits,
+            axes_x_ticks=axes_x_ticks, axes_y_ticks=axes_y_ticks)
+
+        # set figure size
+        _set_figure_size(self.figure, figure_size)
 
         return self
 
@@ -260,48 +358,35 @@ class MatplotlibImageSubplotsViewer2d(MatplotlibRenderer, MatplotlibSubplots):
                render_axes=False, axes_font_name='sans-serif',
                axes_font_size=10, axes_font_style='normal',
                axes_font_weight='normal', axes_x_limits=None,
-               axes_y_limits=None, figure_size=(10, 8)):
-        import matplotlib.cm as cm
+               axes_y_limits=None, axes_x_ticks=None, axes_y_ticks=None,
+               figure_size=(10, 8)):
         import matplotlib.pyplot as plt
+
+        # parse colour map argument
+        cmap = _parse_cmap(cmap_name=cmap_name, image_shape_len=2)
 
         p = self.plot_layout
         for i in range(self.image.shape[2]):
+            # create subplot and append the axes object
             ax = plt.subplot(p[0], p[1], 1 + i)
             self.axes_list.append(ax)
 
-            # render axes options
-            if render_axes:
-                plt.axis('on')
-                # set font options
-                for l in (plt.gca().get_xticklabels() +
-                          plt.gca().get_yticklabels()):
-                    l.set_fontsize(axes_font_size)
-                    l.set_fontname(axes_font_name)
-                    l.set_fontstyle(axes_font_style)
-                    l.set_fontweight(axes_font_weight)
-            else:
-                plt.axis('off')
-                plt.xticks([])
-                plt.yticks([])
-
-            # Set axes limits
-            if axes_x_limits is not None:
-                plt.xlim(axes_x_limits)
-            if axes_y_limits is not None:
-                plt.ylim(axes_y_limits[::-1])
-
-            if cmap_name is not None:
-                cmap = cm.get_cmap(cmap_name)
-            else:
-                # Single channels are viewed in Gray by default
-                cmap = cm.Greys_r
-
+            # render image
             plt.imshow(self.image[:, :, i], cmap=cmap,
                        interpolation=interpolation, alpha=alpha)
 
-        # Set figure size
-        if figure_size is not None:
-            self.figure.set_size_inches(np.asarray(figure_size))
+            # set axes options
+            _set_axes_options(
+                ax, render_axes=render_axes, inverted_y_axis=True,
+                axes_font_name=axes_font_name, axes_font_size=axes_font_size,
+                axes_font_style=axes_font_style,
+                axes_font_weight=axes_font_weight, axes_x_limits=axes_x_limits,
+                axes_y_limits=axes_y_limits, axes_x_ticks=axes_x_ticks,
+                axes_y_ticks=axes_y_ticks)
+
+        # set figure size
+        _set_figure_size(self.figure, figure_size)
+
         return self
 
 
@@ -315,21 +400,35 @@ class MatplotlibPointGraphViewer2d(MatplotlibRenderer):
     def render(self, image_view=False, render_lines=True, line_colour='r',
                line_style='-', line_width=1, render_markers=True,
                marker_style='o', marker_size=20, marker_face_colour='r',
-               marker_edge_colour='k', marker_edge_width=1., render_axes=True,
+               marker_edge_colour='k', marker_edge_width=1.,
+               render_numbering=False, numbers_horizontal_align='center',
+               numbers_vertical_align='bottom',
+               numbers_font_name='sans-serif', numbers_font_size=10,
+               numbers_font_style='normal', numbers_font_weight='normal',
+               numbers_font_colour='k', render_axes=True,
                axes_font_name='sans-serif', axes_font_size=10,
                axes_font_style='normal', axes_font_weight='normal',
-               axes_x_limits=None, axes_y_limits=None, figure_size=(10, 8),
-               label=None):
+               axes_x_limits=None, axes_y_limits=None, axes_x_ticks=None,
+               axes_y_ticks=None, figure_size=(10, 8), label=None):
         from matplotlib import collections as mc
-        import matplotlib.cm as cm
         import matplotlib.pyplot as plt
 
-        # Flip x and y for viewing if points are tied to an image
-        points = self.points[:, ::-1] if image_view else self.points
+        # check axes limits
+        axes_x_limits, axes_y_limits = _correct_axes_limits(
+            self.points, axes_x_limits, axes_y_limits)
 
+        # Flip x and y for viewing if points are tied to an image
+        if image_view:
+            points = self.points[:, ::-1]
+            axes_x_limits, axes_y_limits = axes_y_limits, axes_x_limits
+            axes_x_ticks, axes_y_ticks = axes_y_ticks, axes_x_ticks
+        else:
+            points = self.points
+
+        # get current axes object
         ax = plt.gca()
 
-        # Check if graph has edges to be rendered (for example a PointCLoud
+        # Check if graph has edges to be rendered (for example a PointCloud
         # won't have any edges)
         if render_lines and np.array(self.edges).shape[0] > 0:
             # Get edges to be rendered
@@ -339,53 +438,46 @@ class MatplotlibPointGraphViewer2d(MatplotlibRenderer):
             # Draw line objects
             lc = mc.LineCollection(lines, colors=line_colour,
                                    linestyles=line_style, linewidths=line_width,
-                                   cmap=cm.jet, label=label)
+                                   cmap=GLOBAL_CMAP, label=label)
             ax.add_collection(lc)
 
             # If a label is defined, it should only be applied to the lines, of
             # a PointGraph, which represent each one of the labels, unless a
-            # PointCLoud is passed in.
+            # PointCloud is passed in.
             label = None
             ax.autoscale()
 
         # Scatter
         if render_markers:
-            plt.scatter(points[:, 0], points[:, 1], cmap=cm.jet,
+            plt.scatter(points[:, 0], points[:, 1], cmap=GLOBAL_CMAP,
                         c=marker_face_colour, s=marker_size,
                         marker=marker_style, linewidths=marker_edge_width,
                         edgecolors=marker_edge_colour,
                         facecolors=marker_face_colour, label=label)
 
-        # Apply axes options
-        if render_axes:
-            plt.axis('on')
-            # set font options
-            for l in (plt.gca().get_xticklabels() +
-                      plt.gca().get_yticklabels()):
-                l.set_fontsize(axes_font_size)
-                l.set_fontname(axes_font_name)
-                l.set_fontstyle(axes_font_style)
-                l.set_fontweight(axes_font_weight)
-        else:
-            plt.axis('off')
-            plt.xticks([])
-            plt.yticks([])
+        # set numbering
+        _set_numbering(ax, points, render_numbering=render_numbering,
+                       numbers_horizontal_align=numbers_horizontal_align,
+                       numbers_vertical_align=numbers_vertical_align,
+                       numbers_font_name=numbers_font_name,
+                       numbers_font_size=numbers_font_size,
+                       numbers_font_style=numbers_font_style,
+                       numbers_font_weight=numbers_font_weight,
+                       numbers_font_colour=numbers_font_colour)
 
-        # Plot on image mode
-        if image_view:
-            plt.gca().set_aspect('equal', adjustable='box')
-            plt.gca().invert_yaxis()
+        # set axes options
+        _set_axes_options(
+            ax, render_axes=render_axes, inverted_y_axis=image_view,
+            axes_font_name=axes_font_name, axes_font_size=axes_font_size,
+            axes_font_style=axes_font_style, axes_font_weight=axes_font_weight,
+            axes_x_limits=axes_x_limits, axes_y_limits=axes_y_limits,
+            axes_x_ticks=axes_x_ticks, axes_y_ticks=axes_y_ticks)
 
-        # Set axes limits
-        if axes_x_limits is not None:
-            plt.xlim(axes_x_limits)
-        if axes_y_limits is not None:
-            plt.ylim(axes_y_limits[::-1]) if image_view \
-                else plt.ylim(axes_y_limits)
+        # set equal aspect ratio
+        ax.set_aspect('equal', adjustable='box')
 
-        # Set figure size
-        if figure_size is not None:
-            self.figure.set_size_inches(np.asarray(figure_size))
+        # set figure size
+        _set_figure_size(self.figure, figure_size)
 
         return self
 
@@ -419,10 +511,13 @@ class MatplotlibLandmarkViewer2d(MatplotlibRenderer):
                legend_rounded_corners=False, render_axes=True,
                axes_font_name='sans-serif', axes_font_size=10,
                axes_font_style='normal', axes_font_weight='normal',
-               axes_x_limits=None, axes_y_limits=None, figure_size=(10, 8)):
-        import matplotlib.pyplot as plt
+               axes_x_limits=None, axes_y_limits=None, axes_x_ticks=None,
+               axes_y_ticks=None, figure_size=(10, 8)):
         import matplotlib.lines as mlines
-        from menpo.shape import PointCloud, TriMesh
+        from menpo.shape import TriMesh
+        from menpo.shape.graph import PointGraph
+        import matplotlib.pyplot as plt
+
         # Regarding the labels colours, we may get passed either no colours (in
         # which case we generate random colours) or a single colour to colour
         # all the labels with
@@ -441,17 +536,20 @@ class MatplotlibLandmarkViewer2d(MatplotlibRenderer):
             'Must pass a list of marker edge colours with length n_labels or '
             'a single marker edge colour for all labels.')
 
-        # Get pointcloud of each label
+        # check axes limits
+        axes_x_limits, axes_y_limits = _correct_axes_limits(
+            self.pointcloud.points, axes_x_limits, axes_y_limits)
+
+        # get pointcloud of each label
         sub_pointclouds = self._build_sub_pointclouds()
 
-        # Initialize legend_handles list
+        # initialize legend_handles list
         legend_handles = []
 
+        # for each pointcloud
         for i, (label, pc) in enumerate(sub_pointclouds):
-            # Set kwargs assuming that the pointclouds are viewed using
-            # Matplotlib
-            pc.points = pc.points[:, ::-1] if image_view else pc.points
-            pc.view(figure_id=self.figure_id, image_view=False,
+            # render pointcloud
+            pc.view(figure_id=self.figure_id, image_view=image_view,
                     render_lines=render_lines, line_colour=line_colour[i],
                     line_style=line_style, line_width=line_width,
                     render_markers=render_markers, marker_style=marker_style,
@@ -459,31 +557,28 @@ class MatplotlibLandmarkViewer2d(MatplotlibRenderer):
                     marker_face_colour=marker_face_colour[i],
                     marker_edge_colour=marker_edge_colour[i],
                     marker_edge_width=marker_edge_width,
+                    render_numbering=render_numbering,
+                    numbers_horizontal_align=numbers_horizontal_align,
+                    numbers_vertical_align=numbers_vertical_align,
+                    numbers_font_name=numbers_font_name,
+                    numbers_font_size=numbers_font_size,
+                    numbers_font_style=numbers_font_style,
+                    numbers_font_weight=numbers_font_weight,
+                    numbers_font_colour=numbers_font_colour,
                     render_axes=render_axes, axes_font_name=axes_font_name,
                     axes_font_size=axes_font_size,
                     axes_font_style=axes_font_style,
-                    axes_font_weight=axes_font_weight, axes_x_limits=None,
-                    axes_y_limits=None, figure_size=figure_size)
-
-            ax = plt.gca()
-
-            if render_numbering:
-                for k, p in enumerate(pc.points):
-                    ax.annotate(str(k), xy=(p[0], p[1]),
-                                horizontalalignment=numbers_horizontal_align,
-                                verticalalignment=numbers_vertical_align,
-                                size=numbers_font_size,
-                                family=numbers_font_name,
-                                fontstyle=numbers_font_style,
-                                fontweight=numbers_font_weight,
-                                color=numbers_font_colour)
+                    axes_font_weight=axes_font_weight,
+                    axes_x_limits=axes_x_limits, axes_y_limits=axes_y_limits,
+                    axes_x_ticks=axes_x_ticks, axes_y_ticks=axes_y_ticks,
+                    figure_size=None)
 
             # set legend entry
             if render_legend:
-                tmp_line = line_style
-                if (not render_lines or isinstance(pc, PointCloud) or
-                        isinstance(pc, TriMesh)):
-                    tmp_line = 'None'
+                tmp_line = 'None'
+                if (render_lines and
+                        (isinstance(pc, PointGraph) or isinstance(pc, TriMesh))):
+                    tmp_line = line_style
                 tmp_marker = marker_style if render_markers else 'None'
                 legend_handles.append(
                     mlines.Line2D([], [], linewidth=line_width,
@@ -494,55 +589,26 @@ class MatplotlibLandmarkViewer2d(MatplotlibRenderer):
                                   markeredgecolor=marker_edge_colour[i],
                                   markerfacecolor=marker_face_colour[i],
                                   label='{0}: {1}'.format(self.group, label)))
+        # set legend
+        _set_legend(plt.gca(), legend_handles, render_legend=render_legend,
+                    legend_title=legend_title, legend_font_name=legend_font_name,
+                    legend_font_style=legend_font_style,
+                    legend_font_size=legend_font_size,
+                    legend_font_weight=legend_font_weight,
+                    legend_marker_scale=legend_marker_scale,
+                    legend_location=legend_location,
+                    legend_bbox_to_anchor=legend_bbox_to_anchor,
+                    legend_border_axes_pad=legend_border_axes_pad,
+                    legend_n_columns=legend_n_columns,
+                    legend_horizontal_spacing=legend_horizontal_spacing,
+                    legend_vertical_spacing=legend_vertical_spacing,
+                    legend_border=legend_border,
+                    legend_border_padding=legend_border_padding,
+                    legend_shadow=legend_shadow,
+                    legend_rounded_corners=legend_rounded_corners)
 
-        # Plot on image mode
-        if image_view:
-            plt.gca().set_aspect('equal', adjustable='box')
-            plt.gca().invert_yaxis()
-
-        if render_legend:
-            # Options related to legend's font
-            prop = {'family': legend_font_name, 'size': legend_font_size,
-                    'style': legend_font_style,
-                    'weight': legend_font_weight}
-
-            # Render legend
-            ax.legend(handles=legend_handles, title=legend_title, prop=prop,
-                      loc=legend_location, bbox_to_anchor=legend_bbox_to_anchor,
-                      borderaxespad=legend_border_axes_pad,
-                      ncol=legend_n_columns,
-                      columnspacing=legend_horizontal_spacing,
-                      labelspacing=legend_vertical_spacing,
-                      frameon=legend_border,
-                      borderpad=legend_border_padding, shadow=legend_shadow,
-                      fancybox=legend_rounded_corners,
-                      markerscale=legend_marker_scale)
-
-        # Apply axes options
-        if render_axes:
-            plt.axis('on')
-            # set font options
-            for l in (plt.gca().get_xticklabels() +
-                      plt.gca().get_yticklabels()):
-                l.set_fontsize(axes_font_size)
-                l.set_fontname(axes_font_name)
-                l.set_fontstyle(axes_font_style)
-                l.set_fontweight(axes_font_weight)
-        else:
-            plt.axis('off')
-            plt.xticks([])
-            plt.yticks([])
-
-        # Set axes limits
-        if axes_x_limits is not None:
-            plt.xlim(axes_x_limits)
-        if axes_y_limits is not None:
-            plt.ylim(axes_y_limits[::-1]) if image_view \
-                else plt.ylim(axes_y_limits)
-
-        # Set figure size
-        if figure_size is not None:
-            self.figure.set_size_inches(np.asarray(figure_size))
+        # set figure size
+        _set_figure_size(self.figure, figure_size)
 
         return self
 
@@ -856,7 +922,7 @@ def _check_colours_list(render_flag, colours_list, n_objects, error_str):
     if render_flag:
         if colours_list is None:
             # sample colours from jet colour map
-            colours_list = sample_colours_from_colourmap(n_objects, 'jet')
+            colours_list = sample_colours_from_colourmap(n_objects, GLOBAL_CMAP)
         if isinstance(colours_list, list):
             if len(colours_list) == 1:
                 colours_list *= n_objects

--- a/menpo/visualize/viewmatplotlib.py
+++ b/menpo/visualize/viewmatplotlib.py
@@ -414,16 +414,16 @@ class MatplotlibPointGraphViewer2d(MatplotlibRenderer):
         import matplotlib.pyplot as plt
 
         # check axes limits
-        axes_x_limits, axes_y_limits = _correct_axes_limits(
-            self.points, axes_x_limits, axes_y_limits)
+        # axes_x_limits, axes_y_limits = _correct_axes_limits(
+        #     self.points, axes_x_limits, axes_y_limits)
 
         # Flip x and y for viewing if points are tied to an image
         if image_view:
             points = self.points[:, ::-1]
-            axes_x_limits, axes_y_limits = axes_y_limits, axes_x_limits
-            axes_x_ticks, axes_y_ticks = axes_y_ticks, axes_x_ticks
         else:
             points = self.points
+            axes_x_limits, axes_y_limits = axes_y_limits, axes_x_limits
+            axes_x_ticks, axes_y_ticks = axes_y_ticks, axes_x_ticks
 
         # get current axes object
         ax = plt.gca()
@@ -537,8 +537,8 @@ class MatplotlibLandmarkViewer2d(MatplotlibRenderer):
             'a single marker edge colour for all labels.')
 
         # check axes limits
-        axes_x_limits, axes_y_limits = _correct_axes_limits(
-            self.pointcloud.points, axes_x_limits, axes_y_limits)
+        # axes_x_limits, axes_y_limits = _correct_axes_limits(
+        #     self.pointcloud.points, axes_x_limits, axes_y_limits)
 
         # get pointcloud of each label
         sub_pointclouds = self._build_sub_pointclouds()

--- a/menpo/visualize/viewmatplotlib.py
+++ b/menpo/visualize/viewmatplotlib.py
@@ -2,7 +2,7 @@ import numpy as np
 
 from menpo.visualize.base import Renderer
 
-# GLOBAL_CMAP
+# The colour map used for all lines and markers
 GLOBAL_CMAP = 'jet'
 
 
@@ -205,16 +205,13 @@ def _parse_cmap(cmap_name=None, image_shape_len=3):
             return None
 
 
-def _correct_axes_limits(points, axes_x_limits, axes_y_limits, percentage=0.1):
-    if axes_x_limits is None:
-        min_x = np.min(points[:, 0])
-        max_x = np.max(points[:, 0])
-        pad = (max_x - min_x) * percentage
+def _parse_axes_limits(min_x, max_x, min_y, max_y, axes_x_limits,
+                       axes_y_limits):
+    if isinstance(axes_x_limits, float):
+        pad = (max_x - min_x) * axes_x_limits
         axes_x_limits = [min_x - pad, max_x + pad]
-    if axes_y_limits is None:
-        min_y = np.min(points[:, 1])
-        max_y = np.max(points[:, 1])
-        pad = (max_y - min_y) * percentage
+    if isinstance(axes_y_limits, float):
+        pad = (max_y - min_y) * axes_y_limits
         axes_y_limits = [min_y - pad, max_y + pad]
     return axes_x_limits, axes_y_limits
 
@@ -323,6 +320,11 @@ class MatplotlibImageViewer2d(MatplotlibRenderer):
         cmap = _parse_cmap(cmap_name=cmap_name,
                            image_shape_len=len(self.image.shape))
 
+        # parse axes limits
+        axes_x_limits, axes_y_limits = _parse_axes_limits(
+            0., self.image.shape[1], 0., self.image.shape[0], axes_x_limits,
+            axes_y_limits)
+
         # render image
         plt.imshow(self.image, cmap=cmap, interpolation=interpolation,
                    alpha=alpha)
@@ -364,6 +366,11 @@ class MatplotlibImageSubplotsViewer2d(MatplotlibRenderer, MatplotlibSubplots):
 
         # parse colour map argument
         cmap = _parse_cmap(cmap_name=cmap_name, image_shape_len=2)
+
+        # parse axes limits
+        axes_x_limits, axes_y_limits = _parse_axes_limits(
+            0., self.image.shape[1], 0., self.image.shape[0], axes_x_limits,
+            axes_y_limits)
 
         p = self.plot_layout
         for i in range(self.image.shape[2]):
@@ -413,9 +420,11 @@ class MatplotlibPointGraphViewer2d(MatplotlibRenderer):
         from matplotlib import collections as mc
         import matplotlib.pyplot as plt
 
-        # check axes limits
-        # axes_x_limits, axes_y_limits = _correct_axes_limits(
-        #     self.points, axes_x_limits, axes_y_limits)
+        # parse axes limits
+        min_x, min_y = np.min(self.points, axis=0)
+        max_x, max_y = np.max(self.points, axis=0)
+        axes_x_limits, axes_y_limits = _parse_axes_limits(
+            min_x, max_x, min_y, max_y, axes_x_limits, axes_y_limits)
 
         # Flip x and y for viewing if points are tied to an image
         if image_view:

--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,7 @@ else:
     include_dirs = [np.get_include()]
     install_requires = ['numpy>=1.10,<1.11',
                         'scipy>=0.16,<0.17',
-                        'matplotlib>=1.5,<1.6',
+                        'matplotlib>=1.4,<1.6',
                         'pillow>=2.9,<2.10',
                         'Cython>=0.23,<0.24']
 

--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,7 @@ else:
     include_dirs = [np.get_include()]
     install_requires = ['numpy>=1.10,<1.11',
                         'scipy>=0.16,<0.17',
-                        'matplotlib>=1.4,<1.5',
+                        'matplotlib>=1.5,<1.6',
                         'pillow>=2.9,<2.10',
                         'Cython>=0.23,<0.24']
 


### PR DESCRIPTION
This PR fixes the following bugs:
* Corrects the viewing behaviour of `PointCloud` and `PointGraph` objects in case `image_view=True`, i.e. the way that the y axis gets inverted.
* Prints the `LandmarkGroup` name in the legend (before, it was only printing 'group').

It also adds the following:
*  Adds `axes_x_ticks` and  `axes_y_ticks` to all `view()` methods. This is especially useful when plotting curves (e.g. CED).
* Adds a new `plot_curve()` method in `menpo.visualize` that can plot multiple curves.
* Changes the `axes_x_limits` and `axes_y_limits` behaviour. Specifically, if `float`, then it sets padding around the object that is visualized defined as a percentage of the object's width. If `tuple` or `list`, then they define the axes limits. If ``None``, then the limits are set automatically.
* Adds the ability to print numbers on the points of a `PointCloud` or a `PointGraph`.

Finally, note that this PR also changes the `matplotlib` dependency to:
```
matplotlib>=1.5,<1.6
```
which removes an annoying warning that they used to print.