### PR TITLE
Use Conda environment.yml on RTD

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,6 +1,0 @@
-sphinx==1.3.1
-sphinx_rtd_theme==0.1.7
-sphinxmapxrefrole==0.2.1
-pathlib==1.0
-mock==1.3
-

--- a/docs/rtd_environment.yml
+++ b/docs/rtd_environment.yml
@@ -12,6 +12,7 @@ dependencies:
   - scipy=0.16.*
   - pillow=3.0.*
   - cyvlfeat>=0.4.2,<0.5
+  - imageio>=1.5.0,<1.6.0
   - matplotlib>=1.4,<1.6
   - mock=1.3.*
   - nose

--- a/docs/rtd_environment.yml
+++ b/docs/rtd_environment.yml
@@ -9,7 +9,7 @@ dependencies:
   - pathlib=1.0
 
   - numpy>=1.10,<1.11
-  - scipy=0.16.*
+  - scipy=0.17.*
   - pillow=3.0.*
   - cyvlfeat>=0.4.2,<0.5
   - imageio>=1.5.0,<1.6.0

--- a/docs/rtd_environment.yml
+++ b/docs/rtd_environment.yml
@@ -4,16 +4,16 @@ channels:
 dependencies:
   - python
   - setuptools
-  - numpy >=1.10,<1.11
-  - cython 0.23.*
-  - pathlib 1.0
+  - numpy>=1.10,<1.11
+  - cython=0.23.*
+  - pathlib=1.0
 
-  - numpy >=1.10,<1.11
-  - scipy 0.16.*
-  - pillow  3.0.*
-  - cyvlfeat >=0.4.2,<0.5
-  - matplotlib >=1.4,<1.6
-  - mock 1.3.*
+  - numpy>=1.10,<1.11
+  - scipy=0.16.*
+  - pillow=3.0.*
+  - cyvlfeat>=0.4.2,<0.5
+  - matplotlib>=1.4,<1.6
+  - mock=1.3.*
   - nose
   - pip:
       - sphinx==1.3.1

--- a/docs/rtd_environment.yml
+++ b/docs/rtd_environment.yml
@@ -1,0 +1,22 @@
+name: menpo_rtd
+channels:
+  - menpo
+dependencies:
+  - python
+  - setuptools
+  - numpy >=1.10,<1.11
+  - cython 0.23.*
+  - pathlib 1.0
+
+  - numpy >=1.10,<1.11
+  - scipy 0.16.*
+  - pillow  3.0.*
+  - cyvlfeat >=0.4.2,<0.5
+  - matplotlib >=1.4,<1.6
+  - mock 1.3.*
+  - nose
+  - pip:
+      - sphinx==1.3.1
+      - sphinx_rtd_theme==0.1.7
+      - sphinxmapxrefrole==0.2.1
+

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -1,6 +1,12 @@
 import sys
 import os
 
+
+# on_rtd is whether we are on readthedocs.org,
+# this line of code grabbed from docs.readthedocs.org
+on_rtd = os.environ.get('READTHEDOCS', None) == 'True'
+
+
 # Add the folder above so we can grab the sphinx extensions
 sys.path.insert(0, os.path.abspath('..'))
 # Add the menpo root so we can grab the version

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -6,11 +6,12 @@ import os
 # this line of code grabbed from docs.readthedocs.org
 on_rtd = os.environ.get('READTHEDOCS', None) == 'True'
 
-
 # Add the folder above so we can grab the sphinx extensions
 sys.path.insert(0, os.path.abspath('..'))
-# Add the menpo root so we can grab the version
-sys.path.insert(0, os.path.abspath('../../'))
+
+if not on_rtd:
+  # Add the menpo root so we can grab the version
+  sys.path.insert(0, os.path.abspath('../../'))
 
 import menpo
 

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -1,30 +1,6 @@
 import sys
 import os
 
-
-# on_rtd is whether we are on readthedocs.org,
-# this line of code grabbed from docs.readthedocs.org
-on_rtd = os.environ.get('READTHEDOCS', None) == 'True'
-
-if on_rtd:
-    from mock import MagicMock
-
-    MOCK_MODULES = ['numpy', 'scipy', 'PIL', 'sklearn',
-                    'scipy.linalg', 'numpy.stats', 'scipy.misc', 'PIL.Image',
-                    'matplotlib', 'matplotlib.pyplot', 'scipy.spatial',
-                    'scipy.spatial.distance', 'numpy.dtype', 'scipy.ndimage',
-                    'scipy.linalg.blas', 'scipy.sparse', 'cyvlfeat',
-                    'cyvlfeat.sift', 'cyvlfeat.sift.dsift']
-    # Masking our Cython modules
-    MOCK_MODULES += ['menpo.transform.piecewiseaffine.fastpwa',
-                     'menpo.feature.windowiterator',
-                     'menpo.shape.mesh.normals',
-                     'menpo.feature.gradient',
-                     'menpo.external.skimage._warps_cy',
-                     'menpo.image.patches']
-    for mod_name in MOCK_MODULES:
-        sys.modules[mod_name] = MagicMock()
-
 # Add the folder above so we can grab the sphinx extensions
 sys.path.insert(0, os.path.abspath('..'))
 # Add the menpo root so we can grab the version

--- a/readthedocs.yml
+++ b/readthedocs.yml
@@ -1,0 +1,8 @@
+formats:
+  - pdf
+
+conda:
+  file: docs/rtd_environment.yml
+
+requirements_file: None
+

--- a/readthedocs.yml
+++ b/readthedocs.yml
@@ -4,5 +4,3 @@ formats:
 conda:
   file: docs/rtd_environment.yml
 
-requirements_file: None
-

--- a/readthedocs.yml
+++ b/readthedocs.yml
@@ -4,3 +4,6 @@ formats:
 conda:
   file: docs/rtd_environment.yml
 
+python:
+   setup_py_install: true
+

--- a/setup.py
+++ b/setup.py
@@ -3,37 +3,29 @@ import sys
 from setuptools import setup, find_packages
 import versioneer
 import glob
+from Cython.Build import cythonize
+import numpy as np
 
 
-on_rtd = os.environ.get('READTHEDOCS', None) == 'True'
+# ---- C/C++ EXTENSIONS ---- #
+cython_modules = ['menpo/shape/mesh/normals.pyx',
+                  'menpo/transform/piecewiseaffine/fastpwa.pyx',
+                  'menpo/feature/windowiterator.pyx',
+                  'menpo/feature/gradient.pyx',
+                  'menpo/external/skimage/_warps_cy.pyx',
+                  'menpo/image/patches.pyx']
 
-if on_rtd:
-    install_requires = []
-    ext_modules = []
-    include_dirs = []
-    cython_exts = []
-else:
-    from Cython.Build import cythonize
-    import numpy as np
+cython_exts = cythonize(cython_modules, quiet=True)
+include_dirs = [np.get_include()]
+install_requires = ['numpy>=1.10,<1.11',
+                    'scipy>=0.16,<0.17',
+                    'matplotlib>=1.4,<1.6',
+                    'pillow>=3.0,<4.0',
+                    'Cython>=0.23,<0.24']
 
-    # ---- C/C++ EXTENSIONS ---- #
-    cython_modules = ['menpo/shape/mesh/normals.pyx',
-                      'menpo/transform/piecewiseaffine/fastpwa.pyx',
-                      'menpo/feature/windowiterator.pyx',
-                      'menpo/feature/gradient.pyx',
-                      'menpo/external/skimage/_warps_cy.pyx',
-                      'menpo/image/patches.pyx']
+if sys.version_info.major == 2:
+    install_requires.append('pathlib==1.0')
 
-    cython_exts = cythonize(cython_modules, quiet=True)
-    include_dirs = [np.get_include()]
-    install_requires = ['numpy>=1.10,<1.11',
-                        'scipy>=0.16,<0.17',
-                        'matplotlib>=1.4,<1.6',
-                        'pillow>=3.0,<4.0',
-                        'Cython>=0.23,<0.24']
-
-    if sys.version_info.major == 2:
-        install_requires.append('pathlib==1.0')
 
 setup(name='menpo',
       version=versioneer.get_version(),
@@ -53,3 +45,4 @@ setup(name='menpo',
                     '': ['*.pxd', '*.pyx']},
       tests_require=['nose', 'mock']
 )
+


### PR DESCRIPTION
This makes the `setup.py` much simpler and also means that we don't have to maintain a horrible list of Mocks in the docs `conf.py` which was error prone and frustrating. 

The downside is that the `docs/rtd_environment.yml` must be kept in sync with the `meta.yaml`. The environment yaml seems to be more sensitive to the `=` sign between requirements so we may want to try updating our `meta.yaml` so that you can just copy and paste to maintain it.