### PR TITLE
WIP: move towards immutable PCAModel

### DIFF
--- a/menpo/model/__init__.py
+++ b/menpo/model/__init__.py
@@ -1,4 +1,3 @@
-from .linear import (LinearVectorModel, MeanLinearVectorModel, LinearModel,
-                     MeanLinearModel)
+from .linear import LinearVectorModel, MeanLinearVectorModel
 from .pca import PCAModel, PCAVectorModel
 from .gmrf import GMRFModel, GMRFVectorModel

--- a/menpo/model/linear.py
+++ b/menpo/model/linear.py
@@ -14,7 +14,7 @@ class LinearVectorModel(Copyable):
     """
 
     def __init__(self, components):
-        self._components = components  # getter/setter variable
+        self.components = components  # getter/setter variable
 
     @property
     def n_components(self):
@@ -23,7 +23,7 @@ class LinearVectorModel(Copyable):
 
         :type: `int`
         """
-        return self._components.shape[0]
+        return self.components.shape[0]
 
     @property
     def n_features(self):
@@ -33,38 +33,6 @@ class LinearVectorModel(Copyable):
         :type: `int`
         """
         return self.components.shape[-1]
-
-    @property
-    def components(self):
-        r"""
-        The components matrix of the linear model.
-
-        :type: ``(n_available_components, n_features)`` `ndarray`
-        """
-        return self._components
-
-    @components.setter
-    def components(self, value):
-        r"""
-        Updates the components of this linear model, ensuring that the shape
-        of the components is not changed.
-
-        Parameters
-        ----------
-        value : ``(n_components, n_features)`` `ndarray`
-            The new components array.
-
-        Raises
-        ------
-        ValueError
-            Trying to replace components of shape {} with some of shape {}
-        """
-        if value.shape != self._components.shape:
-            raise ValueError(
-                "Trying to replace components of shape {} with some of "
-                "shape {}".format(self.components.shape, value.shape))
-        else:
-            np.copyto(self._components, value, casting='safe')
 
     def component(self, index):
         r"""
@@ -383,9 +351,3 @@ class MeanLinearVectorModel(LinearVectorModel):
     def _instance_vectors_for_full_weights(self, full_weights):
         x = LinearVectorModel._instance_vectors_for_full_weights(self, full_weights)
         return x + self._mean
-
-
-# TODO: Deprecate in 0.7.0
-# These have been maintained for backwards compatibility
-LinearModel = LinearVectorModel
-MeanLinearModel = MeanLinearVectorModel

--- a/menpo/model/test/test_model.py
+++ b/menpo/model/test/test_model.py
@@ -85,24 +85,23 @@ def test_pca_trim():
     samples = [PointCloud(np.random.randn(10)) for _ in range(10)]
     model = PCAModel(samples)
     # trim components
-    model.trim_components(5)
-    # number of active components should be the same as number of components
-    assert_equal(model.n_active_components, model.n_components)
+    new_model = model.with_n_components(5)
+    assert_equal(new_model.n_components, 5)
 
+
+@raises(ValueError)
+def test_pca_with_n_components_variance_limit():
+    samples = [np.random.randn(10) for _ in range(10)]
+    model = PCAVectorModel(samples)
+    # impossible to keep more than 1.0 ratio variance
+    model = model.with_n_components(2.5)
 
 @raises(ValueError)
 def test_pca_trim_variance_limit():
     samples = [np.random.randn(10) for _ in range(10)]
     model = PCAVectorModel(samples)
     # impossible to keep more than 1.0 ratio variance
-    model.trim_components(2.5)
-
-@raises(ValueError)
-def test_pca_trim_variance_limit():
-    samples = [np.random.randn(10) for _ in range(10)]
-    model = PCAVectorModel(samples)
-    # impossible to keep more than 1.0 ratio variance
-    model.trim_components(2.5)
+    model._trim_components(2.5)
 
 
 @raises(ValueError)
@@ -110,7 +109,7 @@ def test_pca_trim_negative_integers():
     samples = [PointCloud(np.random.randn(10)) for _ in range(10)]
     model = PCAModel(samples)
     # no negative number of components
-    model.trim_components(-2)
+    model._trim_components(-2)
 
 
 @raises(ValueError)
@@ -118,7 +117,7 @@ def test_pca_trim_negative_float():
     samples = [PointCloud(np.random.randn(10)) for _ in range(10)]
     model = PCAModel(samples)
     # no negative number of components
-    model.trim_components(-2)
+    model._trim_components(-2)
 
 
 def test_pca_variance():
@@ -163,7 +162,7 @@ def test_pca_variance_after_trim():
     samples = [np.random.randn(10) for _ in range(10)]
     model = PCAVectorModel(samples)
     # set number of active components
-    model.trim_components(5)
+    model._trim_components(5)
     # kept variance must be smaller than total variance
     assert(model.variance() < model.original_variance())
     # kept variance ratio must be smaller than 1.0


### PR DESCRIPTION
Work in progress implementing #641.

#### Summary:

We use the keyword `original` (any other contenders?) to designate the state that was present when the PCA was taken:

- `n_original_components`
- `original_eigenvalues`

For state which has been lost due to a previous call to `with_n_components()` we use another keyword, `trimmed`

- `trimmed_eigenvalues` ('extra' eigenvalues that were in the original spectrum that we have now discarded).

All other state is used without an extra keyword. There is no concept of 'active'.

- `components`
- `eigenvalues`
- `n_components`
- `n_eigenvalues`
- ...

### Major changes:

- `with_n_components(n)` - new immutable API used to get a trimmed version of a model. The mutating `trim_components(n)` is deprecated, use `with_n_components` instead.
- `n_active_components` -> `n_components`
- `n_components` -> `n_original_components`

### TODO

Move inplace methods to be non-mutating:
- [ ] `orthonormalize_against_inplace`
- [ ] `increment`
- [ ] Fix tests (heavily dependent on `n_active_components`)
- [ ] Consider `n_active_components` alias for `n_components` with deprecation warning
- [ ] Consider supporting and deprecating inplace methods for a release
- [ ] Update menpofit to use new style