### PR TITLE
Implement LazyList __add__

### DIFF
--- a/menpo/base.py
+++ b/menpo/base.py
@@ -535,3 +535,34 @@ class LazyList(collections.Sequence):
         def delayed(x2):
             return f(x2())
         return self.__class__([partial(delayed, x) for x in self._callables])
+
+    def __add__(self, other):
+        r"""
+        Create a new LazyList from this list and the given list. The passed list
+        items will be concatenated to the end of this list to give a new
+        LazyList that contains the concatenation of the two lists.
+
+        If a Python list is passed then the elements are wrapped in a function
+        that just returns their values to maintain the callable nature of
+        LazyList elements.
+
+        Parameters
+        ----------
+        other : `collections.Sequence`
+            Sequence to concatenate with this list.
+
+        Returns
+        -------
+        lazy : `LazyList`
+            A new LazyList formed of the concatenation of this list and
+            the ``other`` list.
+        """
+        # If the passed Sequence was not lazy then fake it being lazy by
+        # wrapping it in a function that just returns the value.
+        if not isinstance(other, LazyList):
+            def empty_f(a):
+                return a
+            new_callables = [partial(empty_f, x) for x in other]
+        else:
+            new_callables = list(other._callables)
+        return self.__class__(list(self._callables) + new_callables)

--- a/menpo/test/lazylist_test.py
+++ b/menpo/test/lazylist_test.py
@@ -4,7 +4,7 @@ from nose.tools import raises
 from menpo.base import LazyList
 
 
-def test_lazylist():
+def test_lazylist_get():
     mock_func = Mock()
     mock_func.return_value = 1
     ll = LazyList([mock_func] * 10)
@@ -60,3 +60,26 @@ def test_lazylist_init_from_index_callable():
 def test_lazylist_immutable():
     ll = LazyList([])
     ll[0] = 1
+
+
+def test_lazylist_add_lazylist():
+    a = Mock()
+    b = Mock()
+    ll1 = LazyList([a])
+    ll2 = LazyList([b])
+    new_ll = ll1 + ll2
+    assert len(new_ll) == 2
+    assert new_ll._callables[0] is a
+    assert new_ll._callables[1] is b
+
+
+def test_lazylist_add_list():
+    a = Mock()
+    b = Mock()
+    ll1 = LazyList([a])
+    l2 = [b]
+    new_ll = ll1 + l2
+    assert len(new_ll) == 2
+    assert new_ll._callables[0] is a
+    assert new_ll._callables[1] is not b
+    assert new_ll[1] is b


### PR DESCRIPTION
Now LazyLists can be concatenated. Non-lazylists concatenated
with the given LazyList will be wrapped in a function that just
returns each value. @jabooth OK with this?