### PR TITLE
Fix bug in python 3.4 with exporting of images.

### DIFF
--- a/menpo/io/output/image.py
+++ b/menpo/io/output/image.py
@@ -14,4 +14,8 @@ def PILExporter(image, file_handle):
         The file to write in to
     """
     pil_image = image.as_PILImage()
+    import sys
+    if sys.version_info >= (3, 4):
+       from pathlib import Path
+       file_handle = Path(file_handle.name)
     pil_image.save(file_handle)


### PR DESCRIPTION
Currently in python 3.4, exporting of images doesn't work, e.g. try: 
```
import menpo.io as mio
im = mio.import_builtin_asset.lenna_png()
mio.export_image(im, '/tmp/lenna.jpg', overwrite=True, extension='jpg')
```

The reason is the PIL handler for python >= 3.4, [line 1636](https://github.com/python-pillow/Pillow/blob/master/PIL/Image.py#L1636).