### PR TITLE
Expose file extension to exporters (Fix PIL exporter bug)

### DIFF
--- a/conda/.coveragerc
+++ b/conda/.coveragerc
@@ -1,0 +1,13 @@
+[run]
+branch=True
+source=menpo
+omit =
+      */visualize/*
+      */_version.*
+
+[report]
+exclude_lines =
+               raise NotImplementedError
+
+ignore_errors=True
+

--- a/conda/meta.yaml
+++ b/conda/meta.yaml
@@ -33,6 +33,9 @@ test:
   requires:
     - coverage
 
+  files:
+    - .coveragerc
+
   imports:
     - menpo
 

--- a/menpo/io/input/base.py
+++ b/menpo/io/input/base.py
@@ -671,7 +671,7 @@ def _import(filepath, extensions_map, landmark_resolver=same_name,
     assets : asset or list of assets
         The loaded asset or list of assets.
     """
-    path = Path(_norm_path(filepath))
+    path = _norm_path(filepath)
     if not path.is_file():
         raise ValueError("{} is not a file".format(path))
     # below could raise ValueError as well...
@@ -730,11 +730,12 @@ def _pathlib_glob_for_pattern(pattern, sort=True):
         If the pattern doesn't contain a '*' wildcard and is not a directory
     """
     pattern = _norm_path(pattern)
-    gsplit = pattern.split('*', 1)
+    pattern_str = str(pattern)
+    gsplit = pattern_str.split('*', 1)
     if len(gsplit) == 1:
         # no glob provided. Is the provided pattern a dir?
         if Path(pattern).is_dir():
-            preglob = pattern
+            preglob = pattern_str
             pattern = '*'
         else:
             raise ValueError('{} is an invalid glob and '

--- a/menpo/io/output/base.py
+++ b/menpo/io/output/base.py
@@ -130,11 +130,10 @@ def export_video(images, filepath, overwrite=False, fps=30, **kwargs):
     exporter_kwargs = {'fps': fps}
     exporter_kwargs.update(kwargs)
     path_filepath = _validate_filepath(Path(filepath), overwrite)
-    extension = _parse_and_validate_extension(filepath, None, video_types)
+    extension = _parse_and_validate_extension(path_filepath, None, video_types)
 
     export_function = _extension_to_export_function(extension, video_types)
-    export_function(images, path_filepath, extension=extension,
-                    **exporter_kwargs)
+    export_function(images, path_filepath, **exporter_kwargs)
 
 
 def export_pickle(obj, fp, overwrite=False, protocol=2):

--- a/menpo/io/output/extensions.py
+++ b/menpo/io/output/extensions.py
@@ -37,6 +37,7 @@ image_types = {
 
 pickle_types = {
     '.pkl': pickle_export,
+    '.pkl.gz': pickle_export,
 }
 
 

--- a/menpo/io/output/image.py
+++ b/menpo/io/output/image.py
@@ -1,4 +1,4 @@
-def PILExporter(image, file_handle):
+def PILExporter(image, file_handle, extension='', **kwargs):
     r"""
     Given a file handle to write in to (which should act like a Python `file`
     object), write out the image data. No value is returned.
@@ -13,5 +13,15 @@ def PILExporter(image, file_handle):
     file_handle : `file`-like object
         The file to write in to
     """
+    from PIL.Image import EXTENSION
     pil_image = image.as_PILImage()
-    pil_image.save(file_handle)
+    # Also, the format kwarg of PIL/Pillow is a bit confusing and actually
+    # refers to the underlying algorithm and not the extension. Therefore,
+    # we need to reach into PIL/Pillow and grab the correct format for our
+    # given extension.
+    try:
+        pil_extension = EXTENSION[extension]
+    except KeyError:
+        raise ValueError('PIL/Pillow does not support the provided '
+                         'extension: ({})'.format(extension))
+    pil_image.save(file_handle, format=pil_extension)

--- a/menpo/io/output/landmark.py
+++ b/menpo/io/output/landmark.py
@@ -3,7 +3,7 @@ import itertools
 import numpy as np
 
 
-def LJSONExporter(landmark_group, file_handle):
+def LJSONExporter(landmark_group, file_handle, **kwargs):
     r"""
     Given a file handle to write in to (which should act like a Python `file`
     object), write out the landmark data. No value is returned.
@@ -48,7 +48,7 @@ def LJSONExporter(landmark_group, file_handle):
                      sort_keys=True, allow_nan=False)
 
 
-def PTSExporter(landmark_group, file_handle):
+def PTSExporter(landmark_group, file_handle, **kwargs):
     r"""
     Given a file handle to write in to (which should act like a Python `file`
     object), write out the landmark data. No value is returned.

--- a/menpo/io/output/pickle.py
+++ b/menpo/io/output/pickle.py
@@ -50,6 +50,6 @@ def pickle_paths_as_pure():
         Path.__reduce__ = default_reduce
 
 
-def pickle_export(obj, file_handle, protocol=2):
+def pickle_export(obj, file_handle, protocol=2, **kwargs):
     with pickle_paths_as_pure():
         pickle.dump(obj, file_handle, protocol=protocol)

--- a/menpo/io/output/video.py
+++ b/menpo/io/output/video.py
@@ -1,8 +1,8 @@
-import numpy as np
 
 
 def ImageioVideoExporter(images, out_path, fps=30, codec='libx264',
-                         quality=None, bitrate=None, pixelformat='yuv420p'):
+                         quality=None, bitrate=None, pixelformat='yuv420p',
+                         **kwargs):
     r"""
     Uses imageio to export the images using FFMPEG. Please see the imageio
     documentation for more information.
@@ -40,9 +40,10 @@ def ImageioVideoExporter(images, out_path, fps=30, codec='libx264',
     writer.close()
 
 
-def ImageioGifExporter(images, out_path, fps=30, loop=0, duration=None):
+def ImageioGifExporter(images, out_path, fps=30, loop=0, duration=None,
+                       **kwargs):
     r"""
-    Uses imageio to export the images to a gIF. Please see the imageio
+    Uses imageio to export the images to a GIF. Please see the imageio
     documentation for more information.
 
     Parameters

--- a/menpo/io/test/io_export_test.py
+++ b/menpo/io/test/io_export_test.py
@@ -234,6 +234,24 @@ def test_export_image_jpg(mock_open, exists, PILImage):
     assert PILImage.fromarray.return_value.save.call_count == 1
 
 
+@patch('imageio.get_writer')
+@patch('menpo.io.output.base.Path.exists')
+def test_export_video_avi(exists, fake_writer):
+    exists.return_value = False
+    fake_path = Path('/fake/fake.avi')
+    mio.export_video([test_img, test_img], fake_path, extension='avi')
+    assert fake_writer.return_value.append_data.call_count == 2
+
+
+@patch('imageio.get_writer')
+@patch('menpo.io.output.base.Path.exists')
+def test_export_video_gif(exists, fake_writer):
+    exists.return_value = False
+    fake_path = Path('/fake/fake.gif')
+    mio.export_video([test_img, test_img], fake_path, extension='gif')
+    assert fake_writer.return_value.append_data.call_count == 2
+
+
 @patch('menpo.io.output.pickle.pickle.dump')
 @patch('menpo.io.output.base.Path.exists')
 @patch('{}.open'.format(__name__), create=True)

--- a/menpo/io/test/io_export_test.py
+++ b/menpo/io/test/io_export_test.py
@@ -1,15 +1,16 @@
 import numpy as np
+import sys
 from numpy.testing import assert_allclose
 import os
-from menpo.io.utils import _norm_path
+from pathlib import PosixPath, WindowsPath, Path
 from mock import patch, PropertyMock, MagicMock
 from nose.tools import raises
-import sys
+
 
 import menpo.io as mio
+from menpo.io.utils import _norm_path
 from menpo.image import Image
 from menpo.io.output.pickle import pickle_paths_as_pure
-from pathlib import PosixPath, WindowsPath, Path
 
 
 builtins_str = '__builtin__' if sys.version_info[0] == 2 else 'builtins'
@@ -27,8 +28,8 @@ fake_path = '/tmp/test.fake'
 def test_export_filepath_overwrite_exists(mock_open, exists, landmark_types):
     exists.return_value = True
     mio.export_landmark_file(test_lg, fake_path, overwrite=True)
-    mock_open.assert_called_once_with('wb')
-    landmark_types.__getitem__.assert_called_once_with('.fake')
+    mock_open.assert_called_with('wb')
+    landmark_types.__getitem__.assert_called_with('.fake')
     export_function = landmark_types.__getitem__.return_value
     assert export_function.call_count == 1
 
@@ -39,8 +40,8 @@ def test_export_filepath_overwrite_exists(mock_open, exists, landmark_types):
 def test_export_filepath_no_overwrite(mock_open, exists, landmark_types):
     exists.return_value = False
     mio.export_landmark_file(test_lg, fake_path)
-    mock_open.assert_called_once_with('wb')
-    landmark_types.__getitem__.assert_called_once_with('.fake')
+    mock_open.assert_called_with('wb')
+    landmark_types.__getitem__.assert_called_with('.fake')
     export_function = landmark_types.__getitem__.return_value
     assert export_function.call_count == 1
 
@@ -52,7 +53,7 @@ def test_export_filepath_no_overwrite(mock_open, exists, landmark_types):
 def test_export_filepath_wrong_extension(mock_open, exists, landmark_types):
     exists.return_value = False
     mio.export_landmark_file(test_lg, fake_path, extension='pts')
-    mock_open.assert_called_once_with('wb')
+    mock_open.assert_called_with('wb')
 
 
 @patch('menpo.io.output.base.landmark_types')
@@ -61,8 +62,8 @@ def test_export_filepath_wrong_extension(mock_open, exists, landmark_types):
 def test_export_filepath_explicit_ext_no_dot(mock_open, exists, landmark_types):
     exists.return_value = False
     mio.export_landmark_file(test_lg, fake_path, extension='fake')
-    mock_open.assert_called_once_with('wb')
-    landmark_types.__getitem__.assert_called_once_with('.fake')
+    mock_open.assert_called_with('wb')
+    landmark_types.__getitem__.assert_called_with('.fake')
     export_function = landmark_types.__getitem__.return_value
     assert export_function.call_count == 1
 
@@ -73,8 +74,8 @@ def test_export_filepath_explicit_ext_no_dot(mock_open, exists, landmark_types):
 def test_export_filepath_explicit_ext_dot(mock_open, exists, landmark_types):
     exists.return_value = False
     mio.export_landmark_file(test_lg, fake_path, extension='.fake')
-    mock_open.assert_called_once_with('wb')
-    landmark_types.__getitem__.assert_called_once_with('.fake')
+    mock_open.assert_called_with('wb')
+    landmark_types.__getitem__.assert_called_with('.fake')
     export_function = landmark_types.__getitem__.return_value
     assert export_function.call_count == 1
 
@@ -143,7 +144,7 @@ def test_export_file_handle_file_exists_overwrite(mock_open, exists,
     with open(fake_path) as f:
         type(f).name = PropertyMock(return_value=fake_path)
         mio.export_landmark_file(test_lg, f, overwrite=True, extension='fake')
-    landmark_types.__getitem__.assert_called_once_with('.fake')
+    landmark_types.__getitem__.assert_called_with('.fake')
     export_function = landmark_types.__getitem__.return_value
     assert export_function.call_count == 1
 
@@ -157,7 +158,7 @@ def test_export_file_handle_file_non_file_buffer(mock_open, exists,
     with open(fake_path) as f:
         del f.name  # Equivalent to raising an AttributeError side effect
         mio.export_landmark_file(test_lg, f, extension='fake')
-    landmark_types.__getitem__.assert_called_once_with('.fake')
+    landmark_types.__getitem__.assert_called_with('.fake')
     export_function = landmark_types.__getitem__.return_value
     assert export_function.call_count == 1
 
@@ -250,14 +251,14 @@ def test_export_pickle(mock_open, exists, pickle_dump):
 @patch('{}.open'.format(builtins_str))
 def test_export_pickle_with_path_uses_open(mock_open, exists, pickle_dump):
     exists.return_value = False
-    fake_path = _norm_path('fake.pkl.gz')
+    fake_path = str(_norm_path('fake.pkl.gz'))
     mock_open_enter = MagicMock()
     # Make sure the name attribute returns the path
     mock_open_enter.__enter__.return_value.configure_mock(name=fake_path)
     mock_open.return_value = mock_open_enter
     mio.export_pickle(test_lg, fake_path)
     assert pickle_dump.call_count == 1
-    mock_open.assert_called_once_with(fake_path, 'wb')
+    mock_open.assert_called_with(fake_path, 'wb')
 
 
 @patch('menpo.io.output.pickle.pickle.dump')
@@ -273,7 +274,7 @@ def test_export_pickle_with_path_expands_vars(mock_open, exists, pickle_dump):
     mio.export_pickle(test_lg, fake_path)
     assert pickle_dump.call_count == 1
     expected_path = os.path.join(os.path.expanduser('~'), 'fake', 'fake.pkl.gz')
-    mock_open.assert_called_once_with(expected_path, 'wb')
+    mock_open.assert_called_with(expected_path, 'wb')
 
 
 def test_pickle_paths_as_pure_switches_reduce_method_on_path():

--- a/menpo/io/test/io_import_test.py
+++ b/menpo/io/test/io_import_test.py
@@ -509,3 +509,37 @@ def test_importing_pickles_as_generator(is_file, glob, mock_open, mock_pickle):
     assert len(objs) == 2
     assert objs[0]['test'] == 1
     assert objs[1]['test'] == 1
+
+
+@patch('imageio.get_reader')
+@patch('menpo.io.input.base.Path.is_file')
+def test_importing_imageio_avi_normalise(is_file, mock_image):
+    mock_image.return_value.get_data.return_value = np.ones((10, 10, 3),
+                                                            dtype=np.uint8)
+    mock_image.return_value.get_length.return_value = 1
+    is_file.return_value = True
+
+    ll = mio.import_video('fake_image_being_mocked.avi', normalise=True)
+    assert len(ll) == 1
+
+    im = ll[0]
+    assert im.shape == (10, 10)
+    assert im.n_channels == 3
+    assert im.pixels.dtype == np.float
+
+
+@patch('imageio.get_reader')
+@patch('menpo.io.input.base.Path.is_file')
+def test_importing_imageio_avi_no_normalise(is_file, mock_image):
+    mock_image.return_value.get_data.return_value = np.ones((10, 10, 3),
+                                                            dtype=np.uint8)
+    mock_image.return_value.get_length.return_value = 1
+    is_file.return_value = True
+
+    ll = mio.import_video('fake_image_being_mocked.avi', normalise=False)
+    assert len(ll) == 1
+
+    im = ll[0]
+    assert im.shape == (10, 10)
+    assert im.n_channels == 3
+    assert im.pixels.dtype == np.uint8

--- a/menpo/io/test/util_test.py
+++ b/menpo/io/test/util_test.py
@@ -1,0 +1,111 @@
+from mock import patch
+from pathlib import Path
+from nose.tools import raises
+
+
+from menpo.io.input.base import _pathlib_glob_for_pattern
+from menpo.io.output.base import _parse_and_validate_extension
+
+
+@patch('menpo.io.input.base.Path.glob')
+def test_glob_parse_contains_file_glob_no_sort(mock_glob):
+    path = '/tmp/test.*'
+    mock_glob.return_value = ['/tmp/test.test']
+    result = list(_pathlib_glob_for_pattern(path, sort=False))
+    assert len(result) == 1
+    mock_glob.assert_called_with('test.*')
+
+
+@patch('menpo.io.input.base.Path.glob')
+def test_glob_parse_contains_dir_glob_no_sort(mock_glob):
+    path = '/tmp/**/*'
+    mock_glob.return_value = ['/tmp/a/test.test', '/tmp/b/test.test']
+    result = list(_pathlib_glob_for_pattern(path, sort=False))
+    assert len(result) == 2
+    mock_glob.assert_called_with('**/*')
+
+
+@patch('menpo.io.input.base.Path.glob')
+def test_glob_parse_sort(mock_glob):
+    path = '/tmp/**/*'
+    mock_glob.return_value = ['/tmp/b/test.test', '/tmp/a/test.test']
+    result = list(_pathlib_glob_for_pattern(path, sort=True))
+    assert len(result) == 2
+    assert result[0] == mock_glob.return_value[1]
+    mock_glob.assert_called_with('**/*')
+
+
+def test_parse_extension_given_extension():
+    filepath = 'test.jpg'
+    extension = filepath[-4:]
+    parsed_extension = _parse_and_validate_extension(Path(filepath), extension,
+                                                     {'.jpg': None})
+    assert parsed_extension == extension
+
+
+def test_parse_extension_no_given_extension():
+    filepath = 'test.jpg'
+    extension = filepath[-4:]
+    parsed_extension = _parse_and_validate_extension(Path(filepath), None,
+                                                     {'.jpg': None})
+    assert parsed_extension == extension
+
+
+def test_parse_double_extension_given_extension():
+    filepath = 'test.pkl.gz'
+    extension = filepath[-7:]
+    parsed_extension = _parse_and_validate_extension(Path(filepath), extension,
+                                                     {'.pkl.gz': None})
+    assert parsed_extension == extension
+
+
+def test_parse_double_extension_no_extension():
+    filepath = 'test.pkl.gz'
+    extension = filepath[-7:]
+    parsed_extension = _parse_and_validate_extension(Path(filepath), None,
+                                                     {'.pkl.gz': None})
+    assert parsed_extension == extension
+
+
+def test_parse_period_in_name_given_extension():
+    filepath = 'test.1.jpg'
+    extension = filepath[-4:]
+    parsed_extension = _parse_and_validate_extension(Path(filepath), extension,
+                                                     {'.jpg': None})
+    assert parsed_extension == extension
+
+
+def test_parse_period_in_name_no_extension():
+    filepath = 'test.1.jpg'
+    extension = filepath[-4:]
+    parsed_extension = _parse_and_validate_extension(Path(filepath), None,
+                                                     {'.jpg': None})
+    assert parsed_extension == extension
+
+
+def test_parse_period_in_name_double_given_extension():
+    filepath = 'test.1.pkl.gz'
+    extension = filepath[-7:]
+    parsed_extension = _parse_and_validate_extension(Path(filepath), extension,
+                                                     {'.pkl.gz': None})
+    assert parsed_extension == extension
+
+
+def test_parse_period_in_name_double_no_extension():
+    filepath = 'test.1.pkl.gz'
+    extension = filepath[-7:]
+    parsed_extension = _parse_and_validate_extension(Path(filepath), extension,
+                                                     {'.pkl.gz': None})
+    assert parsed_extension == extension
+
+
+@raises(ValueError)
+def test_parse_unknown_extension_raises_ValueError():
+    filepath = 'test.1.fake'
+    _parse_and_validate_extension(Path(filepath), None, {'.jpg': None})
+
+
+@raises(ValueError)
+def test_parse_mot_matching_extension_raises_ValueError():
+    filepath = 'test.jpg2'
+    _parse_and_validate_extension(Path(filepath), '.jpg', {'.jpg': None})

--- a/menpo/io/test/util_test.py
+++ b/menpo/io/test/util_test.py
@@ -1,3 +1,4 @@
+from os.path import sep as PATH_SEP
 from mock import patch
 from pathlib import Path
 from nose.tools import raises
@@ -22,7 +23,7 @@ def test_glob_parse_contains_dir_glob_no_sort(mock_glob):
     mock_glob.return_value = ['/tmp/a/test.test', '/tmp/b/test.test']
     result = list(_pathlib_glob_for_pattern(path, sort=False))
     assert len(result) == 2
-    mock_glob.assert_called_with('**/*')
+    mock_glob.assert_called_with('**/*'.replace('/', PATH_SEP))
 
 
 @patch('menpo.io.input.base.Path.glob')
@@ -32,7 +33,7 @@ def test_glob_parse_sort(mock_glob):
     result = list(_pathlib_glob_for_pattern(path, sort=True))
     assert len(result) == 2
     assert result[0] == mock_glob.return_value[1]
-    mock_glob.assert_called_with('**/*')
+    mock_glob.assert_called_with('**/*'.replace('/', PATH_SEP))
 
 
 def test_parse_extension_given_extension():

--- a/menpo/io/utils.py
+++ b/menpo/io/utils.py
@@ -1,9 +1,10 @@
 import os
+from pathlib import Path
 
 
 def _norm_path(filepath):
     r"""
     Uses all the tricks in the book to expand a path out to an absolute one.
     """
-    return os.path.abspath(os.path.normpath(
-        os.path.expandvars(os.path.expanduser(str(filepath)))))
+    return Path(os.path.abspath(os.path.normpath(
+        os.path.expandvars(os.path.expanduser(str(filepath))))))


### PR DESCRIPTION
Fixes #679, adds some tests to check that it is fixed and also increases coverage (mostly through ignoring non-testable packages).

The crux of the issue is that PIL/Pillow expects a slightly confusing set of arguments for it's `format` keyword argument. It doesn't expect extensions, but instead expects a given algorithm (e.g. `JPEG` vs `jpg`). In contrast to the fix at #679, this maintains compatibility with file buffers (as file buffers do not have a `name` attribute).

In order to implement this, I exposed the file extension to all exporters as a keyword argument. This allowed me to look up the correct expected format for PIL/Pillow. I also refactored some of the code that expected string paths to take `pathlib.Path` objects. I added a bunch of tests for this and update the documentation of the private methods for consistency with the rest of Menpo.

Finally, I updated the logic for parsing extensions/paths and ensured that we can handle things like paths that contain periods (and I added tests for this).

(Also I snuck in improving the coverage by ignoring the visualisation package)