### PR TITLE
Bugfix: Widget imports

### DIFF
--- a/menpo/feature/features.py
+++ b/menpo/feature/features.py
@@ -815,6 +815,6 @@ def features_selection_widget():
         image = mio.import_builtin_asset.lenna_png()
         features_image = features_fun[0](image)
     """
-    from menpo.visualize.widgets import features_selection
+    from menpowidgets import features_selection
 
     return features_selection()

--- a/menpo/visualize/viewmatplotlib.py
+++ b/menpo/visualize/viewmatplotlib.py
@@ -125,9 +125,9 @@ class MatplotlibRenderer(Renderer):
     def save_figure_widget(self):
         r"""
         Method for saving the figure of the current ``figure_id`` to file using
-        :func:`menpo.visualize.widgets.base.save_matplotlib_figure` widget.
+        `menpowidgets.base.save_matplotlib_figure` widget.
         """
-        from menpo.visualize.widgets import save_matplotlib_figure
+        from menpowidgets import save_matplotlib_figure
         save_matplotlib_figure(self)
 
 


### PR DESCRIPTION
After moving the widgets into `menpowidgets` we forgot to change a couple of imports performed in `menpo`.