### PR TITLE
Video importer docs and negative max_images

### DIFF
--- a/menpo/io/input/base.py
+++ b/menpo/io/input/base.py
@@ -137,7 +137,7 @@ def import_video(filepath, landmark_resolver=same_name_video, normalise=True,
         flag you will have to manually convert the farmes you import to floating
         point before doing most Menpo operations. This however can be useful to
         save on memory usage if you only wish to view or crop the frames.
-    importer_method : {'ffmpeg', 'avconv'}, optional
+    importer_method : {'ffmpeg'}, optional
         A string representing the type of importer to use, by default ffmpeg
         is used.
 
@@ -227,7 +227,7 @@ def import_images(pattern, max_images=None, shuffle=False,
         A glob path pattern to search for images. Every image found to match
         the glob will be imported one by one. See :map:`image_paths` for more
         details of what images will be found.
-    max_images : positive `int`, optional
+    max_images : `int`, optional
         If not ``None``, only import the first ``max_images`` found. Else,
         import all.
     shuffle : `bool`, optional
@@ -308,7 +308,7 @@ def import_videos(pattern, max_videos=None, shuffle=False,
         A glob path pattern to search for videos. Every video found to match
         the glob will be imported one by one. See :map:`video_paths` for more
         details of what videos will be found.
-    max_videos : positive `int`, optional
+    max_videos : `int`, optional
         If not ``None``, only import the first ``max_videos`` found. Else,
         import all.
     shuffle : `bool`, optional
@@ -326,10 +326,10 @@ def import_videos(pattern, max_videos=None, shuffle=False,
         to floating point. If ``False``, the native datatype of the image will
         be maintained (commonly `uint8`). Note that in general Menpo assumes
         :map:`Image` instances contain floating point data - if you disable this
-        flag you will have to manually convert the farmes you import to floating
+        flag you will have to manually convert the frames you import to floating
         point before doing most Menpo operations. This however can be useful to
         save on memory usage if you only wish to view or crop the frames.
-    importer_method : {'ffmpeg', 'avconv'}, optional
+    importer_method : {'ffmpeg'}, optional
         A string representing the type of importer to use, by default ffmpeg
         is used.
     as_generator : `bool`, optional
@@ -399,7 +399,7 @@ def import_landmark_files(pattern, max_landmarks=None, shuffle=False,
         landmark file found to match the glob will be imported one by one.
         See :map:`landmark_file_paths` for more details of what landmark files
         will be found.
-    max_landmarks : positive `int`, optional
+    max_landmarks : `int`, optional
         If not ``None``, only import the first ``max_landmark_files`` found.
         Else, import all.
     shuffle : `bool`, optional
@@ -447,7 +447,7 @@ def import_pickles(pattern, max_pickles=None, shuffle=False, as_generator=False,
     pattern : `str`
         The glob path pattern to search for pickles. Every pickle file found
         to match the glob will be imported one by one.
-    max_pickles : positive `int`, optional
+    max_pickles : `int`, optional
         If not ``None``, only import the first ``max_pickles`` found.
         Else, import all.
     shuffle : `bool`, optional

--- a/menpo/io/input/base.py
+++ b/menpo/io/input/base.py
@@ -227,7 +227,7 @@ def import_images(pattern, max_images=None, shuffle=False,
         A glob path pattern to search for images. Every image found to match
         the glob will be imported one by one. See :map:`image_paths` for more
         details of what images will be found.
-    max_images : `int`, optional
+    max_images : positive `int`, optional
         If not ``None``, only import the first ``max_images`` found. Else,
         import all.
     shuffle : `bool`, optional
@@ -308,7 +308,7 @@ def import_videos(pattern, max_videos=None, shuffle=False,
         A glob path pattern to search for videos. Every video found to match
         the glob will be imported one by one. See :map:`video_paths` for more
         details of what videos will be found.
-    max_videos : `int`, optional
+    max_videos : positive `int`, optional
         If not ``None``, only import the first ``max_videos`` found. Else,
         import all.
     shuffle : `bool`, optional
@@ -399,7 +399,7 @@ def import_landmark_files(pattern, max_landmarks=None, shuffle=False,
         landmark file found to match the glob will be imported one by one.
         See :map:`landmark_file_paths` for more details of what landmark files
         will be found.
-    max_landmarks : `int`, optional
+    max_landmarks : positive `int`, optional
         If not ``None``, only import the first ``max_landmark_files`` found.
         Else, import all.
     shuffle : `bool`, optional
@@ -447,7 +447,7 @@ def import_pickles(pattern, max_pickles=None, shuffle=False, as_generator=False,
     pattern : `str`
         The glob path pattern to search for pickles. Every pickle file found
         to match the glob will be imported one by one.
-    max_pickles : `int`, optional
+    max_pickles : positive `int`, optional
         If not ``None``, only import the first ``max_pickles`` found.
         Else, import all.
     shuffle : `bool`, optional
@@ -568,7 +568,10 @@ def _import_glob_lazy_list(pattern, extension_map, max_assets=None,
                                       sort=(not shuffle)))
     if shuffle:
         random.shuffle(filepaths)
-    if max_assets:
+    if (max_assets is not None) and max_assets <= 0:
+        raise ValueError('Max elements should be positive'
+                         ' ({} provided)'.format(max_assets))
+    elif max_assets:
         filepaths = filepaths[:max_assets]
     n_files = len(filepaths)
     if n_files == 0:

--- a/menpo/io/test/io_import_test.py
+++ b/menpo/io/test/io_import_test.py
@@ -543,3 +543,14 @@ def test_importing_imageio_avi_no_normalise(is_file, mock_image):
     assert im.shape == (10, 10)
     assert im.n_channels == 3
     assert im.pixels.dtype == np.uint8
+
+
+@raises(ValueError)
+def test_import_images_negative_max_images():
+    list(mio.import_images(mio.data_dir_path(), max_images=-2))
+
+@raises(ValueError)
+def test_import_images_zero_max_images():
+    # different since the conditional 'if max_assets' is skipped,
+    # thus all images might be imported.
+    list(mio.import_images(mio.data_dir_path(), max_images=0))


### PR DESCRIPTION
That is only ffmpeg is currently supported, avconv raises an error.

Additionally, minor fix in the multiple importers, since the max_{}
can get negative int values (does not return the last abs(max_{}) elements).