### PR TITLE
Fix init_2d_grid for TriMesh subclasses + add init_from_depth_image

### DIFF
--- a/menpo/feature/optional/vlfeat.py
+++ b/menpo/feature/optional/vlfeat.py
@@ -88,6 +88,7 @@ def dsift(pixels, window_step_horizontal=1, window_step_vertical=1,
     # returns x, y centres.
     shape = (((centers[-1, :] - centers[0, :]) /
               [window_step_vertical, window_step_horizontal]) + 1)
+    shape = shape.astype(np.int)
 
     # print information
     if verbose:

--- a/menpo/image/base.py
+++ b/menpo/image/base.py
@@ -1076,7 +1076,7 @@ class Image(Vectorizable, Landmarkable, Viewable, LandmarkableViewable):
             raise ImageBoundaryError(min_indices, max_indices,
                                      min_bounded, max_bounded)
 
-        new_shape = max_bounded - min_bounded
+        new_shape = (max_bounded - min_bounded).astype(np.int)
         return self.warp_to_shape(new_shape, Translation(min_bounded), order=0,
                                   warp_landmarks=True,
                                   return_transform=return_transform)

--- a/menpo/shape/__init__.py
+++ b/menpo/shape/__init__.py
@@ -4,4 +4,4 @@ from .groupops import mean_pointcloud
 from .graph import (UndirectedGraph, DirectedGraph, Tree, PointUndirectedGraph,
                     PointDirectedGraph, PointTree)
 from .graph_predefined import (empty_graph, star_graph, complete_graph,
-                               chain_graph, delaunay_graph)
+                               chain_graph, delaunay_graph, stencil_grid)

--- a/menpo/shape/mesh/base.py
+++ b/menpo/shape/mesh/base.py
@@ -184,6 +184,38 @@ class TriMesh(PointCloud):
         return cls(points, trilist=subsampled_grid_triangulation(
             shape, subsampling=1), copy=False)
 
+    @classmethod
+    def init_from_depth_image(cls, depth_image):
+        r"""
+        Return a 3D triangular mesh from the given depth image. The depth image
+        is assumed to represent height/depth values and the XY coordinates
+        are assumed to unit spaced and represent image coordinates. This is
+        particularly useful for visualising depth values that have been
+        recovered from images.
+
+        Parameters
+        ----------
+        depth_image : :map:`Image` or subclass
+            A single channel image that contains depth values - as commonly
+            returned by RGBD cameras, for example.
+
+        Returns
+        -------
+        depth_cloud : ``type(cls)``
+            A new 3D TriMesh with unit XY coordinates and the given depth
+            values as Z coordinates. The trilist is constructed as in
+            :meth:`init_2d_grid`.
+        """
+        from menpo.image import MaskedImage
+
+        new_tmesh = cls.init_2d_grid(depth_image.shape)
+        if isinstance(depth_image, MaskedImage):
+            new_tmesh = new_tmesh.from_mask(depth_image.mask.as_vector())
+        return cls(np.hstack([new_tmesh.points,
+                              depth_image.as_vector(keep_channels=True).T]),
+                   trilist=new_tmesh.trilist,
+                   copy=False)
+
     def __str__(self):
         return '{}, n_tris: {}'.format(PointCloud.__str__(self),
                                        self.n_tris)

--- a/menpo/shape/mesh/base.py
+++ b/menpo/shape/mesh/base.py
@@ -11,6 +11,39 @@ from .normals import compute_normals
 Delaunay = None  # expensive, from scipy.spatial
 
 
+def grid_tcoords(shape):
+    r"""
+    Return texture coordinates laid out on a grid. This is useful for creating
+    a textured version of an image whereby the underlying mesh maps
+    1-1 with a texture. Therefore, the provided shape should be the shape
+    of the texture.
+
+    Parameters
+    ----------
+    shape : `tuple` of 2 `int`
+        The size of the grid to create, this defines the number of points
+        across each dimension in the grid. The first element is the number
+        of rows and the second is the number of columns.
+
+    Returns
+    -------
+    tcoords : ``(M, 2)`` `ndarray`
+        The texture coordinates of a uniform grid. The origin will be
+        at the image origin (appropriate for viewing texture mapped planes
+        such as viewing image height maps).
+    """
+    # Default tcoords are just a grid, which assumes the input texture
+    # is an image the same size as the input grid. The meshgrid is made in
+    # an ordering that attempts to reduce the amount of copying required but
+    # places the texture coordinates in the correct arrangement.
+    tcoords = np.meshgrid(np.linspace(0, 1, num=shape[1]),
+                          np.linspace(1, 0, num=shape[0]),
+                          indexing='xy')
+    tcoords = np.stack(tcoords, axis=2).reshape([-1, 2])
+    tcoords = np.require(tcoords, requirements=['C'])
+    return tcoords
+
+
 def trilist_to_adjacency_array(trilist):
     r"""
     Turn an ``(M, 3)`` trilist into an adjacency array suitable for building

--- a/menpo/shape/mesh/coloured.py
+++ b/menpo/shape/mesh/coloured.py
@@ -87,6 +87,46 @@ class ColouredTriMesh(TriMesh):
         return ColouredTriMesh(points, trilist=trilist, colours=colours,
                                copy=False)
 
+    @classmethod
+    def init_from_depth_image(cls, depth_image, colours=None):
+        r"""
+        Return a 3D textured triangular mesh from the given depth image. The
+        depth image is assumed to represent height/depth values and the XY
+        coordinates are assumed to unit spaced and represent image coordinates.
+        This is particularly useful for visualising depth values that have been
+        recovered from images.
+
+        The optionally passed texture will be textured mapped onto the planar
+        surface using the correct texture coordinates for an image of the
+        same shape as ``depth_image``.
+
+        Parameters
+        ----------
+        depth_image : :map:`Image` or subclass
+            A single channel image that contains depth values - as commonly
+            returned by RGBD cameras, for example.
+        colours : ``(N, 3)`` `ndarray`, optional
+            The floating point RGB colour per vertex. If not given, grey will be
+            assigned to each vertex.
+
+        Returns
+        -------
+        depth_cloud : ``type(cls)``
+            A new 3D TriMesh with unit XY coordinates and the given depth
+            values as Z coordinates. The trilist is constructed as in
+            :meth:`init_2d_grid`.
+        """
+        from menpo.image import MaskedImage
+
+        new_tmesh = cls.init_2d_grid(depth_image.shape, colours=colours)
+        if isinstance(depth_image, MaskedImage):
+            new_tmesh = new_tmesh.from_mask(depth_image.mask.as_vector())
+        return cls(np.hstack([new_tmesh.points,
+                              depth_image.as_vector(keep_channels=True).T]),
+                   colours=new_tmesh.colours,
+                   trilist=new_tmesh.trilist,
+                   copy=False)
+
     def from_mask(self, mask):
         """
         A 1D boolean array with the same number of elements as the number of

--- a/menpo/shape/mesh/coloured.py
+++ b/menpo/shape/mesh/coloured.py
@@ -41,7 +41,7 @@ class ColouredTriMesh(TriMesh):
         else:
             colours_handle = colours.copy()
 
-        if points.shape[0] != colours.shape[0]:
+        if points.shape[0] != colours_handle.shape[0]:
             raise ValueError('Must provide a colour per-vertex.')
         self.colours = colours_handle
 

--- a/menpo/shape/mesh/coloured.py
+++ b/menpo/shape/mesh/coloured.py
@@ -45,6 +45,48 @@ class ColouredTriMesh(TriMesh):
             raise ValueError('Must provide a colour per-vertex.')
         self.colours = colours_handle
 
+    @classmethod
+    def init_2d_grid(cls, shape, spacing=None, colours=None):
+        r"""
+        Create a ColouredTriMesh that exists on a regular 2D grid. The first
+        dimension is the number of rows in the grid and the second dimension
+        of the shape is the number of columns. ``spacing`` optionally allows
+        the definition of the distance between points (uniform over points).
+        The spacing may be different for rows and columns.
+
+        The triangulation will be right-handed and the diagonal will go from
+        the top left to the bottom right of a square on the grid.
+
+        Parameters
+        ----------
+        shape : `tuple` of 2 `int`
+            The size of the grid to create, this defines the number of points
+            across each dimension in the grid. The first element is the number
+            of rows and the second is the number of columns.
+        spacing : `int` or `tuple` of 2 `int`, optional
+            The spacing between points. If a single `int` is provided, this
+            is applied uniformly across each dimension. If a `tuple` is
+            provided, the spacing is applied non-uniformly as defined e.g.
+            ``(2, 3)`` gives a spacing of 2 for the rows and 3 for the
+            columns.
+        colours : ``(N, 3)`` `ndarray`, optional
+            The floating point RGB colour per vertex. If not given, grey will be
+            assigned to each vertex.
+
+        Returns
+        -------
+        trimesh : :map:`TriMesh`
+            A TriMesh arranged in a grid.
+        """
+        pc = TriMesh.init_2d_grid(shape, spacing=spacing)
+        points = pc.points
+        trilist = pc.trilist
+        # Ensure that the colours are copied
+        if colours is not None:
+            colours = colours.copy()
+        return ColouredTriMesh(points, trilist=trilist, colours=colours,
+                               copy=False)
+
     def from_mask(self, mask):
         """
         A 1D boolean array with the same number of elements as the number of

--- a/menpo/shape/mesh/test/trimish_test.py
+++ b/menpo/shape/mesh/test/trimish_test.py
@@ -16,8 +16,26 @@ def test_trimesh_creation():
     TriMesh(points, trilist=trilist)
 
 
-def test_trimesh__init_2d_grid():
+def test_trimesh_init_2d_grid():
     tm = TriMesh.init_2d_grid([10, 10])
+    assert tm.n_points == 100
+    assert tm.n_dims == 2
+    # 162 = 9 * 9 * 2
+    assert_allclose(tm.trilist.shape, (162, 3))
+    assert_allclose(tm.range(), [9, 9])
+
+
+def test_colouredtrimesh_init_2d_grid():
+    tm = ColouredTriMesh.init_2d_grid([10, 10])
+    assert tm.n_points == 100
+    assert tm.n_dims == 2
+    # 162 = 9 * 9 * 2
+    assert_allclose(tm.trilist.shape, (162, 3))
+    assert_allclose(tm.range(), [9, 9])
+
+
+def test_texturedtrimesh_init_2d_grid():
+    tm = TexturedTriMesh.init_2d_grid([10, 10])
     assert tm.n_points == 100
     assert tm.n_dims == 2
     # 162 = 9 * 9 * 2

--- a/menpo/shape/mesh/test/trimish_test.py
+++ b/menpo/shape/mesh/test/trimish_test.py
@@ -1,7 +1,7 @@
 import warnings
 import numpy as np
 from numpy.testing import assert_allclose
-from menpo.image import Image
+from menpo.image import Image, MaskedImage
 from menpo.shape import TriMesh, TexturedTriMesh, ColouredTriMesh
 from menpo.testing import is_same_array
 
@@ -25,6 +25,29 @@ def test_trimesh_init_2d_grid():
     assert_allclose(tm.range(), [9, 9])
 
 
+def test_trimesh_init_from_depth_image():
+    fake_z = np.random.uniform(size=(10, 10))
+    tm = TriMesh.init_from_depth_image(Image(fake_z))
+    assert tm.n_points == 100
+    assert tm.n_dims == 3
+    assert_allclose(tm.range()[:2], [9, 9])
+    assert tm.points[:, -1].max() <= 1.0
+    assert tm.points[:, -1].min() >= 0.0
+
+
+def test_trimesh_init_from_depth_image_masked():
+    fake_z = np.random.uniform(size=(10, 10))
+    mask = np.zeros(fake_z.shape, dtype=np.bool)
+    mask[2:6, 2:6] = True
+    im = MaskedImage(fake_z, mask=mask)
+    tm = TriMesh.init_from_depth_image(im)
+    assert tm.n_points == 16
+    assert tm.n_dims == 3
+    assert_allclose(tm.range()[:2], [3, 3])
+    assert tm.points[:, -1].max() <= 1.0
+    assert tm.points[:, -1].min() >= 0.0
+
+
 def test_colouredtrimesh_init_2d_grid():
     tm = ColouredTriMesh.init_2d_grid([10, 10])
     assert tm.n_points == 100
@@ -34,6 +57,42 @@ def test_colouredtrimesh_init_2d_grid():
     assert_allclose(tm.range(), [9, 9])
 
 
+def test_colouredtrimesh_init_from_depth_image():
+    fake_z = np.random.uniform(size=(10, 10))
+    tm = ColouredTriMesh.init_from_depth_image(Image(fake_z))
+    assert tm.n_points == 100
+    assert tm.n_dims == 3
+    assert_allclose(tm.range()[:2], [9, 9])
+    assert tm.points[:, -1].max() <= 1.0
+    assert tm.points[:, -1].min() >= 0.0
+
+
+def test_colouredtrimesh_init_from_depth_image_masked():
+    fake_z = np.random.uniform(size=(10, 10))
+    mask = np.zeros(fake_z.shape, dtype=np.bool)
+    mask[2:6, 2:6] = True
+    im = MaskedImage(fake_z, mask=mask)
+    tm = ColouredTriMesh.init_from_depth_image(im)
+    assert tm.n_points == 16
+    assert tm.n_dims == 3
+    assert_allclose(tm.range()[:2], [3, 3])
+    assert tm.points[:, -1].max() <= 1.0
+    assert tm.points[:, -1].min() >= 0.0
+
+
+def test_colouredtrimesh_init_from_depth_image_coloured():
+    fake_z = np.random.uniform(size=(10, 10))
+    fake_colours = np.random.uniform(size=(100, 3))
+    tm = ColouredTriMesh.init_from_depth_image(Image(fake_z),
+                                               colours=fake_colours)
+    assert tm.n_points == 100
+    assert tm.n_dims == 3
+    assert tm.colours.shape == (100, 3)
+    assert_allclose(tm.range()[:2], [9, 9])
+    assert tm.points[:, -1].max() <= 1.0
+    assert tm.points[:, -1].min() >= 0.0
+
+
 def test_texturedtrimesh_init_2d_grid():
     tm = TexturedTriMesh.init_2d_grid([10, 10])
     assert tm.n_points == 100
@@ -41,6 +100,41 @@ def test_texturedtrimesh_init_2d_grid():
     # 162 = 9 * 9 * 2
     assert_allclose(tm.trilist.shape, (162, 3))
     assert_allclose(tm.range(), [9, 9])
+
+
+def test_texturedtrimesh_init_from_depth_image():
+    fake_z = np.random.uniform(size=(10, 10))
+    tm = TexturedTriMesh.init_from_depth_image(Image(fake_z))
+    assert tm.n_points == 100
+    assert tm.n_dims == 3
+    assert_allclose(tm.range()[:2], [9, 9])
+    assert tm.points[:, -1].max() <= 1.0
+    assert tm.points[:, -1].min() >= 0.0
+
+
+def test_texturedtrimesh_init_from_depth_image_masked():
+    fake_z = np.random.uniform(size=(10, 10))
+    mask = np.zeros(fake_z.shape, dtype=np.bool)
+    mask[2:6, 2:6] = True
+    im = MaskedImage(fake_z, mask=mask)
+    tm = TexturedTriMesh.init_from_depth_image(im)
+    assert tm.n_points == 16
+    assert tm.n_dims == 3
+    assert_allclose(tm.range()[:2], [3, 3])
+    assert tm.points[:, -1].max() <= 1.0
+    assert tm.points[:, -1].min() >= 0.0
+
+
+def test_texturedtrimesh_init_from_depth_image_textured():
+    fake_z = np.random.uniform(size=(10, 10))
+    fake_tex = Image(fake_z)
+    tm = TexturedTriMesh.init_from_depth_image(fake_tex, texture=fake_tex)
+    assert tm.n_points == 100
+    assert tm.n_dims == 3
+    assert tm.texture.shape == (10, 10)
+    assert_allclose(tm.range()[:2], [9, 9])
+    assert tm.points[:, -1].max() <= 1.0
+    assert tm.points[:, -1].min() >= 0.0
 
 
 def test_trimesh_creation_copy_true():

--- a/menpo/shape/mesh/textured.py
+++ b/menpo/shape/mesh/textured.py
@@ -4,7 +4,7 @@ from menpo.shape import PointCloud
 from menpo.transform import Scale
 
 from ..adjacency import mask_adjacency_array, reindex_adjacency_array
-from .base import TriMesh
+from .base import TriMesh, grid_tcoords
 
 
 class TexturedTriMesh(TriMesh):
@@ -37,6 +37,57 @@ class TexturedTriMesh(TriMesh):
             self.texture = texture
         else:
             self.texture = texture.copy()
+
+    @classmethod
+    def init_2d_grid(cls, shape, spacing=None, tcoords=None, texture=None):
+        r"""
+        Create a TexturedTriMesh that exists on a regular 2D grid. The first
+        dimension is the number of rows in the grid and the second dimension
+        of the shape is the number of columns. ``spacing`` optionally allows
+        the definition of the distance between points (uniform over points).
+        The spacing may be different for rows and columns.
+
+        The triangulation will be right-handed and the diagonal will go from
+        the top left to the bottom right of a square on the grid.
+
+        Parameters
+        ----------
+        shape : `tuple` of 2 `int`
+            The size of the grid to create, this defines the number of points
+            across each dimension in the grid. The first element is the number
+            of rows and the second is the number of columns.
+        spacing : `int` or `tuple` of 2 `int`, optional
+            The spacing between points. If a single `int` is provided, this
+            is applied uniformly across each dimension. If a `tuple` is
+            provided, the spacing is applied non-uniformly as defined e.g.
+            ``(2, 3)`` gives a spacing of 2 for the rows and 3 for the
+            columns.
+        tcoords : ``(N, 2)`` `ndarray`, optional
+            The texture coordinates for the mesh.
+        texture : :map:`Image`, optional
+            The texture for the mesh.
+
+        Returns
+        -------
+        trimesh : :map:`TriMesh`
+            A TriMesh arranged in a grid.
+        """
+        pc = TriMesh.init_2d_grid(shape, spacing=spacing)
+        points = pc.points
+        trilist = pc.trilist
+        # Ensure that the tcoords and texture are copied
+        if tcoords is not None:
+            tcoords = tcoords.copy()
+        else:
+            tcoords = grid_tcoords(shape)
+        if texture is not None:
+            texture = texture.copy()
+        else:
+            from menpo.image import Image
+            # Default texture is all black
+            texture = Image.init_blank(shape)
+        return TexturedTriMesh(points, tcoords, texture, trilist=trilist,
+                               copy=False)
 
     def tcoords_pixel_scaled(self):
         r"""

--- a/menpo/shape/mesh/textured.py
+++ b/menpo/shape/mesh/textured.py
@@ -113,7 +113,7 @@ class TexturedTriMesh(TriMesh):
 
         >>> texture = texturedtrimesh.texture
         >>> tc_ps = texturedtrimesh.tcoords_pixel_scaled()
-        >>> pixel_values_at_tcs = texture[tc_ps[: ,0], tc_ps[:, 1]]
+        >>> pixel_values_at_tcs = texture.sample(tc_ps)
         """
         scale = Scale(np.array(self.texture.shape)[::-1])
         tcoords = self.tcoords.points.copy()

--- a/menpo/shape/pointcloud.py
+++ b/menpo/shape/pointcloud.py
@@ -143,6 +143,36 @@ class PointCloud(Shape):
             points *= np.asarray(spacing, dtype=np.float64)
         return cls(points, copy=False)
 
+    @classmethod
+    def init_from_depth_image(cls, depth_image):
+        r"""
+        Return a 3D point cloud from the given depth image. The depth image
+        is assumed to represent height/depth values and the XY coordinates
+        are assumed to unit spaced and represent image coordinates. This is
+        particularly useful for visualising depth values that have been
+        recovered from images.
+
+        Parameters
+        ----------
+        depth_image : :map:`Image` or subclass
+            A single channel image that contains depth values - as commonly
+            returned by RGBD cameras, for example.
+
+        Returns
+        -------
+        depth_cloud : ``type(cls)``
+            A new 3D PointCloud with unit XY coordinates and the given depth
+            values as Z coordinates.
+        """
+        from menpo.image import MaskedImage
+
+        new_pcloud = cls.init_2d_grid(depth_image.shape)
+        if isinstance(depth_image, MaskedImage):
+            new_pcloud = new_pcloud.from_mask(depth_image.mask.as_vector())
+        return cls(np.hstack([new_pcloud.points,
+                              depth_image.as_vector(keep_channels=True).T]),
+                   copy=False)
+
     @property
     def n_points(self):
         r"""

--- a/menpo/shape/test/pointcloud_test.py
+++ b/menpo/shape/test/pointcloud_test.py
@@ -2,6 +2,7 @@ import warnings
 import numpy as np
 from nose.tools import raises
 from numpy.testing import assert_allclose
+from menpo.image import Image, MaskedImage
 from menpo.shape import PointCloud, bounding_box
 from menpo.testing import is_same_array
 
@@ -17,6 +18,29 @@ def test_pointcloud_init_2d_grid():
     assert pc.n_points == 100
     assert pc.n_dims == 2
     assert_allclose(pc.range(), [9, 9])
+
+
+def test_pointcloud_init_from_depth_image():
+    fake_z = np.random.uniform(size=(10, 10))
+    pc = PointCloud.init_from_depth_image(Image(fake_z))
+    assert pc.n_points == 100
+    assert pc.n_dims == 3
+    assert_allclose(pc.range()[:2], [9, 9])
+    assert pc.points[:, -1].max() <= 1.0
+    assert pc.points[:, -1].min() >= 0.0
+
+
+def test_pointcloud_init_from_depth_image_masked():
+    fake_z = np.random.uniform(size=(10, 10))
+    mask = np.zeros(fake_z.shape, dtype=np.bool)
+    mask[2:6, 2:6] = True
+    im = MaskedImage(fake_z, mask=mask)
+    pc = PointCloud.init_from_depth_image(im)
+    assert pc.n_points == 16
+    assert pc.n_dims == 3
+    assert_allclose(pc.range()[:2], [3, 3])
+    assert pc.points[:, -1].max() <= 1.0
+    assert pc.points[:, -1].min() >= 0.0
 
 
 def test_pointcloud_init_2d_grid_single_spacing():


### PR DESCRIPTION
Fixes #688.

Also fixes a horrible default argument bug for `ColouredTriMesh`.

The default grid texture coordinates are the coordinates you would use to texture an image on a 3D grid.
Also adds a new `init_from_depth_image` method that uses the `init_2d_grid` method to create a 2D grid and then concatenates a set of heights/depths in the form of an image and returns a 3D `PointCloud` or subclass.

E.g

```
depth_image = Image(np.random.random((100, 100)))
tr = TriMesh.init_from_depth_image(depth_image)
```

gives a 3D mesh with random heights, in the correct orientation for viewing a mesh 'image'.