### PR TITLE
Add mio.pickle_paths(glob)

### DIFF
--- a/menpo/io/__init__.py
+++ b/menpo/io/__init__.py
@@ -1,8 +1,9 @@
-from .input import (import_image, import_images, import_video, import_videos,
-                    import_landmark_file, import_landmark_files,
-                    import_pickle, import_pickles,
-                    import_builtin_asset,
-                    image_paths, landmark_file_paths, video_paths,
-                    data_path_to, data_dir_path, ls_builtin_assets)
-from .output import (export_image, export_landmark_file, export_pickle,
-                     export_video)
+from .input import (
+    import_image, import_images, image_paths,
+    import_video, import_videos, video_paths,
+    import_landmark_file, import_landmark_files, landmark_file_paths,
+    import_pickle, import_pickles, pickle_paths,
+    import_builtin_asset, data_dir_path, data_path_to, ls_builtin_assets
+)
+from .output import (export_image, export_video,
+                     export_landmark_file, export_pickle)

--- a/menpo/io/input/__init__.py
+++ b/menpo/io/input/__init__.py
@@ -1,6 +1,7 @@
-from .base import (import_image, import_images, import_video, import_videos,
-                   import_builtin_asset,
-                   import_landmark_file, import_landmark_files,
-                   data_path_to, data_dir_path, ls_builtin_assets,
-                   image_paths, landmark_file_paths, video_paths,
-                   import_pickle, import_pickles)
+from .base import (
+    import_image, import_images, image_paths,
+    import_video, import_videos, video_paths,
+    import_landmark_file, import_landmark_files, landmark_file_paths,
+    import_pickle, import_pickles, pickle_paths,
+    import_builtin_asset, data_dir_path, data_path_to, ls_builtin_assets
+)

--- a/menpo/io/input/base.py
+++ b/menpo/io/input/base.py
@@ -559,6 +559,14 @@ def landmark_file_paths(pattern):
     return glob_with_suffix(pattern, image_landmark_types)
 
 
+def pickle_paths(pattern):
+    r"""
+    Return pickle filepaths that Menpo can import that match the glob
+    pattern.
+    """
+    return glob_with_suffix(pattern, pickle_types)
+
+
 def _import_glob_lazy_list(pattern, extension_map, max_assets=None,
                            landmark_resolver=same_name, shuffle=False,
                            as_generator=False, landmark_ext_map=None,


### PR DESCRIPTION
We currently offer three functions for discovering what assets menpo can import for a given glob:

- `mio.image_paths()`
- `mio.video_paths()`
- `mio.landmark_file_paths()`

This PR simply completes the set by adding

- `mio.pickle_paths()`

I also just laid out the `__init__.py` imports a little more logically.