### PR TITLE
new OverwriteError raised specifically for overwrite errors in io.export

### DIFF
--- a/menpo/io/__init__.py
+++ b/menpo/io/__init__.py
@@ -7,3 +7,4 @@ from .input import (
 )
 from .output import (export_image, export_video,
                      export_landmark_file, export_pickle)
+from .exceptions import OverwriteError

--- a/menpo/io/exceptions.py
+++ b/menpo/io/exceptions.py
@@ -3,3 +3,15 @@ class MeshImportError(Exception):
     Raised when a mesh importer finds an unexpected data format.
     """
     pass
+
+
+class OverwriteError(ValueError):
+    r"""
+    Raised when an IO action would lead to the overwriting of an existing file
+    without explit intention.
+    """
+    def __init__(self, message, path, *args):
+        self.message = message  # without this you may get DeprecationWarning
+        self.path = path
+        # allow users initialize misc. arguments as any other builtin Error
+        super(OverwriteError, self).__init__(message, *args)

--- a/menpo/io/output/base.py
+++ b/menpo/io/output/base.py
@@ -4,6 +4,7 @@ from pathlib import Path
 
 from menpo.compatibility import basestring, str
 from .extensions import landmark_types, image_types, pickle_types, video_types
+from ..exceptions import OverwriteError
 from ..utils import _norm_path
 
 # an open file handle that uses a small fast level of compression
@@ -275,13 +276,15 @@ def _validate_filepath(fp, overwrite):
 
     Raises
     ------
-    ValueError
+    OverwriteError
         If ``overwrite == False`` and a file already exists at the file path.
     """
     path_filepath = _norm_path(fp)
     if path_filepath.exists() and not overwrite:
-        raise ValueError('File already exists. Please set the overwrite '
-                         'kwarg if you wish to overwrite the file.')
+        raise OverwriteError('File {} already exists. Please set the overwrite '
+                             'kwarg if you wish to overwrite '
+                             'the file.'.format(path_filepath.name),
+                             path_filepath)
     return path_filepath
 
 

--- a/menpo/io/test/io_export_test.py
+++ b/menpo/io/test/io_export_test.py
@@ -80,7 +80,7 @@ def test_export_filepath_explicit_ext_dot(mock_open, exists, landmark_types):
     assert export_function.call_count == 1
 
 
-@raises(ValueError)
+@raises(mio.OverwriteError)
 @patch('menpo.io.output.base.Path.exists')
 def test_export_filepath_no_overwrite_exists(exists):
     exists.return_value = True


### PR DESCRIPTION
Adds a new `OverwriteError` that is raised in place of the current `ValueError` when we hit `overwrite=False` cases in `menpo.io.export_*` methods.

`OverwriteError` is a subclass of `ValueError`, so this is not a breaking change.

I also now print the file stem in the error message to make it easier to debug the issue.

Principally needed to be able to implement https://github.com/menpo/menpocli/issues/2 cleanly.