### PR TITLE
Functional IO package

### DIFF
--- a/docs/source/api/menpo/io/index.rst
+++ b/docs/source/api/menpo/io/index.rst
@@ -16,6 +16,10 @@ Input
   import_pickle
   import_pickles
   import_builtin_asset
+  register_image_importer
+  register_landmark_importer
+  register_pickle_importer
+  register_video_importer
 
 
 Output

--- a/docs/source/api/menpo/io/register_image_importer.rst
+++ b/docs/source/api/menpo/io/register_image_importer.rst
@@ -1,0 +1,7 @@
+.. _menpo-io-register_image_importer:
+
+.. currentmodule:: menpo.io
+
+register_image_importer
+=======================
+.. autofunction:: register_image_importer

--- a/docs/source/api/menpo/io/register_landmark_importer.rst
+++ b/docs/source/api/menpo/io/register_landmark_importer.rst
@@ -1,0 +1,7 @@
+.. _menpo-io-register_landmark_importer:
+
+.. currentmodule:: menpo.io
+
+register_landmark_importer
+==========================
+.. autofunction:: register_landmark_importer

--- a/docs/source/api/menpo/io/register_pickle_importer.rst
+++ b/docs/source/api/menpo/io/register_pickle_importer.rst
@@ -1,0 +1,7 @@
+.. _menpo-io-register_pickle_importer:
+
+.. currentmodule:: menpo.io
+
+register_pickle_importer
+========================
+.. autofunction:: register_pickle_importer

--- a/docs/source/api/menpo/io/register_video_importer.rst
+++ b/docs/source/api/menpo/io/register_video_importer.rst
@@ -1,0 +1,7 @@
+.. _menpo-io-register_video_importer:
+
+.. currentmodule:: menpo.io
+
+register_video_importer
+=======================
+.. autofunction:: register_video_importer

--- a/menpo/base.py
+++ b/menpo/base.py
@@ -578,10 +578,6 @@ def partial_doc(func, *args, **kwargs):
     ----------
     func : `callable`
         The func to partial and whose docs should be copied.
-    menpo_f_name : `str`, optional
-        Optionally pass a string to set as the name partial method __name__.
-        Odd parameter name to attempt to avoid collisions with the
-        partial function arguments.
     args : ...
         Any arguments to partial.
     kwargs : `dict`
@@ -592,9 +588,6 @@ def partial_doc(func, *args, **kwargs):
     p_func : `callable`
         The partially wrapped func with __doc__ attached.
     """
-    menpo_f_name = kwargs.pop('menpo_f_name', None)
     p = partial(func, *args, **kwargs)
     p.__doc__ = func.__doc__
-    if menpo_f_name is not None:
-        p.__name__ = menpo_f_name
     return p

--- a/menpo/base.py
+++ b/menpo/base.py
@@ -568,7 +568,7 @@ class LazyList(collections.Sequence):
         return self.__class__(list(self._callables) + new_callables)
 
 
-def partial_doc(func, *args, menpo_f_name__=None, **kwargs):
+def partial_doc(func, *args, menpo_f_name=None, **kwargs):
     r"""
     Return a partial function but the __doc__ attached to the returned
     partial. Note that no effort is made to correct the docstring for
@@ -578,7 +578,7 @@ def partial_doc(func, *args, menpo_f_name__=None, **kwargs):
     ----------
     func : `callable`
         The func to partial and whose docs should be copied.
-    menpo_f_name__ : `str`, optional
+    menpo_f_name : `str`, optional
         Optionally pass a string to set as the name partial method __name__.
         Odd parameter name to attempt to avoid collisions with the
         partial function arguments.
@@ -594,6 +594,6 @@ def partial_doc(func, *args, menpo_f_name__=None, **kwargs):
     """
     p = partial(func, *args, **kwargs)
     p.__doc__ = func.__doc__
-    if menpo_f_name__ is not None:
-        p.__name__ = menpo_f_name__
+    if menpo_f_name is not None:
+        p.__name__ = menpo_f_name
     return p

--- a/menpo/base.py
+++ b/menpo/base.py
@@ -568,7 +568,7 @@ class LazyList(collections.Sequence):
         return self.__class__(list(self._callables) + new_callables)
 
 
-def partial_doc(func, *args, __menpo_f_name__=None, **kwargs):
+def partial_doc(func, *args, menpo_f_name__=None, **kwargs):
     r"""
     Return a partial function but the __doc__ attached to the returned
     partial. Note that no effort is made to correct the docstring for
@@ -578,7 +578,7 @@ def partial_doc(func, *args, __menpo_f_name__=None, **kwargs):
     ----------
     func : `callable`
         The func to partial and whose docs should be copied.
-    __menpo_f_name__ : `str`, optional
+    menpo_f_name__ : `str`, optional
         Optionally pass a string to set as the name partial method __name__.
         Odd parameter name to attempt to avoid collisions with the
         partial function arguments.
@@ -594,6 +594,6 @@ def partial_doc(func, *args, __menpo_f_name__=None, **kwargs):
     """
     p = partial(func, *args, **kwargs)
     p.__doc__ = func.__doc__
-    if __menpo_f_name__ is not None:
-        p.__name__ = __menpo_f_name__
+    if menpo_f_name__ is not None:
+        p.__name__ = menpo_f_name__
     return p

--- a/menpo/base.py
+++ b/menpo/base.py
@@ -568,7 +568,7 @@ class LazyList(collections.Sequence):
         return self.__class__(list(self._callables) + new_callables)
 
 
-def partial_doc(func, *args, menpo_f_name=None, **kwargs):
+def partial_doc(func, *args, **kwargs):
     r"""
     Return a partial function but the __doc__ attached to the returned
     partial. Note that no effort is made to correct the docstring for
@@ -592,6 +592,7 @@ def partial_doc(func, *args, menpo_f_name=None, **kwargs):
     p_func : `callable`
         The partially wrapped func with __doc__ attached.
     """
+    menpo_f_name = kwargs.pop('menpo_f_name', None)
     p = partial(func, *args, **kwargs)
     p.__doc__ = func.__doc__
     if menpo_f_name is not None:

--- a/menpo/feature/optional/vlfeat.py
+++ b/menpo/feature/optional/vlfeat.py
@@ -118,7 +118,7 @@ def dsift(pixels, window_step_horizontal=1, window_step_vertical=1,
 fast_dsift = partial_doc(dsift, fast=True, cell_size_vertical=5,
                          cell_size_horizontal=5, num_bins_horizontal=1,
                          num_bins_vertical=1, num_or_bins=8,
-                         __menpo_f_name__='fast_dsift')
+                         menpo_f_name__='fast_dsift')
 
 
 # Predefined dsift that returns a 128d vector

--- a/menpo/feature/optional/vlfeat.py
+++ b/menpo/feature/optional/vlfeat.py
@@ -118,7 +118,7 @@ def dsift(pixels, window_step_horizontal=1, window_step_vertical=1,
 fast_dsift = partial_doc(dsift, fast=True, cell_size_vertical=5,
                          cell_size_horizontal=5, num_bins_horizontal=1,
                          num_bins_vertical=1, num_or_bins=8,
-                         menpo_f_name__='fast_dsift')
+                         menpo_f_name='fast_dsift')
 
 
 # Predefined dsift that returns a 128d vector

--- a/menpo/feature/optional/vlfeat.py
+++ b/menpo/feature/optional/vlfeat.py
@@ -117,8 +117,7 @@ def dsift(pixels, window_step_horizontal=1, window_step_vertical=1,
 # A predefined method for a 'faster' dsift method
 fast_dsift = partial_doc(dsift, fast=True, cell_size_vertical=5,
                          cell_size_horizontal=5, num_bins_horizontal=1,
-                         num_bins_vertical=1, num_or_bins=8,
-                         menpo_f_name='fast_dsift')
+                         num_bins_vertical=1, num_or_bins=8)
 
 
 # Predefined dsift that returns a 128d vector

--- a/menpo/feature/predefined.py
+++ b/menpo/feature/predefined.py
@@ -1,5 +1,5 @@
 from menpo.base import partial_doc
 from .features import igo, hog
 
-double_igo = partial_doc(igo, double_angles=True, __menpo_f_name__='double_igo')
-sparse_hog = partial_doc(hog, mode='sparse', __menpo_f_name__='sparse_hog')
+double_igo = partial_doc(igo, double_angles=True, menpo_f_name__='double_igo')
+sparse_hog = partial_doc(hog, mode='sparse', menpo_f_name__='sparse_hog')

--- a/menpo/feature/predefined.py
+++ b/menpo/feature/predefined.py
@@ -1,5 +1,5 @@
 from menpo.base import partial_doc
 from .features import igo, hog
 
-double_igo = partial_doc(igo, double_angles=True, menpo_f_name='double_igo')
-sparse_hog = partial_doc(hog, mode='sparse', menpo_f_name='sparse_hog')
+double_igo = partial_doc(igo, double_angles=True)
+sparse_hog = partial_doc(hog, mode='sparse')

--- a/menpo/feature/predefined.py
+++ b/menpo/feature/predefined.py
@@ -1,5 +1,5 @@
 from menpo.base import partial_doc
 from .features import igo, hog
 
-double_igo = partial_doc(igo, double_angles=True, menpo_f_name__='double_igo')
-sparse_hog = partial_doc(hog, mode='sparse', menpo_f_name__='sparse_hog')
+double_igo = partial_doc(igo, double_angles=True, menpo_f_name='double_igo')
+sparse_hog = partial_doc(hog, mode='sparse', menpo_f_name='sparse_hog')

--- a/menpo/io/__init__.py
+++ b/menpo/io/__init__.py
@@ -7,3 +7,4 @@ from .input import (
 )
 from .output import (export_image, export_video,
                      export_landmark_file, export_pickle)
+from .exceptions import OverwriteError

--- a/menpo/io/__init__.py
+++ b/menpo/io/__init__.py
@@ -3,7 +3,9 @@ from .input import (
     import_video, import_videos, video_paths,
     import_landmark_file, import_landmark_files, landmark_file_paths,
     import_pickle, import_pickles, pickle_paths,
-    import_builtin_asset, data_dir_path, data_path_to, ls_builtin_assets
+    import_builtin_asset, data_dir_path, data_path_to, ls_builtin_assets,
+    register_image_importer, register_landmark_importer,
+    register_pickle_importer, register_video_importer
 )
 from .output import (export_image, export_video,
                      export_landmark_file, export_pickle)

--- a/menpo/io/exceptions.py
+++ b/menpo/io/exceptions.py
@@ -3,3 +3,15 @@ class MeshImportError(Exception):
     Raised when a mesh importer finds an unexpected data format.
     """
     pass
+
+
+class OverwriteError(ValueError):
+    r"""
+    Raised when an IO action would lead to the overwriting of an existing file
+    without explit intention.
+    """
+    def __init__(self, message, path, *args):
+        self.message = message  # without this you may get DeprecationWarning
+        self.path = path
+        # allow users initialize misc. arguments as any other builtin Error
+        super(OverwriteError, self).__init__(message, *args)

--- a/menpo/io/input/__init__.py
+++ b/menpo/io/input/__init__.py
@@ -3,9 +3,9 @@ from .base import (
     import_video, import_videos, video_paths,
     import_landmark_file, import_landmark_files, landmark_file_paths,
     import_pickle, import_pickles, pickle_paths,
-    import_builtin_asset, 
-    menpo_data_path_to as data_path_to, 
-    menpo_data_dir_path as data_dir_path, 
+    import_builtin_asset,
+    menpo_data_path_to as data_path_to,
+    menpo_data_dir_path as data_dir_path,
     menpo_ls_builtin_assets as ls_builtin_assets,
     same_name, same_name_video
 )

--- a/menpo/io/input/__init__.py
+++ b/menpo/io/input/__init__.py
@@ -3,5 +3,9 @@ from .base import (
     import_video, import_videos, video_paths,
     import_landmark_file, import_landmark_files, landmark_file_paths,
     import_pickle, import_pickles, pickle_paths,
-    import_builtin_asset, data_dir_path, data_path_to, ls_builtin_assets
+    import_builtin_asset, 
+    menpo_data_path_to as data_path_to, 
+    menpo_data_dir_path as data_dir_path, 
+    menpo_ls_builtin_assets as ls_builtin_assets,
+    same_name, same_name_video
 )

--- a/menpo/io/input/__init__.py
+++ b/menpo/io/input/__init__.py
@@ -7,5 +7,7 @@ from .base import (
     menpo_data_path_to as data_path_to,
     menpo_data_dir_path as data_dir_path,
     menpo_ls_builtin_assets as ls_builtin_assets,
+    register_image_importer, register_landmark_importer,
+    register_pickle_importer, register_video_importer,
     same_name, same_name_video
 )

--- a/menpo/io/input/base.py
+++ b/menpo/io/input/base.py
@@ -118,29 +118,22 @@ def _register_importer(ext_map, extension, callable):
     ext_map[_normalize_extension(extension)] = callable
 
 
-register_image_importer = partial_doc(_register_importer, image_types,
-                                      menpo_f_name='register_image_importer')
+register_image_importer = partial_doc(_register_importer, image_types)
 
-register_video_importer = partial_doc(_register_importer, ffmpeg_video_types,
-                                      menpo_f_name='register_video_importer')
+register_video_importer = partial_doc(_register_importer, ffmpeg_video_types)
 
-register_landmark_importer = partial_doc(
-    _register_importer, image_landmark_types,
-    menpo_f_name='register_landmark_importer')
+register_landmark_importer = partial_doc(_register_importer,
+                                         image_landmark_types)
 
-register_pickle_importer = partial_doc(_register_importer, pickle_types,
-                                       menpo_f_name='register_pickle_importer')
+register_pickle_importer = partial_doc(_register_importer, pickle_types)
 
 
-menpo_data_dir_path = partial_doc(_data_dir_path, menpo_src_dir_path,
-                                  menpo_f_name='data_dir_path')
+menpo_data_dir_path = partial_doc(_data_dir_path, menpo_src_dir_path)
 
-menpo_ls_builtin_assets = partial_doc(_ls_builtin_assets, menpo_data_dir_path,
-                                      menpo_f_name='ls_builtin_assets')
+menpo_ls_builtin_assets = partial_doc(_ls_builtin_assets, menpo_data_dir_path)
 
 menpo_data_path_to = partial_doc(_data_path_to, menpo_data_dir_path,
-                                 menpo_ls_builtin_assets,
-                                 menpo_f_name='data_path_to')
+                                 menpo_ls_builtin_assets)
 
 _menpo_import_builtin_asset = partial_doc(_import_builtin_asset,
                                           menpo_data_path_to,

--- a/menpo/io/input/base.py
+++ b/menpo/io/input/base.py
@@ -6,7 +6,7 @@ import random
 from menpo.base import menpo_src_dir_path, LazyList
 from menpo.visualize import print_progress
 
-from ..utils import _norm_path
+from ..utils import _norm_path, _possible_extensions_from_filepath
 from .extensions import (image_landmark_types, image_types, pickle_types,
                          ffmpeg_video_types)
 
@@ -790,28 +790,6 @@ def glob_with_suffix(pattern, extensions_map, sort=True):
         possible_exts = _possible_extensions_from_filepath(path)
         if any([ext in extensions_map for ext in possible_exts]):
             yield path
-
-
-def _possible_extensions_from_filepath(filepath):
-    r"""
-    Generate a list of possible extensions from the given filepath. Since
-    filenames can contain '.' characters and some extensions are compound
-    (e.g. '.pkl.gz'), there may be many possible extensions for a given
-    path. Generate a list possible extensions, preferring longer extensions.
-
-    Parameters
-    ----------
-    filepath : `Path`
-        A pathlib Path.
-
-    Returns
-    -------
-    possible_extensions : `list` of `str`
-        A list of extensions **with** leading '.' characters and converted
-        to lowercase.
-    """
-    suffixes = filepath.suffixes
-    return [''.join(suffixes[i:]).lower() for i in range(len(suffixes))]
 
 
 def importer_for_filepath(filepath, extensions_map):

--- a/menpo/io/input/base.py
+++ b/menpo/io/input/base.py
@@ -8,8 +8,8 @@ from menpo.base import menpo_src_dir_path, LazyList, partial_doc
 from menpo.compatibility import basestring
 from menpo.visualize import print_progress
 
-from ..utils import _norm_path, _possible_extensions_from_filepath, \
-    _normalize_extension
+from ..utils import (_norm_path, _possible_extensions_from_filepath,
+                     _normalize_extension)
 from .extensions import (image_landmark_types, image_types, pickle_types,
                          ffmpeg_video_types)
 
@@ -97,8 +97,7 @@ def _ls_builtin_assets(data_dir_path):
 
 def _register_importer(ext_map, extension, callable):
     r"""
-    Register a new importer for the given extension. This makes it much
-    simpler to add custom importers to the IO package.
+    Register a new importer for the given extension.
 
     Parameters
     ----------

--- a/menpo/io/input/base.py
+++ b/menpo/io/input/base.py
@@ -1,25 +1,28 @@
 from functools import partial
-from collections import Sequence
 import os
 from pathlib import Path
 import random
-from ..utils import _norm_path
+
 from menpo.base import menpo_src_dir_path, LazyList
 from menpo.visualize import print_progress
 
+from ..utils import _norm_path
+from .extensions import (image_landmark_types, image_types, pickle_types,
+                         ffmpeg_video_types)
 
-def data_dir_path():
-    r"""A path to the Menpo built in ./data folder on this machine.
+
+def _data_dir_path(base_path):
+    r"""A path to the built in ./data folder on this machine.
 
     Returns
     -------
-    ``pathlib.Path``
-        The path to the local Menpo ./data folder
+    path : ``pathlib.Path``
+        The path to the local ./data folder
     """
-    return menpo_src_dir_path() / 'data'
+    return base_path() / 'data'
 
 
-def data_path_to(asset_filename):
+def _data_path_to(data_dir_path, builtin_assets, asset_filename):
     r"""
     The path to a builtin asset in the ./data folder on this machine.
 
@@ -42,30 +45,118 @@ def data_path_to(asset_filename):
     asset_path = data_dir_path() / asset_filename
     if not asset_path.is_file():
         raise ValueError("{} is not a builtin asset: {}".format(
-            asset_filename, ls_builtin_assets()))
+            asset_filename, builtin_assets()))
     return asset_path
 
 
-def same_name(path):
+def _import_builtin_asset(data_path_to, object_types, landmark_types,
+                          asset_name, **kwargs):
+    r"""Single builtin asset (landmark or image) importer.
+
+    Imports the relevant builtin asset from the ``./data`` directory that
+    ships with Menpo.
+
+    Parameters
+    ----------
+    asset_name : `str`
+        The filename of a builtin asset (see :map:`ls_builtin_assets`
+        for allowed values)
+
+    Returns
+    -------
+    asset :
+        An instantiated :map:`Image` or :map:`LandmarkGroup` asset.
+    """
+    asset_path = data_path_to(asset_name)
+    # Import could be either an image or a set of landmarks, so we try
+    # importing them both separately.
+    try:
+        return _import(asset_path, object_types,
+                       landmark_ext_map=landmark_types,
+                       landmark_attach_func=_import_object_attach_landmarks,
+                       importer_kwargs=kwargs)
+    except ValueError:
+        return _import(asset_path, landmark_types,
+                       importer_kwargs=kwargs)
+
+
+def _ls_builtin_assets(data_dir_path):
+    r"""List all the builtin asset examples provided.
+
+    Returns
+    -------
+    file_paths : list of `str`
+        Filenames of all assets in the data directory shipped with Menpo
+    """
+    return [p.name for p in data_dir_path().glob('*') if not p.is_dir()]
+
+
+menpo_data_dir_path = partial(_data_dir_path, menpo_src_dir_path)
+menpo_data_dir_path.__doc__ = _data_dir_path.__doc__
+
+menpo_ls_builtin_assets = partial(_ls_builtin_assets, menpo_data_dir_path)
+menpo_ls_builtin_assets.__doc__ = _ls_builtin_assets.__doc__
+
+menpo_data_path_to = partial(_data_path_to, menpo_data_dir_path,
+                             menpo_ls_builtin_assets)
+menpo_data_path_to.__doc__ = _data_path_to.__doc__
+
+_menpo_import_builtin_asset = partial(_import_builtin_asset, menpo_data_path_to,
+                                      image_types, image_landmark_types)
+_menpo_import_builtin_asset.__doc__ = _import_builtin_asset.__doc__
+
+
+def image_paths(pattern):
     r"""
-    Menpo's default image landmark resolver. Returns all landmarks found to have
+    Return image filepaths that Menpo can import that match the glob pattern.
+    """
+    return glob_with_suffix(pattern, image_types)
+
+
+def video_paths(pattern):
+    r"""
+    Return video filepaths that Menpo can import that match the glob pattern.
+    """
+    return glob_with_suffix(pattern, ffmpeg_video_types)
+
+
+def landmark_file_paths(pattern):
+    r"""
+    Return landmark file filepaths that Menpo can import that match the glob
+    pattern.
+    """
+    return glob_with_suffix(pattern, image_landmark_types)
+
+
+def pickle_paths(pattern):
+    r"""
+    Return pickle filepaths that Menpo can import that match the glob
+    pattern.
+    """
+    return glob_with_suffix(pattern, pickle_types)
+
+
+def same_name(path, paths_callable=landmark_file_paths):
+    r"""
+    Default image landmark resolver. Returns all landmarks found to have
     the same stem as the asset.
     """
     # pattern finding all landmarks with the same stem
     pattern = path.with_suffix('.*')
-    # find all the landmarks we can with this name. Key is ext (without '.')
-    return {p.suffix[1:].upper(): p for p in landmark_file_paths(pattern)}
+    # find all the assets we can with this name. Key is extension.
+    return {p.suffix[1:].upper(): p for p in paths_callable(pattern)}
 
 
-def same_name_video(path, frame_number):
+def same_name_video(path, frame_number,
+                    paths_callable=landmark_file_paths):
     r"""
-    Menpo's default video landmark resolver. Returns all landmarks found to have
+    Default video landmark resolver. Returns all landmarks found to have
     the same stem as the asset.
     """
     # pattern finding all landmarks with the same stem
     pattern = path.with_name('{}_{}.*'.format(path.stem, frame_number))
-    # find all the landmarks we can with this name. Key is ext (without '.')
-    return {p.suffix[1:].upper(): p for p in landmark_file_paths(pattern)}
+    # find all the assets we can with this name. Key is extension
+    return {p.suffix[1:].upper(): p for p in paths_callable(pattern)}
 
 
 def import_image(filepath, landmark_resolver=same_name, normalise=True):
@@ -476,97 +567,6 @@ def import_pickles(pattern, max_pickles=None, shuffle=False, as_generator=False,
                                   as_generator=as_generator, verbose=verbose)
 
 
-def _import_builtin_asset(asset_name, **kwargs):
-    r"""Single builtin asset (landmark or image) importer.
-
-    Imports the relevant builtin asset from the ``./data`` directory that
-    ships with Menpo.
-
-    Parameters
-    ----------
-    asset_name : `str`
-        The filename of a builtin asset (see :map:`ls_builtin_assets`
-        for allowed values)
-
-    Returns
-    -------
-    asset :
-        An instantiated :map:`Image` or :map:`LandmarkGroup` asset.
-    """
-    asset_path = data_path_to(asset_name)
-    # Import could be either an image or a set of landmarks, so we try
-    # importing them both separately.
-    try:
-        return _import(asset_path, image_types,
-                       landmark_ext_map=image_landmark_types,
-                       landmark_attach_func=_import_object_attach_landmarks,
-                       importer_kwargs=kwargs)
-    except ValueError:
-        return _import(asset_path, image_landmark_types,
-                       importer_kwargs=kwargs)
-
-
-def ls_builtin_assets():
-    r"""List all the builtin asset examples provided in Menpo.
-
-    Returns
-    -------
-    list of strings
-        Filenames of all assets in the data directory shipped with Menpo
-    """
-    return [p.name for p in data_dir_path().glob('*') if not p.is_dir()]
-
-
-def import_builtin(x):
-
-    def execute(**kwargs):
-        return _import_builtin_asset(x, **kwargs)
-
-    return execute
-
-
-class BuiltinAssets(object):
-
-    def __call__(self, asset_name, **kwargs):
-        return _import_builtin_asset(asset_name, **kwargs)
-
-import_builtin_asset = BuiltinAssets()
-
-for asset in ls_builtin_assets():
-    setattr(import_builtin_asset, asset.replace('.', '_'),
-            import_builtin(asset))
-
-
-def image_paths(pattern):
-    r"""
-    Return image filepaths that Menpo can import that match the glob pattern.
-    """
-    return glob_with_suffix(pattern, image_types)
-
-
-def video_paths(pattern):
-    r"""
-    Return video filepaths that Menpo can import that match the glob pattern.
-    """
-    return glob_with_suffix(pattern, ffmpeg_video_types)
-
-
-def landmark_file_paths(pattern):
-    r"""
-    Return landmark file filepaths that Menpo can import that match the glob
-    pattern.
-    """
-    return glob_with_suffix(pattern, image_landmark_types)
-
-
-def pickle_paths(pattern):
-    r"""
-    Return pickle filepaths that Menpo can import that match the glob
-    pattern.
-    """
-    return glob_with_suffix(pattern, pickle_types)
-
-
 def _import_glob_lazy_list(pattern, extension_map, max_assets=None,
                            landmark_resolver=same_name, shuffle=False,
                            as_generator=False, landmark_ext_map=None,
@@ -581,6 +581,7 @@ def _import_glob_lazy_list(pattern, extension_map, max_assets=None,
                          ' ({} provided)'.format(max_assets))
     elif max_assets:
         filepaths = filepaths[:max_assets]
+
     n_files = len(filepaths)
     if n_files == 0:
         raise ValueError('The glob {} yields no assets'.format(pattern))
@@ -649,32 +650,31 @@ def _import(filepath, extensions_map, landmark_resolver=same_name,
             landmark_ext_map=None, landmark_attach_func=None,
             asset=None, importer_kwargs=None):
     r"""
-    Creates an importer for the filepath passed in, and then calls build on
-    it, returning a list of assets or a single asset, depending on the
-    file type.
+    Finds an importer for the filepath passed in and then calls it with the
+    filepath and optionally an asset, returning either a list of assets or a
+    single asset, depending on the file type.
 
     The type of assets returned are specified by the `extensions_map`.
 
     Parameters
     ----------
-    filepath : string
-        The filepath to import
-    extensions_map : dictionary (String, :class:`menpo.io.base.Importer`)
+    filepath : `Path` or `str`
+        The filepath to import.
+    extensions_map : `dict` (String, :class:`menpo.io.base.Importer`)
         A map from extensions to importers. The importers are expected to be
         non-instantiated classes. The extensions are expected to
         contain the leading period eg. `.obj`.
-    landmark_ext_map : dictionary (str, :map:`Importer`), optional
+    landmark_ext_map : `dict` (str, :map:`Importer`), optional
         If not None an attempt will be made to import annotations with
         extensions defined in this mapping. If None, no attempt will be
         made to import annotations.
-    landmark_resolver: function, optional
+    landmark_resolver : `callable`, optional
         If not None, this function will be used to find landmarks for each
         asset. The function should take one argument (the asset itself) and
         return a dictionary of the form {'group_name': 'landmark_filepath'}
-    asset: object, optional
-        If not None, the asset will be passed to the importer's build method
-        as the asset kwarg
-    importer_kwargs: dict, optional:
+    asset : `object`, optional
+        Passed through to the importer callable.
+    importer_kwargs : `dict`, optional
         kwargs that will be supplied to the importer if not None
 
     Returns
@@ -685,15 +685,14 @@ def _import(filepath, extensions_map, landmark_resolver=same_name,
     path = _norm_path(filepath)
     if not path.is_file():
         raise ValueError("{} is not a file".format(path))
+
     # below could raise ValueError as well...
-    importer = importer_for_filepath(path, extensions_map,
-                                     importer_kwargs=importer_kwargs)
-    if asset is not None:
-        built_objects = importer.build(asset=asset)
-    else:
-        built_objects = importer.build()
+    importer_callable = importer_for_filepath(path, extensions_map)
+    if importer_kwargs is None:
+        importer_kwargs = {}
+    built_objects = importer_callable(path, asset=asset, **importer_kwargs)
+
     # landmarks are iterable so check for list precisely
-    # enforce a list to make processing consistent
     if not isinstance(built_objects, list):
         built_objects = [built_objects]
 
@@ -709,7 +708,6 @@ def _import(filepath, extensions_map, landmark_resolver=same_name,
         landmark_attach_func(built_objects, landmark_resolver,
                              landmark_ext_map=landmark_ext_map)
 
-    # undo list-ification (if we added it!)
     if len(built_objects) == 1:
         built_objects = built_objects[0]
 
@@ -789,17 +787,34 @@ def glob_with_suffix(pattern, extensions_map, sort=True):
         The list of filepaths that have valid extensions.
     """
     for path in _pathlib_glob_for_pattern(pattern, sort=sort):
-        # we want to extract '.pkl.gz' as an extension - for this we need to
-        # use suffixes and join.
-        # .suffix only takes
-        # However, the filename might have a '.' in it, e.g. '1.1.png'.
-        # In this case, try again with just the suffix.
-        if (''.join(path.suffixes[-2:]) in extensions_map or
-                path.suffix in extensions_map):
+        possible_exts = _possible_extensions_from_filepath(path)
+        if any([ext in extensions_map for ext in possible_exts]):
             yield path
 
 
-def importer_for_filepath(filepath, extensions_map, importer_kwargs=None):
+def _possible_extensions_from_filepath(filepath):
+    r"""
+    Generate a list of possible extensions from the given filepath. Since
+    filenames can contain '.' characters and some extensions are compound
+    (e.g. '.pkl.gz'), there may be many possible extensions for a given
+    path. Generate a list possible extensions, preferring longer extensions.
+
+    Parameters
+    ----------
+    filepath : `Path`
+        A pathlib Path.
+
+    Returns
+    -------
+    possible_extensions : `list` of `str`
+        A list of extensions **with** leading '.' characters and converted
+        to lowercase.
+    """
+    suffixes = filepath.suffixes
+    return [''.join(suffixes[i:]).lower() for i in range(len(suffixes))]
+
+
+def importer_for_filepath(filepath, extensions_map):
     r"""
     Given a filepath, return the appropriate importer as mapped by the
     extension map.
@@ -807,81 +822,46 @@ def importer_for_filepath(filepath, extensions_map, importer_kwargs=None):
     Parameters
     ----------
     filepath : `pathlib.Path`
-        The filepath to get importers for
+        The filepath to get importers for.
     extensions_map : dictionary (String, :class:`menpo.io.base.Importer`)
         A map from extensions to importers. The importers are expected to be
         a subclass of :class:`Importer`. The extensions are expected to
         contain the leading period eg. `.obj`.
-    importer_kwargs: dictionary, optional
-        kwargs that will be supplied to the importer if not None.
 
     Returns
     --------
     importer: :class:`menpo.io.base.Importer` instance
         Importer as found in the `extensions_map` instantiated for the
         filepath provided.
-
     """
-    suffix = ''.join(filepath.suffixes)
-    if suffix.isupper():
-        # If for some reason the ending is in capital letters, make them lower
-        # case first.
-        suffix = suffix.lower()
-    importer_type = extensions_map.get(suffix)
+    possible_exts = _possible_extensions_from_filepath(filepath)
+
     # we couldn't find an importer for all the suffixes (e.g .foo.bar)
     # maybe the file stem has '.' in it? -> try again but this time just use the
     # final suffix (.bar). (Note we first try '.foo.bar' as we want to catch
-    # cases like 'pkl.gz')
-    if importer_type is None and len(filepath.suffixes) > 1:
-        suffix = filepath.suffix
-        importer_type = extensions_map.get(suffix)
-    if importer_type is None:
+    # cases like '.pkl.gz')
+    importer_callable = None
+    while importer_callable is None and possible_exts:
+        importer_callable = extensions_map.get(possible_exts.pop(0))
+
+    if importer_callable is None:
         raise ValueError("{} does not have a "
-                         "suitable importer.".format(suffix))
-    if importer_kwargs is not None:
-        return importer_type(str(filepath), **importer_kwargs)
-    else:
-        return importer_type(str(filepath))
+                         "suitable importer.".format(filepath.name))
+    return importer_callable
 
 
-class Importer(object):
-    r"""
-    Abstract representation of an Importer. Construction of an importer simply
-    sets the filepaths etc up. To actually import the object and build a valid
-    representation, the `build` method must be called. This allows a set
-    of importers to be instantiated but the heavy duty importing to happen
-    separately.
+# Create special callable that can both be called with a builtin asset name
+# and has dynamic methods attached that list the available builtin assets
+class BuiltinAssets(object):
 
-    Parameters
-    ----------
-    filepath : string
-        An absolute filepath
-    """
+    def __init__(self, import_builtin_callable):
+        self.import_builtin_asset = import_builtin_callable
 
-    def __init__(self, filepath):
-        self.filepath = os.path.abspath(os.path.expanduser(filepath))
-        self.filename = os.path.splitext(os.path.basename(self.filepath))[0]
-        self.extension = os.path.splitext(self.filepath)[1]
-        self.folder = os.path.dirname(self.filepath)
+    def __call__(self, asset_name, **kwargs):
+        return self.import_builtin_asset(asset_name, **kwargs)
 
-    def build(self):
-        r"""
-        Performs the heavy lifting for the importer class. This actually reads
-        the file in from disk and does any necessary parsing of the data in to
-        an appropriate format.
+import_builtin_asset = BuiltinAssets(_menpo_import_builtin_asset)
 
-        Returns
-        -------
-        object : object or list
-            An instantiated class of the expected type. For example, for an
-            `.obj` importer, this would be a
-            :class:`menpo.shape.Trimesh`. If multiple objects need
-            to be returned from one importer, a list must be returned (and
-            not a subclass of list - explicitly a list).
-        """
-        raise NotImplementedError()
-
-
-# Avoid circular imports
-from menpo.io.input.extensions import (image_landmark_types, image_types,
-                                       pickle_types, ffmpeg_video_types)
+for asset in menpo_ls_builtin_assets():
+    setattr(import_builtin_asset, asset.replace('.', '_'),
+            partial(_menpo_import_builtin_asset, asset))

--- a/menpo/io/input/base.py
+++ b/menpo/io/input/base.py
@@ -120,28 +120,28 @@ def _register_importer(ext_map, extension, callable):
 
 
 register_image_importer = partial_doc(_register_importer, image_types,
-                                      menpo_f_name__='register_image_importer')
+                                      menpo_f_name='register_image_importer')
 
 register_video_importer = partial_doc(_register_importer, ffmpeg_video_types,
-                                      menpo_f_name__='register_video_importer')
+                                      menpo_f_name='register_video_importer')
 
 register_landmark_importer = partial_doc(
     _register_importer, image_landmark_types,
-    menpo_f_name__='register_landmark_importer')
+    menpo_f_name='register_landmark_importer')
 
 register_pickle_importer = partial_doc(_register_importer, pickle_types,
-                                       menpo_f_name__='register_pickle_importer')
+                                       menpo_f_name='register_pickle_importer')
 
 
 menpo_data_dir_path = partial_doc(_data_dir_path, menpo_src_dir_path,
-                                  menpo_f_name__='data_dir_path')
+                                  menpo_f_name='data_dir_path')
 
 menpo_ls_builtin_assets = partial_doc(_ls_builtin_assets, menpo_data_dir_path,
-                                      menpo_f_name__='ls_builtin_assets')
+                                      menpo_f_name='ls_builtin_assets')
 
 menpo_data_path_to = partial_doc(_data_path_to, menpo_data_dir_path,
                                  menpo_ls_builtin_assets,
-                                 menpo_f_name__='data_path_to')
+                                 menpo_f_name='data_path_to')
 
 _menpo_import_builtin_asset = partial_doc(_import_builtin_asset,
                                           menpo_data_path_to,

--- a/menpo/io/input/base.py
+++ b/menpo/io/input/base.py
@@ -120,28 +120,28 @@ def _register_importer(ext_map, extension, callable):
 
 
 register_image_importer = partial_doc(_register_importer, image_types,
-                                      __menpo_f_name__='register_image_importer')
+                                      menpo_f_name__='register_image_importer')
 
 register_video_importer = partial_doc(_register_importer, ffmpeg_video_types,
-                                      __menpo_f_name__='register_video_importer')
+                                      menpo_f_name__='register_video_importer')
 
 register_landmark_importer = partial_doc(
     _register_importer, image_landmark_types,
-    __menpo_f_name__='register_landmark_importer')
+    menpo_f_name__='register_landmark_importer')
 
 register_pickle_importer = partial_doc(_register_importer, pickle_types,
-                                       __menpo_f_name__='register_pickle_importer')
+                                       menpo_f_name__='register_pickle_importer')
 
 
 menpo_data_dir_path = partial_doc(_data_dir_path, menpo_src_dir_path,
-                                  __menpo_f_name__='data_dir_path')
+                                  menpo_f_name__='data_dir_path')
 
 menpo_ls_builtin_assets = partial_doc(_ls_builtin_assets, menpo_data_dir_path,
-                                      __menpo_f_name__='ls_builtin_assets')
+                                      menpo_f_name__='ls_builtin_assets')
 
 menpo_data_path_to = partial_doc(_data_path_to, menpo_data_dir_path,
                                  menpo_ls_builtin_assets,
-                                 __menpo_f_name__='data_path_to')
+                                 menpo_f_name__='data_path_to')
 
 _menpo_import_builtin_asset = partial_doc(_import_builtin_asset,
                                           menpo_data_path_to,

--- a/menpo/io/input/extensions.py
+++ b/menpo/io/input/extensions.py
@@ -1,45 +1,45 @@
-from .landmark import LM2Importer, LJSONImporter
-from .image import (PILImporter, ImageioImporter, ImageioGIFImporter,
-                    ABSImporter, FLOImporter)
-from .video import ImageioFFMPEGImporter
-from .landmark_image import ImageASFImporter, ImagePTSImporter
-from .pickle import PickleImporter, GZipPickleImporter
+from .landmark import lm2_importer, ljson_importer
+from .image import (pillow_importer, imageio_importer, imageio_gif_importer,
+                    abs_importer, flo_importer)
+from .video import ffmpeg_types
+from .landmark_image import asf_image_importer, pts_image_importer
+from .pickle import pickle_importer, pickle_gzip_importer
 
 
-image_types = {'.bmp': ImageioImporter,
-               '.dib': PILImporter,
-               '.dcx': PILImporter,
-               '.eps': PILImporter,
-               '.ps': PILImporter,
-               '.gif': ImageioGIFImporter,
-               '.im': PILImporter,
-               '.jpg': ImageioImporter,
-               '.jpg2': ImageioImporter,
-               '.jpx': PILImporter,
-               '.jpe': ImageioImporter,
-               '.jpeg': ImageioImporter,
-               '.pcd': PILImporter,
-               '.pcx': PILImporter,
-               '.png': PILImporter,
-               '.pbm': PILImporter,
-               '.pgm': PILImporter,
-               '.ppm': PILImporter,
-               '.psd': PILImporter,
-               '.tif': PILImporter,
-               '.tiff': PILImporter,
-               '.xbm': PILImporter,
-               '.xpm': PILImporter,
-               '.abs': ABSImporter,
-               '.flo': FLOImporter}
+image_types = {'.bmp': imageio_importer,
+               '.dib': pillow_importer,
+               '.dcx': pillow_importer,
+               '.eps': pillow_importer,
+               '.ps': pillow_importer,
+               '.gif': imageio_gif_importer,
+               '.im': pillow_importer,
+               '.jpg': imageio_importer,
+               '.jpg2': imageio_importer,
+               '.jpx': pillow_importer,
+               '.jpe': imageio_importer,
+               '.jpeg': imageio_importer,
+               '.pcd': pillow_importer,
+               '.pcx': pillow_importer,
+               '.png': pillow_importer,
+               '.pbm': pillow_importer,
+               '.pgm': pillow_importer,
+               '.ppm': pillow_importer,
+               '.psd': pillow_importer,
+               '.tif': pillow_importer,
+               '.tiff': pillow_importer,
+               '.xbm': pillow_importer,
+               '.xpm': pillow_importer,
+               '.abs': abs_importer,
+               '.flo': flo_importer}
 
 
-ffmpeg_video_types = ImageioFFMPEGImporter.ffmpeg_types()
+ffmpeg_video_types = ffmpeg_types()
 
-image_landmark_types = {'.asf': ImageASFImporter,
-                        '.lm2': LM2Importer,
-                        '.pts': ImagePTSImporter,
-                        '.ptsx': ImagePTSImporter,
-                        '.ljson': LJSONImporter}
+image_landmark_types = {'.asf': asf_image_importer,
+                        '.lm2': lm2_importer,
+                        '.pts': pts_image_importer,
+                        '.ptsx': pts_image_importer,
+                        '.ljson': ljson_importer}
 
-pickle_types = {'.pkl': PickleImporter,
-                '.pkl.gz': GZipPickleImporter}
+pickle_types = {'.pkl': pickle_importer,
+                '.pkl.gz': pickle_gzip_importer}

--- a/menpo/io/input/image.py
+++ b/menpo/io/input/image.py
@@ -4,14 +4,22 @@ import numpy as np
 from pathlib import Path
 
 from menpo.base import LazyList
-from .base import Importer
 from menpo.image import Image, MaskedImage, BooleanImage
 from menpo.image.base import normalize_pixels_range, channels_to_front
 
 
-class PILImporter(Importer):
+def _pil_to_numpy(pil_image, normalise, convert=None):
+    p = pil_image.convert(convert) if convert else pil_image
+    p = channels_to_front(p)
+    if normalise:
+        return normalize_pixels_range(p)
+    else:
+        return p
+
+
+def pillow_importer(filepath, asset=None, normalise=True, **kwargs):
     r"""
-    Imports an image using PIL.
+    Imports an image using PIL/pillow.
 
     Different image modes cause different importing strategies.
 
@@ -27,65 +35,56 @@ class PILImporter(Importer):
 
     Parameters
     ----------
-    filepath : string
+    filepath : `Path`
         Absolute filepath of image
+    asset : `object`, optional
+        An optional asset that may help with loading. This is unused for this
+        implementation.
     normalise : `bool`, optional
         If ``True``, normalise between 0.0 and 1.0 and convert to float. If
         ``False`` just pass whatever PIL imports back (according
         to types rules outlined in constructor).
+    \**kwargs : `dict`, optional
+        Any other keyword arguments.
+
+    Returns
+    -------
+    image : :map:`Image` or subclass
+        The imported image.
     """
-    def __init__(self, filepath, normalise=True):
-        super(PILImporter, self).__init__(filepath)
-        self._pil_image = None
-        self.normalise = normalise
+    import PIL.Image as PILImage
 
-    def build(self):
-        r"""
-        Read the image using PIL and then use the :map:`Image` constructor to
-        create a class.
-        """
-        import PIL.Image as PILImage
-
-        self._pil_image = PILImage.open(self.filepath)
-        mode = self._pil_image.mode
-        if mode == 'RGBA':
-            # If normalise is False, then we return the alpha as an extra
-            # channel, which can be useful if the alpha channel has semantic
-            # meanings!
-            if self.normalise:
-                alpha = np.array(self._pil_image)[..., 3].astype(np.bool)
-                image_pixels = self._pil_to_numpy(True,
-                                                  convert='RGB')
-                image = MaskedImage(image_pixels, mask=alpha, copy=False)
-            else:
-                # With no normalisation we just return the pixels
-                image = Image(self._pil_to_numpy(False), copy=False)
-        elif mode in ['L', 'I', 'RGB']:
-            # Greyscale, Integer and RGB images
-            image = Image(self._pil_to_numpy(self.normalise), copy=False)
-        elif mode == '1':
-            # Can't normalise a binary image
-            image = BooleanImage(self._pil_to_numpy(False), copy=False)
-        elif mode == 'P':
-            # Convert pallete images to RGB
-            image = Image(self._pil_to_numpy(self.normalise, convert='RGB'))
-        elif mode == 'F':  # Floating point images
-            # Don't normalise as we don't know the scale
-            image = Image(self._pil_to_numpy(False), copy=False)
-        else:
-            raise ValueError('Unexpected mode for PIL: {}'.format(mode))
-        return image
-
-    def _pil_to_numpy(self, normalise, convert=None):
-        p = self._pil_image.convert(convert) if convert else self._pil_image
-        p = channels_to_front(p)
+    pil_image = PILImage.open(str(filepath))
+    mode = pil_image.mode
+    if mode == 'RGBA':
+        # If normalise is False, then we return the alpha as an extra
+        # channel, which can be useful if the alpha channel has semantic
+        # meanings!
         if normalise:
-            return normalize_pixels_range(p)
+            alpha = np.array(pil_image)[..., 3].astype(np.bool)
+            image_pixels = _pil_to_numpy(pil_image, True, convert='RGB')
+            image = MaskedImage(image_pixels, mask=alpha, copy=False)
         else:
-            return p
+            # With no normalisation we just return the pixels
+            image = Image(_pil_to_numpy(pil_image, False), copy=False)
+    elif mode in ['L', 'I', 'RGB']:
+        # Greyscale, Integer and RGB images
+        image = Image(_pil_to_numpy(pil_image, normalise), copy=False)
+    elif mode == '1':
+        # Can't normalise a binary image
+        image = BooleanImage(_pil_to_numpy(pil_image, False), copy=False)
+    elif mode == 'P':
+        # Convert pallete images to RGB
+        image = Image(_pil_to_numpy(pil_image, normalise, convert='RGB'))
+    elif mode == 'F':  # Floating point images
+        # Don't normalise as we don't know the scale
+        image = Image(_pil_to_numpy(pil_image, False), copy=False)
+    else:
+        raise ValueError('Unexpected mode for PIL: {}'.format(mode))
+    return image
 
 
-class ABSImporter(Importer):
+def abs_importer(filepath, asset=None, **kwargs):
     r"""
     Allows importing the ABS file format from the FRGC dataset.
 
@@ -93,75 +92,83 @@ class ABSImporter(Importer):
 
     Parameters
     ----------
-    filepath : string
-        Absolute filepath of the ABS file.
+    filepath : `Path`
+        Absolute filepath of the file.
+    asset : `object`, optional
+        An optional asset that may help with loading. This is unused for this
+        implementation.
+    \**kwargs : `dict`, optional
+        Any other keyword arguments.
+
+    Returns
+    -------
+    image : :map:`Image` or subclass
+        The imported image.
     """
+    import re
 
-    def __init__(self, filepath, **kwargs):
-        # Setup class before super class call
-        super(ABSImporter, self).__init__(filepath)
+    with open(str(filepath), 'r') as f:
+        # Currently these are unused, but they are in the format
+        # Could possibly store as metadata?
+        # Assume first result for regexes
+        re_rows = re.compile(u'([0-9]+) rows')
+        n_rows = int(re_rows.findall(f.readline())[0])
+        re_cols = re.compile(u'([0-9]+) columns')
+        n_cols = int(re_cols.findall(f.readline())[0])
 
-    def build(self):
-        import re
+    # This also loads the mask
+    #   >>> image_data[:, 0]
+    image_data = np.loadtxt(str(filepath), skiprows=3, unpack=True)
 
-        with open(self.filepath, 'r') as f:
-            # Currently these are unused, but they are in the format
-            # Could possibly store as metadata?
-            # Assume first result for regexes
-            re_rows = re.compile(u'([0-9]+) rows')
-            n_rows = int(re_rows.findall(f.readline())[0])
-            re_cols = re.compile(u'([0-9]+) columns')
-            n_cols = int(re_cols.findall(f.readline())[0])
+    # Replace the lowest value with nan so that we can render properly
+    data_view = image_data[:, 1:]
+    corrupt_value = np.min(data_view)
+    data_view[np.any(np.isclose(data_view, corrupt_value), axis=1)] = np.nan
 
-        # This also loads the mask
-        #   >>> image_data[:, 0]
-        image_data = np.loadtxt(self.filepath, skiprows=3, unpack=True)
-
-        # Replace the lowest value with nan so that we can render properly
-        data_view = image_data[:, 1:]
-        corrupt_value = np.min(data_view)
-        data_view[np.any(np.isclose(data_view, corrupt_value), axis=1)] = np.nan
-
-        return MaskedImage(
-            np.rollaxis(np.reshape(data_view, [n_rows, n_cols, 3]), -1),
-            np.reshape(image_data[:, 0], [n_rows, n_cols]).astype(np.bool),
-            copy=False)
+    return MaskedImage(
+        np.rollaxis(np.reshape(data_view, [n_rows, n_cols, 3]), -1),
+        np.reshape(image_data[:, 0], [n_rows, n_cols]).astype(np.bool),
+        copy=False)
 
 
-class FLOImporter(Importer):
+def flo_importer(filepath, asset=None, **kwargs):
     r"""
     Allows importing the Middlebury FLO file format.
 
     Parameters
     ----------
-    filepath : string
-        Absolute filepath of the FLO file.
+    filepath : `Path`
+        Absolute filepath of the file.
+    asset : `object`, optional
+        An optional asset that may help with loading. This is unused for this
+        implementation.
+    \**kwargs : `dict`, optional
+        Any other keyword arguments.
+
+    Returns
+    -------
+    image : :map:`Image` or subclass
+        The imported image.
     """
+    with open(str(filepath), 'rb') as f:
+        fingerprint = f.read(4)
+        if fingerprint != 'PIEH':
+            raise ValueError('Invalid FLO file.')
 
-    def __init__(self, filepath, **kwargs):
-        # Setup class before super class call
-        super(FLOImporter, self).__init__(filepath)
+        width, height = np.fromfile(f, dtype=np.uint32, count=2)
+        # read the raw flow data (u0, v0, u1, v1, u2, v2,...)
+        rawData = np.fromfile(f, dtype=np.float32,
+                              count=width * height * 2)
 
-    def build(self):
-        with open(self.filepath, 'rb') as f:
-            fingerprint = f.read(4)
-            if fingerprint != 'PIEH':
-                raise ValueError('Invalid FLO file.')
+    shape = (height, width)
+    u_raw = rawData[::2].reshape(shape)
+    v_raw = rawData[1::2].reshape(shape)
+    uv = np.vstack([u_raw[None, ...], v_raw[None, ...]])
 
-            width, height = np.fromfile(f, dtype=np.uint32, count=2)
-            # read the raw flow data (u0, v0, u1, v1, u2, v2,...)
-            rawData = np.fromfile(f, dtype=np.float32,
-                                  count=width * height * 2)
-
-        shape = (height, width)
-        u_raw = rawData[::2].reshape(shape)
-        v_raw = rawData[1::2].reshape(shape)
-        uv = np.vstack([u_raw[None, ...], v_raw[None, ...]])
-
-        return Image(uv, copy=False)
+    return Image(uv, copy=False)
 
 
-class ImageioImporter(Importer):
+def imageio_importer(filepath, asset=None, normalise=True, **kwargs):
     r"""
     Imports images using the imageio library - which is actually fairly similar
     to our importing logic - but contains the necessary plugins to import lots
@@ -169,45 +176,47 @@ class ImageioImporter(Importer):
 
     Parameters
     ----------
-    filepath : string
+    filepath : `Path`
         Absolute filepath of the image.
+    asset : `object`, optional
+        An optional asset that may help with loading. This is unused for this
+        implementation.
     normalise : `bool`, optional
         If ``True``, normalise between 0.0 and 1.0 and convert to float. If
         ``False`` just return whatever imageio imports.
+    \**kwargs : `dict`, optional
+        Any other keyword arguments.
+
+    Returns
+    -------
+    image : :map:`Image` or subclass
+        The imported image.
     """
+    import imageio
 
-    def __init__(self, filepath, normalise=True):
-        super(ImageioImporter, self).__init__(filepath)
-        self._pil_image = None
-        self.normalise = normalise
+    pixels = imageio.imread(str(filepath))
+    pixels = channels_to_front(pixels)
 
-    def build(self):
-        import imageio
-
-        pixels = imageio.imread(self.filepath)
-        pixels = channels_to_front(pixels)
-
-        transparent_types = {'.png'}
-        filepath = Path(self.filepath)
-        if pixels.shape[0] == 4 and filepath.suffix in transparent_types:
-            # If normalise is False, then we return the alpha as an extra
-            # channel, which can be useful if the alpha channel has semantic
-            # meanings!
-            if self.normalise:
-                p = normalize_pixels_range(pixels[:3])
-                return MaskedImage(p, mask=pixels[-1].astype(np.bool),
-                                   copy=False)
-            else:
-                return Image(pixels, copy=False)
-
-        # Assumed not to have an Alpha channel
-        if self.normalise:
-            return Image(normalize_pixels_range(pixels), copy=False)
+    transparent_types = {'.png'}
+    if pixels.shape[0] == 4 and filepath.suffix in transparent_types:
+        # If normalise is False, then we return the alpha as an extra
+        # channel, which can be useful if the alpha channel has semantic
+        # meanings!
+        if normalise:
+            p = normalize_pixels_range(pixels[:3])
+            return MaskedImage(p, mask=pixels[-1].astype(np.bool),
+                               copy=False)
         else:
             return Image(pixels, copy=False)
 
+    # Assumed not to have an Alpha channel
+    if normalise:
+        return Image(normalize_pixels_range(pixels), copy=False)
+    else:
+        return Image(pixels, copy=False)
 
-class ImageioGIFImporter(Importer):
+
+def imageio_gif_importer(filepath, asset=None, normalise=True, **kwargs):
     r"""
     Imports GIF images using freeimagemulti plugin from the imageio library.
     Returns a :map:`LazyList` that gives lazy access to the GIF on a per-frame
@@ -215,44 +224,49 @@ class ImageioGIFImporter(Importer):
 
     Parameters
     ----------
-    filepath : string
+    filepath : `Path`
         Absolute filepath of the video.
+    asset : `object`, optional
+        An optional asset that may help with loading. This is unused for this
+        implementation.
     normalise : `bool`, optional
         If ``True``, normalise between 0.0 and 1.0 and convert to float. If
         ``False`` just return whatever imageio imports.
+    \**kwargs : `dict`, optional
+        Any other keyword arguments.
+
+    Returns
+    -------
+    image : :map:`LazyList`
+        A :map:`LazyList` containing :map:`Image` or subclasses per frame
+        of the GIF.
     """
+    import imageio
 
-    def __init__(self, filepath, normalise=True):
-        super(ImageioGIFImporter, self).__init__(filepath)
-        self.normalise = normalise
+    reader = imageio.get_reader(str(filepath), format='gif', mode='I')
 
-    def build(self):
-        import imageio
+    def imageio_to_menpo(imio_reader, index):
+        pixels = imio_reader.get_data(index)
+        pixels = channels_to_front(pixels)
 
-        reader = imageio.get_reader(self.filepath, format='gif', mode='I')
-
-        def imageio_to_menpo(imio_reader, index):
-            pixels = imio_reader.get_data(index)
-            pixels = channels_to_front(pixels)
-
-            if pixels.shape[0] == 4:
-                # If normalise is False, then we return the alpha as an extra
-                # channel, which can be useful if the alpha channel has semantic
-                # meanings!
-                if self.normalise:
-                    p = normalize_pixels_range(pixels[:3])
-                    return MaskedImage(p, mask=pixels[-1].astype(np.bool),
-                                       copy=False)
-                else:
-                    return Image(pixels, copy=False)
-
-            # Assumed not to have an Alpha channel
-            if self.normalise:
-                return Image(normalize_pixels_range(pixels), copy=False)
+        if pixels.shape[0] == 4:
+            # If normalise is False, then we return the alpha as an extra
+            # channel, which can be useful if the alpha channel has semantic
+            # meanings!
+            if normalise:
+                p = normalize_pixels_range(pixels[:3])
+                return MaskedImage(p, mask=pixels[-1].astype(np.bool),
+                                   copy=False)
             else:
                 return Image(pixels, copy=False)
 
-        index_callable = partial(imageio_to_menpo, reader)
-        ll = LazyList.init_from_index_callable(index_callable,
-                                               reader.get_length())
-        return ll
+        # Assumed not to have an Alpha channel
+        if normalise:
+            return Image(normalize_pixels_range(pixels), copy=False)
+        else:
+            return Image(pixels, copy=False)
+
+    index_callable = partial(imageio_to_menpo, reader)
+    ll = LazyList.init_from_index_callable(index_callable,
+                                           reader.get_length())
+    return ll

--- a/menpo/io/input/landmark_image.py
+++ b/menpo/io/input/landmark_image.py
@@ -1,71 +1,10 @@
-import numpy as np
+from functools import partial
 
-from .landmark import ASFImporter, PTSImporter
-
-
-class ImageASFImporter(ASFImporter):
-    r"""
-    Implements the :meth:`_build_points` method for images. Here, `y` is the
-    first axis.
-
-    Parameters
-    ----------
-    filepath : string
-        Absolute filepath of the landmarks
-    """
-
-    def __init__(self, filepath):
-        super(ImageASFImporter, self).__init__(filepath)
-
-    def _build_points(self, xs, ys):
-        """
-        For images, `axis 0 = ys` and `axis 1 = xs`. Therefore, return the
-        appropriate points array ordering.
-
-        Parameters
-        ----------
-        xs : (N,) ndarray
-            Row vector of `x` coordinates
-        ys : (N,) ndarray
-            Row vector of `y` coordinates
-
-        Returns
-        -------
-        points : (N, 2) ndarray
-            Array with `ys` as the first axis: `[ys; xs]`
-        """
-        return np.hstack([ys, xs])
+from .landmark import asf_importer, pts_importer
 
 
-class ImagePTSImporter(PTSImporter):
-    r"""
-    Implements the :meth:`_build_points` method for images. Here, `y` is the
-    first axis.
+asf_image_importer = partial(asf_importer, image_origin=True)
+asf_image_importer.__doc__ = asf_importer.__doc__
 
-    Parameters
-    ----------
-    filepath : string
-        Absolute filepath of the landmarks
-    """
-
-    def __init__(self, filepath):
-        super(ImagePTSImporter, self).__init__(filepath)
-
-    def _build_points(self, xs, ys):
-        """
-        For images, `axis 0 = ys` and `axis 1 = xs`. Therefore, return the
-        appropriate points array ordering.
-
-        Parameters
-        ----------
-        xs : (N,) ndarray
-            Row vector of `x` coordinates
-        ys : (N,) ndarray
-            Row vector of `y` coordinates
-
-        Returns
-        -------
-        points : (N, 2) ndarray
-            Array with `ys` as the first axis: `[ys; xs]`
-        """
-        return np.hstack([ys, xs])
+pts_image_importer = partial(pts_importer, image_origin=True)
+pts_image_importer.__doc__ = pts_importer.__doc__

--- a/menpo/io/input/pickle.py
+++ b/menpo/io/input/pickle.py
@@ -3,20 +3,49 @@ try:
 except ImportError:
     import pickle
 import gzip
-from .base import Importer
 
 
-class PickleImporter(Importer):
+def pickle_importer(filepath, asset=None, **kwargs):
+    r"""Import a pickle file.
 
-    def build(self):
-        with open(self.filepath, 'rb') as f:
-            x = pickle.load(f)
-        return x
+    Parameters
+    ----------
+    filepath : `Path`
+        Absolute filepath of the file.
+    asset : `object`, optional
+        An optional asset that may help with loading. This is unused for this
+        implementation.
+    \**kwargs : `dict`, optional
+        Any other keyword arguments.
+
+    Returns
+    -------
+    object : `object`
+        The pickled objects.
+    """
+    with open(str(filepath), 'rb') as f:
+        x = pickle.load(f)
+    return x
 
 
-class GZipPickleImporter(Importer):
+def pickle_gzip_importer(filepath, asset=None, **kwargs):
+    r"""Import a pickle file that has been compressed with GZip compression.
 
-    def build(self):
-        with gzip.open(self.filepath, 'rb') as f:
-            x = pickle.load(f)
-        return x
+    Parameters
+    ----------
+    filepath : `Path`
+        Absolute filepath of the file.
+    asset : `object`, optional
+        An optional asset that may help with loading. This is unused for this
+        implementation.
+    \**kwargs : `dict`, optional
+        Any other keyword arguments.
+
+    Returns
+    -------
+    object : `object`
+        The pickled objects.
+    """
+    with gzip.open(str(filepath), 'rb') as f:
+        x = pickle.load(f)
+    return x

--- a/menpo/io/input/video.py
+++ b/menpo/io/input/video.py
@@ -4,55 +4,65 @@ from menpo.image.base import normalize_pixels_range, channels_to_front
 from menpo.image import Image
 from menpo.base import LazyList
 
-from .base import Importer
+
+def ffmpeg_types():
+    r"""The supported FFMPEG types.
+
+    Returns
+    -------
+    supported_types : `dict`
+        A dictionary of extensions to the :map:`imageio_ffmpeg_importer`.
+    """
+    try:
+        import imageio
+
+        # Lazy way to get all the extensions supported by imageio/FFMPEG
+        ffmpeg_exts = imageio.formats['ffmpeg'].extensions
+        return dict(zip(ffmpeg_exts,
+                        [imageio_ffmpeg_importer] * len(ffmpeg_exts)))
+    except ImportError:
+        return {}
 
 
-class ImageioFFMPEGImporter(Importer):
+def imageio_ffmpeg_importer(filepath, asset=None, normalise=True, **kwargs):
     r"""
     Imports videos using the FFMPEG plugin from the imageio library. Returns a
     :map:`LazyList` that gives lazy access to the video on a per-frame basis.
 
     Parameters
     ----------
-    filepath : string
+    filepath : `Path`
         Absolute filepath of the video.
+    asset : `object`, optional
+        An optional asset that may help with loading. This is unused for this
+        implementation.
     normalise : `bool`, optional
         If ``True``, normalise between 0.0 and 1.0 and convert to float. If
         ``False`` just return whatever imageio imports.
+    \**kwargs : `dict`, optional
+        Any other keyword arguments.
+
+    Returns
+    -------
+    image : :map:`LazyList`
+        A :map:`LazyList` containing :map:`Image` or subclasses per frame
+        of the video.
     """
+    import imageio
 
-    def __init__(self, filepath, normalise=True):
-        super(ImageioFFMPEGImporter, self).__init__(filepath)
-        self.normalise = normalise
+    reader = imageio.get_reader(str(filepath), format='ffmpeg', mode='I')
 
-    @classmethod
-    def ffmpeg_types(cls):
-        try:
-            import imageio
+    def imageio_to_menpo(imio_reader, index):
+        pixels = imio_reader.get_data(index)
+        pixels = channels_to_front(pixels)
 
-            # Lazy way to get all the extensions supported by imageio/FFMPEG
-            ffmpeg_exts = imageio.formats['ffmpeg'].extensions
-            return dict(zip(ffmpeg_exts,
-                        [ImageioFFMPEGImporter] * len(ffmpeg_exts)))
-        except ImportError:
-            return {}
+        if normalise:
+            return Image(normalize_pixels_range(pixels), copy=False)
+        else:
+            return Image(pixels, copy=False)
 
-    def build(self):
-        import imageio
-
-        reader = imageio.get_reader(self.filepath, format='ffmpeg', mode='I')
-
-        def imageio_to_menpo(imio_reader, index):
-            pixels = imio_reader.get_data(index)
-            pixels = channels_to_front(pixels)
-
-            if self.normalise:
-                return Image(normalize_pixels_range(pixels), copy=False)
-            else:
-                return Image(pixels, copy=False)
-
-        index_callable = partial(imageio_to_menpo, reader)
-        ll = LazyList.init_from_index_callable(index_callable,
-                                               reader.get_length())
-        ll.fps = reader.get_meta_data()['fps']
-        return ll
+    index_callable = partial(imageio_to_menpo, reader)
+    ll = LazyList.init_from_index_callable(index_callable,
+                                           reader.get_length())
+    ll.fps = reader.get_meta_data()['fps']
+    return ll

--- a/menpo/io/output/base.py
+++ b/menpo/io/output/base.py
@@ -4,6 +4,7 @@ from pathlib import Path
 
 from menpo.compatibility import basestring, str
 from .extensions import landmark_types, image_types, pickle_types, video_types
+from ..exceptions import OverwriteError
 from ..utils import _norm_path
 
 # an open file handle that uses a small fast level of compression
@@ -275,13 +276,15 @@ def _validate_filepath(fp, overwrite):
 
     Raises
     ------
-    ValueError
+    OverwriteError
         If ``overwrite == False`` and a file already exists at the file path.
     """
     path_filepath = _norm_path(fp)
     if path_filepath.exists() and not overwrite:
-        raise ValueError('File already exists. Please set the overwrite '
-                         'kwarg if you wish to overwrite the file.')
+        raise OverwriteError('File {} already exists. Please set the overwrite '
+                             'kwarg if you wish to overwrite '
+                             'the file.'.format(path_filepath.name),
+                             path_filepath)
     return path_filepath
 
 

--- a/menpo/io/output/base.py
+++ b/menpo/io/output/base.py
@@ -5,7 +5,8 @@ from pathlib import Path
 from menpo.compatibility import basestring, str
 from .extensions import landmark_types, image_types, pickle_types, video_types
 from ..exceptions import OverwriteError
-from ..utils import _norm_path, _possible_extensions_from_filepath
+from ..utils import (_norm_path, _possible_extensions_from_filepath,
+                     _normalize_extension)
 
 # an open file handle that uses a small fast level of compression
 gzip_open = partial(gzip.open, compresslevel=3)
@@ -202,28 +203,6 @@ def export_pickle(obj, fp, overwrite=False, protocol=2):
         _export(obj, fp, pickle_types, '.pkl', overwrite, protocol=protocol)
 
 
-def _normalise_extension(extension):
-    r"""
-    Simple function that takes a given extension string and ensures that it
-    is lower case and contains the leading period e.g. ('.jpg')
-
-    Parameters
-    ----------
-    extension : `str`
-        The string extension.
-
-    Returns
-    -------
-    norm_extension : `str`
-        The normalised extension, lower case with '.' prefix.
-    """
-    # Account for the fact the user may only have passed the extension
-    # without the proceeding period
-    if extension[0] is not '.':
-        extension = '.' + extension
-    return extension.lower()
-
-
 def _extension_to_export_function(extension, extensions_map):
     r"""
     Simple function that wraps the extensions map indexing and raises
@@ -334,7 +313,7 @@ def _parse_and_validate_extension(filepath, extension, extensions_map):
             ''.join(filepath.suffixes)))
 
     if extension is not None:
-        extension = _normalise_extension(extension)
+        extension = _normalize_extension(extension)
         if extension != known_extension:
             raise ValueError('The file path extension must match the '
                              'requested file extension: {} != {}'.format(
@@ -385,7 +364,7 @@ def _export(obj, fp, extensions_map, extension, overwrite, protocol=None):
             raise ValueError('An export file extension must be provided if a '
                              'file-like object is passed.')
         else:
-            extension = _normalise_extension(extension)
+            extension = _normalize_extension(extension)
 
         # Apparently in Python 2.x there is no reliable way to detect something
         # that is 'file' like (file handle or a StringIO object or something

--- a/menpo/io/output/extensions.py
+++ b/menpo/io/output/extensions.py
@@ -1,53 +1,53 @@
-from .landmark import LJSONExporter, PTSExporter
-from .image import PILExporter
-from .video import ImageioVideoExporter, ImageioGifExporter
-from .pickle import pickle_export
+from .landmark import ljson_exporter, pts_exporter
+from .image import pil_exporter
+from .video import imageio_video_exporter, image_gif_exporter
+from .pickle import pickle_exporter
 
 
 landmark_types = {
-    '.ljson': LJSONExporter,
-    '.pts': PTSExporter
+    '.ljson': ljson_exporter,
+    '.pts': pts_exporter
 }
 
 
 image_types = {
-    '.bmp': PILExporter,
-    '.dib': PILExporter,
-    '.dcx': PILExporter,
-    '.eps': PILExporter,
-    '.ps': PILExporter,
-    '.gif': PILExporter,
-    '.im': PILExporter,
-    '.jpg': PILExporter,
-    '.jpe': PILExporter,
-    '.jpeg': PILExporter,
-    '.pcd': PILExporter,
-    '.pcx': PILExporter,
-    '.png': PILExporter,
-    '.pbm': PILExporter,
-    '.pgm': PILExporter,
-    '.ppm': PILExporter,
-    '.psd': PILExporter,
-    '.tif': PILExporter,
-    '.tiff': PILExporter,
-    '.xbm': PILExporter,
-    '.xpm': PILExporter
+    '.bmp': pil_exporter,
+    '.dib': pil_exporter,
+    '.dcx': pil_exporter,
+    '.eps': pil_exporter,
+    '.ps': pil_exporter,
+    '.gif': pil_exporter,
+    '.im': pil_exporter,
+    '.jpg': pil_exporter,
+    '.jpe': pil_exporter,
+    '.jpeg': pil_exporter,
+    '.pcd': pil_exporter,
+    '.pcx': pil_exporter,
+    '.png': pil_exporter,
+    '.pbm': pil_exporter,
+    '.pgm': pil_exporter,
+    '.ppm': pil_exporter,
+    '.psd': pil_exporter,
+    '.tif': pil_exporter,
+    '.tiff': pil_exporter,
+    '.xbm': pil_exporter,
+    '.xpm': pil_exporter
 }
 
 
 pickle_types = {
-    '.pkl': pickle_export,
-    '.pkl.gz': pickle_export,
+    '.pkl': pickle_exporter,
+    '.pkl.gz': pickle_exporter,
 }
 
 
 video_types = {
-    '.mov': ImageioVideoExporter,
-    '.avi': ImageioVideoExporter,
-    '.mpg': ImageioVideoExporter,
-    '.mpeg': ImageioVideoExporter,
-    '.mp4': ImageioVideoExporter,
-    '.mkv': ImageioVideoExporter,
-    '.wmv': ImageioVideoExporter,
-    '.gif': ImageioGifExporter
+    '.mov': imageio_video_exporter,
+    '.avi': imageio_video_exporter,
+    '.mpg': imageio_video_exporter,
+    '.mpeg': imageio_video_exporter,
+    '.mp4': imageio_video_exporter,
+    '.mkv': imageio_video_exporter,
+    '.wmv': imageio_video_exporter,
+    '.gif': image_gif_exporter
 }

--- a/menpo/io/output/image.py
+++ b/menpo/io/output/image.py
@@ -1,4 +1,4 @@
-def PILExporter(image, file_handle, extension='', **kwargs):
+def pil_exporter(image, file_handle, extension='', **kwargs):
     r"""
     Given a file handle to write in to (which should act like a Python `file`
     object), write out the image data. No value is returned.
@@ -12,6 +12,8 @@ def PILExporter(image, file_handle, extension='', **kwargs):
         The image data to write out.
     file_handle : `file`-like object
         The file to write in to
+    extension : `str`, optional
+        The extension to use for writing if necessary
     """
     from PIL.Image import EXTENSION
     # The extensions are only filled out when save or open are called - which

--- a/menpo/io/output/landmark.py
+++ b/menpo/io/output/landmark.py
@@ -3,7 +3,7 @@ import itertools
 import numpy as np
 
 
-def LJSONExporter(landmark_group, file_handle, **kwargs):
+def ljson_exporter(landmark_group, file_handle, **kwargs):
     r"""
     Given a file handle to write in to (which should act like a Python `file`
     object), write out the landmark data. No value is returned.
@@ -48,7 +48,7 @@ def LJSONExporter(landmark_group, file_handle, **kwargs):
                      sort_keys=True, allow_nan=False)
 
 
-def PTSExporter(landmark_group, file_handle, **kwargs):
+def pts_exporter(landmark_group, file_handle, **kwargs):
     r"""
     Given a file handle to write in to (which should act like a Python `file`
     object), write out the landmark data. No value is returned.

--- a/menpo/io/output/pickle.py
+++ b/menpo/io/output/pickle.py
@@ -50,6 +50,6 @@ def pickle_paths_as_pure():
         Path.__reduce__ = default_reduce
 
 
-def pickle_export(obj, file_handle, protocol=2, **kwargs):
+def pickle_exporter(obj, file_handle, protocol=2, **kwargs):
     with pickle_paths_as_pure():
         pickle.dump(obj, file_handle, protocol=protocol)

--- a/menpo/io/output/video.py
+++ b/menpo/io/output/video.py
@@ -1,8 +1,8 @@
 
 
-def ImageioVideoExporter(images, out_path, fps=30, codec='libx264',
-                         quality=None, bitrate=None, pixelformat='yuv420p',
-                         **kwargs):
+def imageio_video_exporter(images, out_path, fps=30, codec='libx264',
+                           quality=None, bitrate=None, pixelformat='yuv420p',
+                           **kwargs):
     r"""
     Uses imageio to export the images using FFMPEG. Please see the imageio
     documentation for more information.
@@ -40,7 +40,7 @@ def ImageioVideoExporter(images, out_path, fps=30, codec='libx264',
     writer.close()
 
 
-def ImageioGifExporter(images, out_path, fps=30, loop=0, duration=None,
+def image_gif_exporter(images, out_path, fps=30, loop=0, duration=None,
                        **kwargs):
     r"""
     Uses imageio to export the images to a GIF. Please see the imageio

--- a/menpo/io/test/io_export_test.py
+++ b/menpo/io/test/io_export_test.py
@@ -80,7 +80,7 @@ def test_export_filepath_explicit_ext_dot(mock_open, exists, landmark_types):
     assert export_function.call_count == 1
 
 
-@raises(ValueError)
+@raises(mio.OverwriteError)
 @patch('menpo.io.output.base.Path.exists')
 def test_export_filepath_no_overwrite_exists(exists):
     exists.return_value = True

--- a/menpo/io/test/io_export_test.py
+++ b/menpo/io/test/io_export_test.py
@@ -27,6 +27,7 @@ fake_path = '/tmp/test.fake'
 @patch('menpo.io.output.base.Path.open')
 def test_export_filepath_overwrite_exists(mock_open, exists, landmark_types):
     exists.return_value = True
+    landmark_types.__contains__.return_value = True
     mio.export_landmark_file(test_lg, fake_path, overwrite=True)
     mock_open.assert_called_with('wb')
     landmark_types.__getitem__.assert_called_with('.fake')
@@ -39,6 +40,7 @@ def test_export_filepath_overwrite_exists(mock_open, exists, landmark_types):
 @patch('menpo.io.output.base.Path.open')
 def test_export_filepath_no_overwrite(mock_open, exists, landmark_types):
     exists.return_value = False
+    landmark_types.__contains__.return_value = True
     mio.export_landmark_file(test_lg, fake_path)
     mock_open.assert_called_with('wb')
     landmark_types.__getitem__.assert_called_with('.fake')
@@ -61,6 +63,7 @@ def test_export_filepath_wrong_extension(mock_open, exists, landmark_types):
 @patch('menpo.io.output.base.Path.open')
 def test_export_filepath_explicit_ext_no_dot(mock_open, exists, landmark_types):
     exists.return_value = False
+    landmark_types.__contains__.return_value = True
     mio.export_landmark_file(test_lg, fake_path, extension='fake')
     mock_open.assert_called_with('wb')
     landmark_types.__getitem__.assert_called_with('.fake')
@@ -73,6 +76,7 @@ def test_export_filepath_explicit_ext_no_dot(mock_open, exists, landmark_types):
 @patch('menpo.io.output.base.Path.open')
 def test_export_filepath_explicit_ext_dot(mock_open, exists, landmark_types):
     exists.return_value = False
+    landmark_types.__contains__.return_value = True
     mio.export_landmark_file(test_lg, fake_path, extension='.fake')
     mock_open.assert_called_with('wb')
     landmark_types.__getitem__.assert_called_with('.fake')
@@ -92,7 +96,7 @@ def test_export_filepath_no_overwrite_exists(exists):
 @patch('menpo.io.output.base.Path.exists')
 def test_export_unsupported_extension(exists, landmark_types):
     exists.return_value = False
-    landmark_types.__getitem__.side_effect = KeyError
+    landmark_types.get.side_effect = KeyError
     mio.export_landmark_file(test_lg, fake_path)
 
 
@@ -141,6 +145,7 @@ def test_export_file_handle_file_exists(mock_open, exists):
 def test_export_file_handle_file_exists_overwrite(mock_open, exists,
                                                   landmark_types):
     exists.return_value = True
+    landmark_types.__contains__.return_value = True
     with open(fake_path) as f:
         type(f).name = PropertyMock(return_value=fake_path)
         mio.export_landmark_file(test_lg, f, overwrite=True, extension='fake')
@@ -155,6 +160,7 @@ def test_export_file_handle_file_exists_overwrite(mock_open, exists,
 def test_export_file_handle_file_non_file_buffer(mock_open, exists,
                                                  landmark_types):
     exists.return_value = False
+    landmark_types.__contains__.return_value = True
     with open(fake_path) as f:
         del f.name  # Equivalent to raising an AttributeError side effect
         mio.export_landmark_file(test_lg, f, extension='fake')
@@ -174,6 +180,7 @@ def test_export_landmark_ljson(mock_open, exists, json_dump):
         mio.export_landmark_file(test_lg, f, extension='ljson')
     assert json_dump.call_count == 1
 
+
 @patch('menpo.io.output.landmark.json.dump')
 @patch('menpo.io.output.base.Path.exists')
 @patch('{}.open'.format(__name__), create=True)
@@ -192,6 +199,7 @@ def test_export_landmark_ljson_3d(mock_open, exists, json_dump):
     assert json_dump.call_count == 1
     json_points = np.array(json_dump.call_args[0][0]['landmarks']['points'])
     assert_allclose(json_points[:, -1], fake_z_points)
+
 
 @patch('menpo.io.output.base.Path.exists')
 @patch('{}.open'.format(__name__), create=True)

--- a/menpo/io/test/io_import_test.py
+++ b/menpo/io/test/io_import_test.py
@@ -105,7 +105,8 @@ def test_double_suffix(pathlib_glob):
 
     ret_val = next(mio_base.glob_with_suffix('*.t1.t2', ext_map))
     assert (ret_val == fake_path)
-    ext_map.__contains__.assert_called_with('.t1.t2')
+    ext_map.__contains__.assert_any_call('.t1.t2')
+    ext_map.__contains__.assert_any_call('.t2')
 
 
 def test_import_image():

--- a/menpo/io/test/io_import_test.py
+++ b/menpo/io/test/io_import_test.py
@@ -1,10 +1,10 @@
 import sys
+import warnings
 import numpy as np
 from mock import patch, MagicMock
 from nose.tools import raises
 from PIL import Image as PILImage
 import menpo.io as mio
-import warnings
 
 
 builtins_str = '__builtin__' if sys.version_info[0] == 2 else 'builtins'
@@ -550,8 +550,80 @@ def test_importing_imageio_avi_no_normalise(is_file, mock_image):
 def test_import_images_negative_max_images():
     list(mio.import_images(mio.data_dir_path(), max_images=-2))
 
+
 @raises(ValueError)
 def test_import_images_zero_max_images():
     # different since the conditional 'if max_assets' is skipped,
     # thus all images might be imported.
     list(mio.import_images(mio.data_dir_path(), max_images=0))
+
+
+@patch('menpo.io.input.base.Path.is_file')
+def test_register_image_importer(is_file):
+    from menpo.image import Image
+    image = Image.init_blank((10, 10))
+
+    def foo_importer(filepath, **kwargs):
+        return image
+
+    is_file.return_value = True
+
+    with patch.dict(mio.input.extensions.image_types, {}, clear=True):
+        mio.register_image_importer('.foo', foo_importer)
+        new_image = mio.import_image('fake.foo')
+    assert image is new_image
+
+
+@patch('menpo.io.input.base.Path.is_file')
+def test_register_landmark_importer(is_file):
+    from menpo.shape import PointCloud
+    from menpo.landmark import LandmarkGroup
+    lmark = LandmarkGroup.init_with_all_label(PointCloud.init_2d_grid((1, 1)))
+
+    def foo_importer(filepath, **kwargs):
+        return lmark
+
+    is_file.return_value = True
+
+    with patch.dict(mio.input.extensions.image_landmark_types, {}, clear=True):
+        mio.register_landmark_importer('.foo', foo_importer)
+        new_lmark = mio.import_landmark_file('fake.foo')
+    assert lmark is new_lmark
+
+
+@patch('menpo.io.input.base.Path.is_file')
+def test_register_video_importer(is_file):
+    from menpo.image import Image
+    from menpo.base import LazyList
+
+    def foo_importer(filepath, **kwargs):
+        return LazyList([lambda: Image.init_blank((10, 10))])
+
+    is_file.return_value = True
+
+    with patch.dict(mio.input.extensions.ffmpeg_video_types, {}, clear=True):
+        mio.register_video_importer('.foo', foo_importer)
+        new_video = mio.import_video('fake.foo')
+    assert len(new_video) == 1
+
+
+@patch('menpo.io.input.base.Path.is_file')
+def test_register_pickle_importer(is_file):
+    obj = object()
+
+    def foo_importer(filepath, **kwargs):
+        return obj
+
+    is_file.return_value = True
+
+    with patch.dict(mio.input.extensions.pickle_types, {}, clear=True):
+        mio.register_pickle_importer('.foo', foo_importer)
+        new_obj = mio.import_pickle('fake.foo')
+    assert new_obj is obj
+
+
+def test_register_no_leading_period():
+    ext_map = {}
+    mio.input.base._register_importer(ext_map, 'foo', lambda x: x)
+    assert '.foo' in ext_map
+    assert 'foo' not in ext_map

--- a/menpo/io/utils.py
+++ b/menpo/io/utils.py
@@ -30,3 +30,25 @@ def _possible_extensions_from_filepath(filepath):
     """
     suffixes = filepath.suffixes
     return [''.join(suffixes[i:]).lower() for i in range(len(suffixes))]
+
+
+def _normalize_extension(extension):
+    r"""
+    Simple function that takes a given extension string and ensures that it
+    is lower case and contains the leading period e.g. ('.jpg')
+
+    Parameters
+    ----------
+    extension : `str`
+        The string extension.
+
+    Returns
+    -------
+    norm_extension : `str`
+        The normalised extension, lower case with '.' prefix.
+    """
+    # Account for the fact the user may only have passed the extension
+    # without the proceeding period
+    if extension[0] is not '.':
+        extension = '.' + extension
+    return extension.lower()

--- a/menpo/io/utils.py
+++ b/menpo/io/utils.py
@@ -8,3 +8,25 @@ def _norm_path(filepath):
     """
     return Path(os.path.abspath(os.path.normpath(
         os.path.expandvars(os.path.expanduser(str(filepath))))))
+
+
+def _possible_extensions_from_filepath(filepath):
+    r"""
+    Generate a list of possible extensions from the given filepath. Since
+    filenames can contain '.' characters and some extensions are compound
+    (e.g. '.pkl.gz'), there may be many possible extensions for a given
+    path. Generate a list possible extensions, preferring longer extensions.
+
+    Parameters
+    ----------
+    filepath : `Path`
+        A pathlib Path.
+
+    Returns
+    -------
+    possible_extensions : `list` of `str`
+        A list of extensions **with** leading '.' characters and converted
+        to lowercase.
+    """
+    suffixes = filepath.suffixes
+    return [''.join(suffixes[i:]).lower() for i in range(len(suffixes))]


### PR DESCRIPTION
Now the IO package is much more functional and importers and exporters are just expected to be defined as functions/callables that take either a path (input) or a file handle (output) and do the appropriate job. This makes it much easier for users to leverage the menpo smart globbing etc but actually import whatever they want.

### TODO
  - [x] `mio.register_*_importer('.jpg', custom_jpg_importer)`