### PR TITLE
Relex version constraints on dependencies

### DIFF
--- a/conda/meta.yaml
+++ b/conda/meta.yaml
@@ -6,24 +6,24 @@ requirements:
   build:
     - python
     - setuptools
-    - numpy >=1.10,<1.11
-    - cython 0.23.*
+    - numpy >=1.10,<2.0
+    - cython >=0.23
 
   run:
     - python
     - pathlib 1.0  # [py2k]
 
     # Scientific Python Stack
-    - numpy >=1.10,<1.11
-    - scipy 0.17.*
-    - pillow  3.1.*
-    - imageio 1.5.*
+    - numpy >=1.10,<2.0
+    - scipy >=0.16,<1.0
+    - pillow >=3.0,<4.0
+    - imageio >=1.5,<2.0
 
     # Features
     - cyvlfeat >=0.4.3,<0.5
 
     # Visualization
-    - matplotlib >=1.4,<1.6
+    - matplotlib >=1.4,<2.0
 
     # Test dependencies
     - mock 1.3.*
@@ -45,4 +45,3 @@ test:
 about:
   home: https://github.com/menpo/menpo/
   license: BSD
-

--- a/setup.py
+++ b/setup.py
@@ -17,12 +17,12 @@ cython_modules = ['menpo/shape/mesh/normals.pyx',
 
 cython_exts = cythonize(cython_modules, quiet=True)
 include_dirs = [np.get_include()]
-install_requires = ['numpy>=1.10,<1.11',
-                    'scipy>=0.17,<0.18',
-                    'matplotlib>=1.4,<1.6',
+install_requires = ['numpy>=1.10,<2.0',
+                    'scipy>=0.16,<1.0',
+                    'matplotlib>=1.4,<2.0',
                     'pillow>=3.0,<4.0',
-                    'imageio>=1.5.0,<1.6.0',
-                    'Cython>=0.23,<0.24']
+                    'imageio>=1.5.0,<2.0',
+                    'Cython>=0.23']
 
 if sys.version_info.major == 2:
     install_requires.append('pathlib==1.0')


### PR DESCRIPTION
We're currently being sticklers for version constraints on our dependencies because we want to be able to offer a high confidence that menpo works as advertised and we don't have the time to really test menpo in-depth on all platforms with all the different permutations of our deps.

Saying that, this causes issues when trying to install menpo alongside other software, which may have particular deps for very good reasons, which, because we are so strict, is in conflict with us.

In an effort to make menpo play better with other packages, we are relaxing our dependencies. There are still certain versions that we require for good reason, but if there isn't a good reason to upgrade we will take the optimistic view that things will continue to work a little more that we have to date.