### PR TITLE
Standardise the normalize spelling in importers.

### DIFF
--- a/menpo/feature/features.py
+++ b/menpo/feature/features.py
@@ -794,12 +794,12 @@ def normalize(img, scale_func=None, mode='all',
     error_on_divide_by_zero : `bool`, optional
         If ``True``, will raise a ``ValueError`` on dividing by zero.
         If ``False``, will merely raise a warning and only those values
-        with non-zero denominators will be normalised.
+        with non-zero denominators will be normalized.
 
     Returns
     -------
     pixels : :map:`Image` or subclass or ``(X, Y, ..., Z, C)`` `ndarray`
-        A normalised copy of the image that was passed in.
+        A normalized copy of the image that was passed in.
 
     Raises
     ------
@@ -858,12 +858,12 @@ def normalize_norm(pixels, mode='all', error_on_divide_by_zero=True):
     error_on_divide_by_zero : `bool`, optional
         If ``True``, will raise a ``ValueError`` on dividing by zero.
         If ``False``, will merely raise a warning and only those values
-        with non-zero denominators will be normalised.
+        with non-zero denominators will be normalized.
 
     Returns
     -------
     pixels : :map:`Image` or subclass or ``(X, Y, ..., Z, C)`` `ndarray`
-        A normalised copy of the image that was passed in.
+        A normalized copy of the image that was passed in.
 
     Raises
     ------
@@ -898,12 +898,12 @@ def normalize_std(pixels, mode='all', error_on_divide_by_zero=True):
     error_on_divide_by_zero : `bool`, optional
         If ``True``, will raise a ``ValueError`` on dividing by zero.
         If ``False``, will merely raise a warning and only those values
-        with non-zero denominators will be normalised.
+        with non-zero denominators will be normalized.
 
     Returns
     -------
     pixels : :map:`Image` or subclass or ``(X, Y, ..., Z, C)`` `ndarray`
-        A normalised copy of the image that was passed in.
+        A normalized copy of the image that was passed in.
 
     Raises
     ------
@@ -921,7 +921,7 @@ def normalize_std(pixels, mode='all', error_on_divide_by_zero=True):
 @ndfeature
 def normalize_var(pixels, mode='all', error_on_divide_by_zero=True):
     r"""
-    Normalize the pixels to be mean centred and normalise according
+    Normalize the pixels to be mean centred and normalize according
     to the variance.
     The ``mode`` parameter selects whether the normalisation is computed across
     all pixels in the image or per-channel.
@@ -939,12 +939,12 @@ def normalize_var(pixels, mode='all', error_on_divide_by_zero=True):
     error_on_divide_by_zero : `bool`, optional
         If ``True``, will raise a ``ValueError`` on dividing by zero.
         If ``False``, will merely raise a warning and only those values
-        with non-zero denominators will be normalised.
+        with non-zero denominators will be normalized.
 
     Returns
     -------
     pixels : :map:`Image` or subclass or ``(X, Y, ..., Z, C)`` `ndarray`
-        A normalised copy of the image that was passed in.
+        A normalized copy of the image that was passed in.
 
     Raises
     ------

--- a/menpo/feature/optional/vlfeat.py
+++ b/menpo/feature/optional/vlfeat.py
@@ -165,7 +165,7 @@ def hellinger_vector_128_dsift(x, dtype=np.float32):
     **must** be square and the output vector will *always* be a ``(128,)``
     vector. Please see :func:`dsift` for more information.
 
-    The output of :func:`vector_128_dsift` is normalised using the hellinger
+    The output of :func:`vector_128_dsift` is normalized using the hellinger
     norm (also called the Bhattacharyya distance) which is a measure
     designed to quantify the similarity between two probability distributions.
     Since SIFT is a histogram based feature, this has been shown to improve

--- a/menpo/image/test/image_patches_test.py
+++ b/menpo/image/test/image_patches_test.py
@@ -31,7 +31,7 @@ def test_float_type():
 
 
 def test_uint8_type():
-    image = mio.import_builtin_asset('breakingbad.jpg', normalise=False)
+    image = mio.import_builtin_asset('breakingbad.jpg', normalize=False)
     patch_shape = (16, 16)
     patches = image.extract_patches(image.landmarks['PTS'].lms,
                                     patch_shape=patch_shape,
@@ -60,7 +60,7 @@ def test_int_pointcloud():
 
 
 def test_uint8_type_single_array():
-    image = mio.import_builtin_asset('breakingbad.jpg', normalise=False)
+    image = mio.import_builtin_asset('breakingbad.jpg', normalize=False)
     patch_shape = (16, 16)
     patches = image.extract_patches(image.landmarks['PTS'].lms,
                                     patch_shape=patch_shape,

--- a/menpo/io/input/base.py
+++ b/menpo/io/input/base.py
@@ -7,6 +7,8 @@ from ..utils import _norm_path
 from menpo.base import menpo_src_dir_path, LazyList
 from menpo.visualize import print_progress
 
+from warnings import warn
+from menpo.base import MenpoDeprecationWarning
 
 def data_dir_path():
     r"""A path to the Menpo built in ./data folder on this machine.
@@ -68,7 +70,8 @@ def same_name_video(path, frame_number):
     return {p.suffix[1:].upper(): p for p in landmark_file_paths(pattern)}
 
 
-def import_image(filepath, landmark_resolver=same_name, normalize=True):
+def import_image(filepath, landmark_resolver=same_name, normalize=None,
+                 normalise=None):
     r"""Single image (and associated landmarks) importer.
 
     If an image file is found at `filepath`, returns an :map:`Image` or
@@ -95,12 +98,26 @@ def import_image(filepath, landmark_resolver=same_name, normalize=True):
         this flag you will have to manually convert the images you import to
         floating point before doing most Menpo operations. This however can be
         useful to save on memory usage if you only wish to view or crop images.
+    normalise: `bool`, optional
+        Deprecated version of normalize. Please use the normalize arg.
 
     Returns
     -------
     images : :map:`Image` or list of
         An instantiated :map:`Image` or subclass thereof or a list of images.
     """
+    if normalise is not None and normalize is not None:
+        m = 'Do not se both arguments. The preferred one is normalize.'
+        raise ValueError(m)
+    elif normalise is not None:
+        warn('This argument is no longer supported and will be removed in a '
+             'future version of Menpo. '
+             'Use normalize instead.',
+             MenpoDeprecationWarning)
+        normalize = normalise
+    elif normalize is None:
+        normalize = True
+
     kwargs = {'normalize': normalize}
     return _import(filepath, image_types,
                    landmark_ext_map=image_landmark_types,
@@ -109,8 +126,8 @@ def import_image(filepath, landmark_resolver=same_name, normalize=True):
                    importer_kwargs=kwargs)
 
 
-def import_video(filepath, landmark_resolver=same_name_video, normalize=True,
-                 importer_method='ffmpeg'):
+def import_video(filepath, landmark_resolver=same_name_video, normalize=None,
+                 normalise=None, importer_method='ffmpeg'):
     r"""Single video (and associated landmarks) importer.
 
     If a video file is found at `filepath`, returns an :map:`LazyList` wrapping
@@ -146,6 +163,8 @@ def import_video(filepath, landmark_resolver=same_name_video, normalize=True,
         flag you will have to manually convert the farmes you import to floating
         point before doing most Menpo operations. This however can be useful to
         save on memory usage if you only wish to view or crop the frames.
+    normalise : `bool`, optional
+        Deprecated version of normalize. Please use the normalize arg.
     importer_method : {'ffmpeg'}, optional
         A string representing the type of importer to use, by default ffmpeg
         is used.
@@ -163,6 +182,18 @@ def import_video(filepath, landmark_resolver=same_name_video, normalize=True,
     >>> # Lazily load the 100th frame without reading the entire video
     >>> frame100 = video[100]
     """
+    if normalise is not None and normalize is not None:
+        m = 'Do not se both arguments. The preferred one is normalize.'
+        raise ValueError(m)
+    elif normalise is not None:
+        warn('This argument is no longer supported and will be removed in a '
+             'future version of Menpo. '
+             'Use normalize instead.',
+             MenpoDeprecationWarning)
+        normalize = normalise
+    elif normalize is None:
+        normalize = True
+
     kwargs = {'normalize': normalize}
 
     video_importer_methods = {'ffmpeg': ffmpeg_video_types}
@@ -220,8 +251,8 @@ def import_pickle(filepath):
 
 
 def import_images(pattern, max_images=None, shuffle=False,
-                  landmark_resolver=same_name, normalize=True,
-                  as_generator=False, verbose=False):
+                  landmark_resolver=same_name, normalize=None,
+                  normalise=None, as_generator=False, verbose=False):
     r"""Multiple image (and associated landmarks) importer.
 
     For each image found creates an importer than returns a :map:`Image` or
@@ -262,6 +293,8 @@ def import_images(pattern, max_images=None, shuffle=False,
         this flag you will have to manually convert the images you import to
         floating point before doing most Menpo operations. This however can be
         useful to save on memory usage if you only wish to view or crop images.
+    normalise : `bool`, optional
+        Deprecated version of normalize. Please use the normalize arg.
     as_generator : `bool`, optional
         If ``True``, the function returns a generator and assets will be yielded
         one after another when the generator is iterated over.
@@ -289,6 +322,18 @@ def import_images(pattern, max_images=None, shuffle=False,
     >>> images = images.map(rescale_20p)  # Returns immediately
     >>> images[0]  # Get the first image, resize, lazily loaded
     """
+    if normalise is not None and normalize is not None:
+        m = 'Do not se both arguments. The preferred one is normalize.'
+        raise ValueError(m)
+    elif normalise is not None:
+        warn('This argument is no longer supported and will be removed in a '
+             'future version of Menpo. '
+             'Use normalize instead.',
+             MenpoDeprecationWarning)
+        normalize = normalise
+    elif normalize is None:
+        normalize = True
+
     kwargs = {'normalize': normalize}
     return _import_glob_lazy_list(
         pattern, image_types,
@@ -303,8 +348,9 @@ def import_images(pattern, max_images=None, shuffle=False,
 
 
 def import_videos(pattern, max_videos=None, shuffle=False,
-                  landmark_resolver=same_name_video, normalize=True,
-                  importer_method='ffmpeg', as_generator=False, verbose=False):
+                  landmark_resolver=same_name_video, normalize=None,
+                  normalise=None, importer_method='ffmpeg',
+                  as_generator=False, verbose=False):
     r"""Multiple video (and associated landmarks) importer.
 
     For each video found yields a :map:`LazyList`. By default, landmark files
@@ -353,6 +399,8 @@ def import_videos(pattern, max_videos=None, shuffle=False,
         flag you will have to manually convert the frames you import to floating
         point before doing most Menpo operations. This however can be useful to
         save on memory usage if you only wish to view or crop the frames.
+    normalise : `bool`, optional
+        Deprecated version of normalize. Please use the normalize arg.
     importer_method : {'ffmpeg'}, optional
         A string representing the type of importer to use, by default ffmpeg
         is used.
@@ -386,6 +434,18 @@ def import_videos(pattern, max_videos=None, shuffle=False,
     >>>        frames.append(frame.rescale(0.2))
     >>>    videos.append(frames)
     """
+    if normalise is not None and normalize is not None:
+        m = 'Do not se both arguments. The preferred one is normalize.'
+        raise ValueError(m)
+    elif normalise is not None:
+        warn('This argument is no longer supported and will be removed in a '
+             'future version of Menpo. '
+             'Use normalize instead.',
+             MenpoDeprecationWarning)
+        normalize = normalise
+    elif normalize is None:
+        normalize = True
+
     kwargs = {'normalize': normalize}
     video_importer_methods = {'ffmpeg': ffmpeg_video_types}
     if importer_method not in video_importer_methods:
@@ -517,9 +577,25 @@ def _import_builtin_asset(asset_name, **kwargs):
     asset :
         An instantiated :map:`Image` or :map:`LandmarkGroup` asset.
     """
+    if kwargs != {}:
+        # catch the case of having normalise as kwarg. Remove once
+        # the argument is removed.
+        if 'normalise' in kwargs.keys() and 'normalize' in kwargs.keys():
+            m = 'Do not se both normalize and normalise arguments. ' \
+                'The preferred one is normalize.'
+            raise ValueError(m)
+        elif 'normalise' in kwargs.keys():
+            warn('The argument of normalise is no longer supported and '
+                 'will be removed in a future version of Menpo. '
+                 'Use normalize instead.',
+                 MenpoDeprecationWarning)
+            kwargs['normalize'] = kwargs['normalise']
+            del kwargs['normalise']
+
     asset_path = data_path_to(asset_name)
     # Import could be either an image or a set of landmarks, so we try
     # importing them both separately.
+
     try:
         return _import(asset_path, image_types,
                        landmark_ext_map=image_landmark_types,

--- a/menpo/io/input/base.py
+++ b/menpo/io/input/base.py
@@ -1,5 +1,4 @@
 from functools import partial
-from collections import Sequence
 import os
 from pathlib import Path
 import random
@@ -9,6 +8,22 @@ from menpo.visualize import print_progress
 
 from warnings import warn
 from menpo.base import MenpoDeprecationWarning
+
+
+# TODO: Remove once deprecated
+def _parse_deprecated_normalise(normalise, normalize):
+    if normalise is not None and normalize is not None:
+        raise ValueError('normalise is now deprecated, do not set both '
+                         'normalize and normalise.')
+    elif normalise is not None:
+        warn('normalise is no longer supported and will be removed in a '
+             'future version of Menpo. Use normalize instead.',
+             MenpoDeprecationWarning)
+        normalize = normalise
+    elif normalize is None:
+        normalize = True
+    return normalize
+
 
 def data_dir_path():
     r"""A path to the Menpo built in ./data folder on this machine.
@@ -106,18 +121,7 @@ def import_image(filepath, landmark_resolver=same_name, normalize=None,
     images : :map:`Image` or list of
         An instantiated :map:`Image` or subclass thereof or a list of images.
     """
-    if normalise is not None and normalize is not None:
-        m = 'Do not set both arguments. The preferred one is normalize.'
-        raise ValueError(m)
-    elif normalise is not None:
-        warn('This argument is no longer supported and will be removed in a '
-             'future version of Menpo. '
-             'Use normalize instead.',
-             MenpoDeprecationWarning)
-        normalize = normalise
-    elif normalize is None:
-        normalize = True
-
+    normalize = _parse_deprecated_normalise(normalise, normalize)
     kwargs = {'normalize': normalize}
     return _import(filepath, image_types,
                    landmark_ext_map=image_landmark_types,
@@ -182,17 +186,7 @@ def import_video(filepath, landmark_resolver=same_name_video, normalize=None,
     >>> # Lazily load the 100th frame without reading the entire video
     >>> frame100 = video[100]
     """
-    if normalise is not None and normalize is not None:
-        m = 'Do not set both arguments. The preferred one is normalize.'
-        raise ValueError(m)
-    elif normalise is not None:
-        warn('This argument is no longer supported and will be removed in a '
-             'future version of Menpo. '
-             'Use normalize instead.',
-             MenpoDeprecationWarning)
-        normalize = normalise
-    elif normalize is None:
-        normalize = True
+    normalize = _parse_deprecated_normalise(normalise, normalize)
 
     kwargs = {'normalize': normalize}
 
@@ -322,17 +316,7 @@ def import_images(pattern, max_images=None, shuffle=False,
     >>> images = images.map(rescale_20p)  # Returns immediately
     >>> images[0]  # Get the first image, resize, lazily loaded
     """
-    if normalise is not None and normalize is not None:
-        m = 'Do not set both arguments. The preferred one is normalize.'
-        raise ValueError(m)
-    elif normalise is not None:
-        warn('This argument is no longer supported and will be removed in a '
-             'future version of Menpo. '
-             'Use normalize instead.',
-             MenpoDeprecationWarning)
-        normalize = normalise
-    elif normalize is None:
-        normalize = True
+    normalize = _parse_deprecated_normalise(normalise, normalize)
 
     kwargs = {'normalize': normalize}
     return _import_glob_lazy_list(
@@ -434,17 +418,7 @@ def import_videos(pattern, max_videos=None, shuffle=False,
     >>>        frames.append(frame.rescale(0.2))
     >>>    videos.append(frames)
     """
-    if normalise is not None and normalize is not None:
-        m = 'Do not set both arguments. The preferred one is normalize.'
-        raise ValueError(m)
-    elif normalise is not None:
-        warn('This argument is no longer supported and will be removed in a '
-             'future version of Menpo. '
-             'Use normalize instead.',
-             MenpoDeprecationWarning)
-        normalize = normalise
-    elif normalize is None:
-        normalize = True
+    normalize = _parse_deprecated_normalise(normalise, normalize)
 
     kwargs = {'normalize': normalize}
     video_importer_methods = {'ffmpeg': ffmpeg_video_types}
@@ -578,24 +552,15 @@ def _import_builtin_asset(asset_name, **kwargs):
         An instantiated :map:`Image` or :map:`LandmarkGroup` asset.
     """
     if kwargs != {}:
-        # catch the case of having normalise as kwarg. Remove once
-        # the argument is removed.
-        if 'normalise' in kwargs.keys() and 'normalize' in kwargs.keys():
-            m = 'Do not set both normalize and normalise arguments. ' \
-                'The preferred one is normalize.'
-            raise ValueError(m)
-        elif 'normalise' in kwargs.keys():
-            warn('The argument of normalise is no longer supported and '
-                 'will be removed in a future version of Menpo. '
-                 'Use normalize instead.',
-                 MenpoDeprecationWarning)
-            kwargs['normalize'] = kwargs['normalise']
+        normalize = _parse_deprecated_normalise(kwargs.get('normalise'),
+                                                kwargs.get('normalize'))
+        kwargs['normalize'] = normalize
+        if 'normalise' in kwargs:
             del kwargs['normalise']
 
     asset_path = data_path_to(asset_name)
     # Import could be either an image or a set of landmarks, so we try
     # importing them both separately.
-
     try:
         return _import(asset_path, image_types,
                        landmark_ext_map=image_landmark_types,

--- a/menpo/io/input/base.py
+++ b/menpo/io/input/base.py
@@ -68,7 +68,7 @@ def same_name_video(path, frame_number):
     return {p.suffix[1:].upper(): p for p in landmark_file_paths(pattern)}
 
 
-def import_image(filepath, landmark_resolver=same_name, normalise=True):
+def import_image(filepath, landmark_resolver=same_name, normalize=True):
     r"""Single image (and associated landmarks) importer.
 
     If an image file is found at `filepath`, returns an :map:`Image` or
@@ -87,8 +87,8 @@ def import_image(filepath, landmark_resolver=same_name, normalise=True):
         image. The function should take one argument (the path to the image) and
         return a dictionary of the form ``{'group_name': 'landmark_filepath'}``
         Default finds landmarks with the same name as the image file.
-    normalise : `bool`, optional
-        If ``True``, normalise the image pixels between 0 and 1 and convert
+    normalize : `bool`, optional
+        If ``True``, normalize the image pixels between 0 and 1 and convert
         to floating point. If false, the native datatype of the image will be
         maintained (commonly `uint8`). Note that in general Menpo assumes
         :map:`Image` instances contain floating point data - if you disable
@@ -101,7 +101,7 @@ def import_image(filepath, landmark_resolver=same_name, normalise=True):
     images : :map:`Image` or list of
         An instantiated :map:`Image` or subclass thereof or a list of images.
     """
-    kwargs = {'normalise': normalise}
+    kwargs = {'normalize': normalize}
     return _import(filepath, image_types,
                    landmark_ext_map=image_landmark_types,
                    landmark_resolver=landmark_resolver,
@@ -109,7 +109,7 @@ def import_image(filepath, landmark_resolver=same_name, normalise=True):
                    importer_kwargs=kwargs)
 
 
-def import_video(filepath, landmark_resolver=same_name_video, normalise=True,
+def import_video(filepath, landmark_resolver=same_name_video, normalize=True,
                  importer_method='ffmpeg'):
     r"""Single video (and associated landmarks) importer.
 
@@ -138,8 +138,8 @@ def import_video(filepath, landmark_resolver=same_name_video, normalise=True,
         the frame number) and return a dictionary of the form ``{'group_name':
         'landmark_filepath'}`` Default finds landmarks with the same name as the
         video file, appended with '_{frame_number}'.
-    normalise : `bool`, optional
-        If ``True``, normalise the frame pixels between 0 and 1 and convert
+    normalize : `bool`, optional
+        If ``True``, normalize the frame pixels between 0 and 1 and convert
         to floating point. If ``False``, the native datatype of the image will
         be maintained (commonly `uint8`). Note that in general Menpo assumes
         :map:`Image` instances contain floating point data - if you disable this
@@ -163,7 +163,7 @@ def import_video(filepath, landmark_resolver=same_name_video, normalise=True,
     >>> # Lazily load the 100th frame without reading the entire video
     >>> frame100 = video[100]
     """
-    kwargs = {'normalise': normalise}
+    kwargs = {'normalize': normalize}
 
     video_importer_methods = {'ffmpeg': ffmpeg_video_types}
     if importer_method not in video_importer_methods:
@@ -220,7 +220,7 @@ def import_pickle(filepath):
 
 
 def import_images(pattern, max_images=None, shuffle=False,
-                  landmark_resolver=same_name, normalise=True,
+                  landmark_resolver=same_name, normalize=True,
                   as_generator=False, verbose=False):
     r"""Multiple image (and associated landmarks) importer.
 
@@ -254,8 +254,8 @@ def import_images(pattern, max_images=None, shuffle=False,
         image. The function should take one argument (the image itself) and
         return a dictionary of the form ``{'group_name': 'landmark_filepath'}``
         Default finds landmarks with the same name as the image file.
-    normalise : `bool`, optional
-        If ``True``, normalise the image pixels between 0 and 1 and convert
+    normalize : `bool`, optional
+        If ``True``, normalize the image pixels between 0 and 1 and convert
         to floating point. If false, the native datatype of the image will be
         maintained (commonly `uint8`). Note that in general Menpo assumes
         :map:`Image` instances contain floating point data - if you disable
@@ -286,10 +286,10 @@ def import_images(pattern, max_images=None, shuffle=False,
 
     >>> rescale_20p = lambda x: x.rescale(0.2)
     >>> images =  menpo.io.import_images('./massive_image_db/*')  # Returns immediately
-    >>> images.map(rescale_20p)  # Returns immediately
+    >>> images = images.map(rescale_20p)  # Returns immediately
     >>> images[0]  # Get the first image, resize, lazily loaded
     """
-    kwargs = {'normalise': normalise}
+    kwargs = {'normalize': normalize}
     return _import_glob_lazy_list(
         pattern, image_types,
         max_assets=max_images, shuffle=shuffle,
@@ -303,7 +303,7 @@ def import_images(pattern, max_images=None, shuffle=False,
 
 
 def import_videos(pattern, max_videos=None, shuffle=False,
-                  landmark_resolver=same_name_video, normalise=True,
+                  landmark_resolver=same_name_video, normalize=True,
                   importer_method='ffmpeg', as_generator=False, verbose=False):
     r"""Multiple video (and associated landmarks) importer.
 
@@ -345,8 +345,8 @@ def import_videos(pattern, max_videos=None, shuffle=False,
         the frame number) and return a dictionary of the form ``{'group_name':
         'landmark_filepath'}`` Default finds landmarks with the same name as the
         video file, appended with '_{frame_number}'.
-    normalise : `bool`, optional
-        If ``True``, normalise the frame pixels between 0 and 1 and convert
+    normalize : `bool`, optional
+        If ``True``, normalize the frame pixels between 0 and 1 and convert
         to floating point. If ``False``, the native datatype of the image will
         be maintained (commonly `uint8`). Note that in general Menpo assumes
         :map:`Image` instances contain floating point data - if you disable this
@@ -386,7 +386,7 @@ def import_videos(pattern, max_videos=None, shuffle=False,
     >>>        frames.append(frame.rescale(0.2))
     >>>    videos.append(frames)
     """
-    kwargs = {'normalise': normalise}
+    kwargs = {'normalize': normalize}
     video_importer_methods = {'ffmpeg': ffmpeg_video_types}
     if importer_method not in video_importer_methods:
         raise ValueError('Unsupported importer method requested. Valid values '

--- a/menpo/io/input/base.py
+++ b/menpo/io/input/base.py
@@ -107,7 +107,7 @@ def import_image(filepath, landmark_resolver=same_name, normalize=None,
         An instantiated :map:`Image` or subclass thereof or a list of images.
     """
     if normalise is not None and normalize is not None:
-        m = 'Do not se both arguments. The preferred one is normalize.'
+        m = 'Do not set both arguments. The preferred one is normalize.'
         raise ValueError(m)
     elif normalise is not None:
         warn('This argument is no longer supported and will be removed in a '
@@ -183,7 +183,7 @@ def import_video(filepath, landmark_resolver=same_name_video, normalize=None,
     >>> frame100 = video[100]
     """
     if normalise is not None and normalize is not None:
-        m = 'Do not se both arguments. The preferred one is normalize.'
+        m = 'Do not set both arguments. The preferred one is normalize.'
         raise ValueError(m)
     elif normalise is not None:
         warn('This argument is no longer supported and will be removed in a '
@@ -323,7 +323,7 @@ def import_images(pattern, max_images=None, shuffle=False,
     >>> images[0]  # Get the first image, resize, lazily loaded
     """
     if normalise is not None and normalize is not None:
-        m = 'Do not se both arguments. The preferred one is normalize.'
+        m = 'Do not set both arguments. The preferred one is normalize.'
         raise ValueError(m)
     elif normalise is not None:
         warn('This argument is no longer supported and will be removed in a '
@@ -435,7 +435,7 @@ def import_videos(pattern, max_videos=None, shuffle=False,
     >>>    videos.append(frames)
     """
     if normalise is not None and normalize is not None:
-        m = 'Do not se both arguments. The preferred one is normalize.'
+        m = 'Do not set both arguments. The preferred one is normalize.'
         raise ValueError(m)
     elif normalise is not None:
         warn('This argument is no longer supported and will be removed in a '
@@ -581,7 +581,7 @@ def _import_builtin_asset(asset_name, **kwargs):
         # catch the case of having normalise as kwarg. Remove once
         # the argument is removed.
         if 'normalise' in kwargs.keys() and 'normalize' in kwargs.keys():
-            m = 'Do not se both normalize and normalise arguments. ' \
+            m = 'Do not set both normalize and normalise arguments. ' \
                 'The preferred one is normalize.'
             raise ValueError(m)
         elif 'normalise' in kwargs.keys():

--- a/menpo/io/input/video.py
+++ b/menpo/io/input/video.py
@@ -17,14 +17,14 @@ class ImageioFFMPEGImporter(Importer):
     ----------
     filepath : string
         Absolute filepath of the video.
-    normalise : `bool`, optional
-        If ``True``, normalise between 0.0 and 1.0 and convert to float. If
+    normalize : `bool`, optional
+        If ``True``, normalize between 0.0 and 1.0 and convert to float. If
         ``False`` just return whatever imageio imports.
     """
 
-    def __init__(self, filepath, normalise=True):
+    def __init__(self, filepath, normalize=True):
         super(ImageioFFMPEGImporter, self).__init__(filepath)
-        self.normalise = normalise
+        self.normalize = normalize
 
     @classmethod
     def ffmpeg_types(cls):
@@ -47,7 +47,7 @@ class ImageioFFMPEGImporter(Importer):
             pixels = imio_reader.get_data(index)
             pixels = channels_to_front(pixels)
 
-            if self.normalise:
+            if self.normalize:
                 return Image(normalize_pixels_range(pixels), copy=False)
             else:
                 return Image(pixels, copy=False)

--- a/menpo/io/output/base.py
+++ b/menpo/io/output/base.py
@@ -236,7 +236,7 @@ def _extension_to_export_function(extension, extensions_map):
 
 def _validate_filepath(fp, overwrite):
     r"""
-    Normalise a given file path and ensure that ``overwrite == True`` if the
+    Normalize a given file path and ensure that ``overwrite == True`` if the
     file path exists. Normalisation involves things like making the given
     path absolute and expanding environment variables and user variables.
 
@@ -250,8 +250,8 @@ def _validate_filepath(fp, overwrite):
 
     Returns
     -------
-    normalised_filepath : `Path`
-        The normalised file path.
+    normalized_filepath : `Path`
+        The normalized file path.
 
     Raises
     ------
@@ -278,7 +278,7 @@ def _parse_and_validate_extension(filepath, extension, extensions_map):
     Parameters
     ----------
     filepath : `Path`
-        The file path (normalised).
+        The file path (normalized).
     extension : `str`
         The extension provided by the user.
     extensions_map : `dict` of `str` -> `callable`

--- a/menpo/io/test/io_import_test.py
+++ b/menpo/io/test/io_import_test.py
@@ -23,7 +23,7 @@ def test_breaking_bad_import():
 
 
 def test_breaking_bad_import_kwargs():
-    img = mio.import_builtin_asset('breakingbad.jpg', normalise=False)
+    img = mio.import_builtin_asset('breakingbad.jpg', normalize=False)
     assert(img.pixels.dtype == np.uint8)
 
 
@@ -117,7 +117,7 @@ def test_import_image():
 
 def test_import_image_no_norm():
     img_path = mio.data_dir_path() / 'einstein.jpg'
-    im = mio.import_image(img_path, normalise=False)
+    im = mio.import_image(img_path, normalize=False)
     assert im.pixels.dtype == np.uint8
 
 
@@ -170,11 +170,11 @@ def test_import_landmark_files_wrong_path_raises_value_error():
 
 @patch('PIL.Image.open')
 @patch('menpo.io.input.base.Path.is_file')
-def test_importing_PIL_no_normalise(is_file, mock_image):
+def test_importing_PIL_no_normalize(is_file, mock_image):
     mock_image.return_value = PILImage.new('RGBA', (10, 10))
     is_file.return_value = True
 
-    im = mio.import_image('fake_image_being_mocked.png', normalise=False)
+    im = mio.import_image('fake_image_being_mocked.png', normalize=False)
     assert im.shape == (10, 10)
     assert im.n_channels == 4
     assert im.pixels.dtype == np.uint8
@@ -182,13 +182,13 @@ def test_importing_PIL_no_normalise(is_file, mock_image):
 
 @patch('PIL.Image.open')
 @patch('menpo.io.input.base.Path.is_file')
-def test_importing_imageio_RGBA_normalise(is_file, mock_image):
+def test_importing_imageio_RGBA_normalize(is_file, mock_image):
     from menpo.image import MaskedImage
 
     mock_image.return_value = PILImage.new('RGBA', (10, 10))
     is_file.return_value = True
 
-    im = mio.import_image('fake_image_being_mocked.png', normalise=True)
+    im = mio.import_image('fake_image_being_mocked.png', normalize=True)
     assert im.shape == (10, 10)
     assert im.n_channels == 3
     assert im.pixels.dtype == np.float
@@ -197,12 +197,12 @@ def test_importing_imageio_RGBA_normalise(is_file, mock_image):
 
 @patch('imageio.imread')
 @patch('menpo.io.input.base.Path.is_file')
-def test_importing_imageio_RGB_normalise(is_file, mock_image):
+def test_importing_imageio_RGB_normalize(is_file, mock_image):
 
     mock_image.return_value = np.zeros([10, 10, 3], dtype=np.uint8)
     is_file.return_value = True
 
-    im = mio.import_image('fake_image_being_mocked.jpg', normalise=True)
+    im = mio.import_image('fake_image_being_mocked.jpg', normalize=True)
     assert im.shape == (10, 10)
     assert im.n_channels == 3
     assert im.pixels.dtype == np.float
@@ -210,12 +210,12 @@ def test_importing_imageio_RGB_normalise(is_file, mock_image):
 
 @patch('imageio.imread')
 @patch('menpo.io.input.base.Path.is_file')
-def test_importing_imageio_RGB_no_normalise(is_file, mock_image):
+def test_importing_imageio_RGB_no_normalize(is_file, mock_image):
 
     mock_image.return_value = np.zeros([10, 10, 3], dtype=np.uint8)
     is_file.return_value = True
 
-    im = mio.import_image('fake_image_being_mocked.jpg', normalise=False)
+    im = mio.import_image('fake_image_being_mocked.jpg', normalize=False)
     assert im.shape == (10, 10)
     assert im.n_channels == 3
     assert im.pixels.dtype == np.uint8
@@ -223,13 +223,13 @@ def test_importing_imageio_RGB_no_normalise(is_file, mock_image):
 
 @patch('PIL.Image.open')
 @patch('menpo.io.input.base.Path.is_file')
-def test_importing_PIL_RGBA_normalise(is_file, mock_image):
+def test_importing_PIL_RGBA_normalize(is_file, mock_image):
     from menpo.image import MaskedImage
 
     mock_image.return_value = PILImage.new('RGBA', (10, 10))
     is_file.return_value = True
 
-    im = mio.import_image('fake_image_being_mocked.ppm', normalise=True)
+    im = mio.import_image('fake_image_being_mocked.ppm', normalize=True)
     assert im.shape == (10, 10)
     assert im.n_channels == 3
     assert im.pixels.dtype == np.float
@@ -238,12 +238,12 @@ def test_importing_PIL_RGBA_normalise(is_file, mock_image):
 
 @patch('PIL.Image.open')
 @patch('menpo.io.input.base.Path.is_file')
-def test_importing_PIL_RGBA_no_normalise(is_file, mock_image):
+def test_importing_PIL_RGBA_no_normalize(is_file, mock_image):
 
     mock_image.return_value = PILImage.new('RGBA', (10, 10))
     is_file.return_value = True
 
-    im = mio.import_image('fake_image_being_mocked.ppm', normalise=False)
+    im = mio.import_image('fake_image_being_mocked.ppm', normalize=False)
     assert im.shape == (10, 10)
     assert im.n_channels == 4
     assert im.pixels.dtype == np.uint8
@@ -251,11 +251,11 @@ def test_importing_PIL_RGBA_no_normalise(is_file, mock_image):
 
 @patch('PIL.Image.open')
 @patch('menpo.io.input.base.Path.is_file')
-def test_importing_PIL_L_no_normalise(is_file, mock_image):
+def test_importing_PIL_L_no_normalize(is_file, mock_image):
     mock_image.return_value = PILImage.new('L', (10, 10))
     is_file.return_value = True
 
-    im = mio.import_image('fake_image_being_mocked.ppm', normalise=False)
+    im = mio.import_image('fake_image_being_mocked.ppm', normalize=False)
     assert im.shape == (10, 10)
     assert im.n_channels == 1
     assert im.pixels.dtype == np.uint8
@@ -263,11 +263,11 @@ def test_importing_PIL_L_no_normalise(is_file, mock_image):
 
 @patch('PIL.Image.open')
 @patch('menpo.io.input.base.Path.is_file')
-def test_importing_PIL_L_normalise(is_file, mock_image):
+def test_importing_PIL_L_normalize(is_file, mock_image):
     mock_image.return_value = PILImage.new('L', (10, 10))
     is_file.return_value = True
 
-    im = mio.import_image('fake_image_being_mocked.ppm', normalise=True)
+    im = mio.import_image('fake_image_being_mocked.ppm', normalize=True)
     assert im.shape == (10, 10)
     assert im.n_channels == 1
     assert im.pixels.dtype == np.float
@@ -276,20 +276,20 @@ def test_importing_PIL_L_normalise(is_file, mock_image):
 @patch('PIL.Image.open')
 @patch('menpo.io.input.base.Path.is_file')
 @raises
-def test_importing_PIL_I_normalise(is_file, mock_image):
+def test_importing_PIL_I_normalize(is_file, mock_image):
     mock_image.return_value = PILImage.new('I', (10, 10))
     is_file.return_value = True
 
-    im = mio.import_image('fake_image_being_mocked.ppm', normalise=True)
+    im = mio.import_image('fake_image_being_mocked.ppm', normalize=True)
 
 
 @patch('PIL.Image.open')
 @patch('menpo.io.input.base.Path.is_file')
-def test_importing_PIL_I_no_normalise(is_file, mock_image):
+def test_importing_PIL_I_no_normalize(is_file, mock_image):
     mock_image.return_value = PILImage.new('I', (10, 10))
     is_file.return_value = True
 
-    im = mio.import_image('fake_image_being_mocked.ppm', normalise=False)
+    im = mio.import_image('fake_image_being_mocked.ppm', normalize=False)
     assert im.shape == (10, 10)
     assert im.n_channels == 1
     assert im.pixels.dtype == np.int32
@@ -297,13 +297,13 @@ def test_importing_PIL_I_no_normalise(is_file, mock_image):
 
 @patch('PIL.Image.open')
 @patch('menpo.io.input.base.Path.is_file')
-def test_importing_PIL_1_normalise(is_file, mock_image):
+def test_importing_PIL_1_normalize(is_file, mock_image):
     from menpo.image import BooleanImage
 
     mock_image.return_value = PILImage.new('1', (10, 10))
     is_file.return_value = True
 
-    im = mio.import_image('fake_image_being_mocked.ppm', normalise=True)
+    im = mio.import_image('fake_image_being_mocked.ppm', normalize=True)
     assert im.shape == (10, 10)
     assert im.n_channels == 1
     assert im.pixels.dtype == np.bool
@@ -312,13 +312,13 @@ def test_importing_PIL_1_normalise(is_file, mock_image):
 
 @patch('PIL.Image.open')
 @patch('menpo.io.input.base.Path.is_file')
-def test_importing_PIL_1_no_normalise(is_file, mock_image):
+def test_importing_PIL_1_no_normalize(is_file, mock_image):
     from menpo.image import BooleanImage
 
     mock_image.return_value = PILImage.new('1', (10, 10))
     is_file.return_value = True
 
-    im = mio.import_image('fake_image_being_mocked.ppm', normalise=False)
+    im = mio.import_image('fake_image_being_mocked.ppm', normalize=False)
     assert im.shape == (10, 10)
     assert im.n_channels == 1
     assert im.pixels.dtype == np.bool
@@ -327,11 +327,11 @@ def test_importing_PIL_1_no_normalise(is_file, mock_image):
 
 @patch('PIL.Image.open')
 @patch('menpo.io.input.base.Path.is_file')
-def test_importing_PIL_P_normalise(is_file, mock_image):
+def test_importing_PIL_P_normalize(is_file, mock_image):
     mock_image.return_value = PILImage.new('P', (10, 10))
     is_file.return_value = True
 
-    im = mio.import_image('fake_image_being_mocked.ppm', normalise=True)
+    im = mio.import_image('fake_image_being_mocked.ppm', normalize=True)
     assert im.shape == (10, 10)
     assert im.n_channels == 3
     assert im.pixels.dtype == np.float
@@ -339,11 +339,11 @@ def test_importing_PIL_P_normalise(is_file, mock_image):
 
 @patch('PIL.Image.open')
 @patch('menpo.io.input.base.Path.is_file')
-def test_importing_PIL_P_no_normalise(is_file, mock_image):
+def test_importing_PIL_P_no_normalize(is_file, mock_image):
     mock_image.return_value = PILImage.new('P', (10, 10))
     is_file.return_value = True
 
-    im = mio.import_image('fake_image_being_mocked.ppm', normalise=False)
+    im = mio.import_image('fake_image_being_mocked.ppm', normalize=False)
     assert im.shape == (10, 10)
     assert im.n_channels == 3
     assert im.pixels.dtype == np.uint8
@@ -351,13 +351,13 @@ def test_importing_PIL_P_no_normalise(is_file, mock_image):
 
 @patch('imageio.get_reader')
 @patch('menpo.io.input.base.Path.is_file')
-def test_importing_imageio_GIF_normalise(is_file, mock_image):
+def test_importing_imageio_GIF_normalize(is_file, mock_image):
     mock_image.return_value.get_data.return_value = np.ones((10, 10, 3),
                                                             dtype=np.uint8)
     mock_image.return_value.get_length.return_value = 1
     is_file.return_value = True
 
-    ll = mio.import_image('fake_image_being_mocked.gif', normalise=True)
+    ll = mio.import_image('fake_image_being_mocked.gif', normalize=True)
     assert len(ll) == 1
 
     im = ll[0]
@@ -368,13 +368,13 @@ def test_importing_imageio_GIF_normalise(is_file, mock_image):
 
 @patch('imageio.get_reader')
 @patch('menpo.io.input.base.Path.is_file')
-def test_importing_imageio_GIF_no_normalise(is_file, mock_image):
+def test_importing_imageio_GIF_no_normalize(is_file, mock_image):
     mock_image.return_value.get_data.return_value = np.ones((10, 10, 3),
                                                             dtype=np.uint8)
     mock_image.return_value.get_length.return_value = 2
     is_file.return_value = True
 
-    ll = mio.import_image('fake_image_being_mocked.gif', normalise=False)
+    ll = mio.import_image('fake_image_being_mocked.gif', normalize=False)
     assert len(ll) == 2
 
     im = ll[0]
@@ -526,7 +526,7 @@ def test_importing_imageio_ffmpeg_bad_frames(is_file, mock_reader):
     mock_reader.return_value.get_data.side_effect = fake_get_data
     is_file.return_value = True
 
-    ll = mio.import_video('fake_image_being_mocked.avi', normalise=False)
+    ll = mio.import_video('fake_image_being_mocked.avi', normalize=False)
     assert len(ll) == 2
 
     im = ll[0]
@@ -550,7 +550,7 @@ def test_importing_imageio_ffmpeg_many_bad_frames_warning_start(is_file, mock_re
     is_file.return_value = True
 
     with warnings.catch_warnings(record=True) as w:
-        ll = mio.import_video('fake_image_being_mocked.avi', normalise=False)
+        ll = mio.import_video('fake_image_being_mocked.avi', normalize=False)
         assert len(w) == 1
     assert len(ll) == 4
 
@@ -575,7 +575,7 @@ def test_importing_imageio_ffmpeg_many_bad_frames_warning_end(is_file, mock_read
     is_file.return_value = True
 
     with warnings.catch_warnings(record=True) as w:
-        ll = mio.import_video('fake_image_being_mocked.avi', normalise=False)
+        ll = mio.import_video('fake_image_being_mocked.avi', normalize=False)
         assert len(w) == 1
     assert len(ll) == 4
 
@@ -610,13 +610,13 @@ def test_importing_imageio_avi_no_frames(is_file, mock_image):
 
 @patch('imageio.get_reader')
 @patch('menpo.io.input.base.Path.is_file')
-def test_importing_imageio_avi_normalise(is_file, mock_image):
+def test_importing_imageio_avi_normalize(is_file, mock_image):
     mock_image.return_value.get_data.return_value = np.ones((10, 10, 3),
                                                             dtype=np.uint8)
     mock_image.return_value.get_length.return_value = 1
     is_file.return_value = True
 
-    ll = mio.import_video('fake_image_being_mocked.avi', normalise=True)
+    ll = mio.import_video('fake_image_being_mocked.avi', normalize=True)
     assert len(ll) == 1
 
     im = ll[0]
@@ -627,13 +627,13 @@ def test_importing_imageio_avi_normalise(is_file, mock_image):
 
 @patch('imageio.get_reader')
 @patch('menpo.io.input.base.Path.is_file')
-def test_importing_imageio_avi_no_normalise(is_file, mock_image):
+def test_importing_imageio_avi_no_normalize(is_file, mock_image):
     mock_image.return_value.get_data.return_value = np.ones((10, 10, 3),
                                                             dtype=np.uint8)
     mock_image.return_value.get_length.return_value = 1
     is_file.return_value = True
 
-    ll = mio.import_video('fake_image_being_mocked.avi', normalise=False)
+    ll = mio.import_video('fake_image_being_mocked.avi', normalize=False)
     assert len(ll) == 1
 
     im = ll[0]

--- a/menpo/io/test/io_import_test.py
+++ b/menpo/io/test/io_import_test.py
@@ -646,8 +646,18 @@ def test_importing_imageio_avi_no_normalize(is_file, mock_image):
 def test_import_images_negative_max_images():
     list(mio.import_images(mio.data_dir_path(), max_images=-2))
 
+
 @raises(ValueError)
 def test_import_images_zero_max_images():
     # different since the conditional 'if max_assets' is skipped,
     # thus all images might be imported.
     list(mio.import_images(mio.data_dir_path(), max_images=0))
+
+
+# TODO: remove once the normalise argument is removed.
+def test_import_image_deprecated_normalise_kwarg():
+    with warnings.catch_warnings(record=True) as w:
+        img = mio.import_builtin_asset('breakingbad.jpg', normalise=False)
+        assert len(w) == 1
+    assert img.pixels.dtype == np.uint8
+    

--- a/menpo/io/test/io_import_test.py
+++ b/menpo/io/test/io_import_test.py
@@ -660,4 +660,3 @@ def test_import_image_deprecated_normalise_kwarg():
         img = mio.import_builtin_asset('breakingbad.jpg', normalise=False)
         assert len(w) == 1
     assert img.pixels.dtype == np.uint8
-    

--- a/menpo/io/utils.py
+++ b/menpo/io/utils.py
@@ -45,7 +45,7 @@ def _normalize_extension(extension):
     Returns
     -------
     norm_extension : `str`
-        The normalised extension, lower case with '.' prefix.
+        The normalized extension, lower case with '.' prefix.
     """
     # Account for the fact the user may only have passed the extension
     # without the proceeding period

--- a/menpo/shape/mesh/normals.pyx
+++ b/menpo/shape/mesh/normals.pyx
@@ -10,19 +10,19 @@ ctypedef fused integrals:
     np.int32_t
     np.int64_t
 
-cdef np.ndarray[FLOAT64_T, ndim=2] normalise(np.ndarray[FLOAT64_T, ndim=2] vec):
+cdef np.ndarray[FLOAT64_T, ndim=2] normalize(np.ndarray[FLOAT64_T, ndim=2] vec):
     """
-    Normalise the given array of vectors.
+    Normalize the given array of vectors.
 
     Parameters
     ----------
     vec : (N, 3) c-contiguous double ndarray
-        The array of vectors to normalise
+        The array of vectors to normalize
 
     Returns
     -------
-    normalised : (N, 3) c-contiguous double ndarray
-        Normalised array of vectors.
+    normalized : (N, 3) c-contiguous double ndarray
+        Normalized array of vectors.
     """
     # Avoid divisions by almost 0 numbers
     # np.spacing(1) is equivalent to Matlab's eps
@@ -91,7 +91,7 @@ cpdef compute_normals(np.ndarray[FLOAT64_T, ndim=2] vertex,
     cdef np.ndarray[FLOAT64_T, ndim=2] face_normal = cross(
         vertex[face[:, 1], :] - vertex[face[:, 0], :],
         vertex[face[:, 2], :] - vertex[face[:, 0], :])
-    face_normal = normalise(face_normal)
+    face_normal = normalize(face_normal)
 
     # Calculate per-vertex normal
     cdef np.ndarray[FLOAT64_T, ndim=2] vertex_normal = np.zeros([nvert, 3])
@@ -106,6 +106,6 @@ cpdef compute_normals(np.ndarray[FLOAT64_T, ndim=2] vertex,
             vertex_normal[f2, j] += face_normal[i, j]
 
     # Normalize
-    vertex_normal = normalise(vertex_normal)
+    vertex_normal = normalize(vertex_normal)
 
     return vertex_normal, face_normal

--- a/menpo/shape/mesh/test/trimish_test.py
+++ b/menpo/shape/mesh/test/trimish_test.py
@@ -308,8 +308,8 @@ def test_trimesh_vertex_normals():
     trilist = np.array([[0, 1, 3],
                         [1, 2, 3]])
     # 0 and 2 are the corner of the triangles and so the maintain the
-    # face normals. The other two are the re-normalised vertices:
-    # normalise(n0 + n2)
+    # face normals. The other two are the re-normalized vertices:
+    # normalize(n0 + n2)
     expected_normals = np.array([[-np.sqrt(3)/3, -np.sqrt(3)/3, np.sqrt(3)/3],
                                  [-0.32505758,  -0.32505758, 0.88807383],
                                  [0, 0, 1],


### PR DESCRIPTION
Ensure consistency in the 'normalize' keyword spelling as inquired from https://github.com/menpo/menpo/issues/699 . 

Locally everything works with the new spelling, along with the tests.