### PR TITLE
Fix the bug with rasterize landmarks with matplotlib backend.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 *~
+__pycache__
 .coverage
 cover/*
 *.pyd

--- a/menpo/image/rasterize.py
+++ b/menpo/image/rasterize.py
@@ -80,7 +80,8 @@ def _rasterize_matplotlib(image, pclouds, render_lines=True, line_style='-',
     # Get the pixels directly from the canvas buffer which is fast
     c_buffer, shape = f.canvas.print_to_buffer()
     # Turn buffer into numpy array and reshape to image
-    pixels_buffer = np.array(c_buffer).reshape(shape[::-1] + (-1,))
+    pixels_buffer = np.fromstring(c_buffer, dtype=np.int8).reshape(shape[::-1] + (-1,))
+    pixels_buffer = pixels_buffer.astype(np.uint8)
     # Prevent matplotlib from rendering
     plt.close(f)
     # Ignore the Alpha channel

--- a/menpo/image/rasterize.py
+++ b/menpo/image/rasterize.py
@@ -80,8 +80,8 @@ def _rasterize_matplotlib(image, pclouds, render_lines=True, line_style='-',
     # Get the pixels directly from the canvas buffer which is fast
     c_buffer, shape = f.canvas.print_to_buffer()
     # Turn buffer into numpy array and reshape to image
-    pixels_buffer = np.fromstring(c_buffer, dtype=np.int8).reshape(shape[::-1] + (-1,))
-    pixels_buffer = pixels_buffer.astype(np.uint8)
+    pixels_buffer = np.fromstring(c_buffer,
+                                  dtype=np.uint8).reshape(shape[::-1] + (-1,))
     # Prevent matplotlib from rendering
     plt.close(f)
     # Ignore the Alpha channel

--- a/menpo/image/test/rasterize_test.py
+++ b/menpo/image/test/rasterize_test.py
@@ -21,6 +21,7 @@ def test_rasterize_matplotlib_basic():
                                     marker_size=2, marker_edge_width=0,
                                     backend='matplotlib')
     assert new_im.n_channels == 3
+    assert new_im.shape == (11, 11)
     assert_allclose(new_im.pixels[:, 5, 5], [255, 0, 0])
 
 
@@ -33,6 +34,7 @@ def test_rasterize_matplotlib_basic_line():
                                     marker_size=2, marker_edge_width=0,
                                     backend='matplotlib')
     assert new_im.n_channels == 3
+    assert new_im.shape == (11, 11)
     assert_allclose(new_im.pixels[0, 3, 5], [255])
     assert_allclose(new_im.pixels[0, 9, 5], [255])
     assert_allclose(new_im.pixels[2, 5:8, 5], [255, 255, 255])
@@ -47,6 +49,7 @@ def test_rasterize_pillow_basic():
                                     marker_size=1, marker_edge_width=0,
                                     backend='pillow')
     assert new_im.n_channels == 3
+    assert new_im.shape == (11, 11)
     assert_allclose(new_im.pixels[0, 3:6, 3:6], 255)
 
 

--- a/menpo/image/test/rasterize_test.py
+++ b/menpo/image/test/rasterize_test.py
@@ -1,4 +1,6 @@
+import os
 import numpy as np
+import unittest
 from numpy.testing import assert_allclose
 from menpo.shape import PointCloud, PointUndirectedGraph
 from menpo.image import Image
@@ -10,6 +12,7 @@ line = PointUndirectedGraph(np.array([[2, 4.5], [8, 4.5]]),
                             adjacency_matrix=np.array([[0, 1], [1, 0]]))
 
 
+@unittest.skipIf(os.environ.get('TRAVIS'), 'Skipping due to lack of DISPLAY on Travis')
 def test_rasterize_matplotlib_basic():
     im = Image.init_blank([11, 11], fill=0, n_channels=1)
     im.landmarks['test'] = centre
@@ -21,6 +24,7 @@ def test_rasterize_matplotlib_basic():
     assert_allclose(new_im.pixels[:, 5, 5], [255, 0, 0])
 
 
+@unittest.skipIf(os.environ.get('TRAVIS'), 'Skipping due to lack of DISPLAY on Travis')
 def test_rasterize_matplotlib_basic_line():
     im = Image.init_blank([11, 11], fill=0, n_channels=1)
     im.landmarks['test'] = line
@@ -34,6 +38,7 @@ def test_rasterize_matplotlib_basic_line():
     assert_allclose(new_im.pixels[2, 5:8, 5], [255, 255, 255])
 
 
+@unittest.skipIf(os.environ.get('TRAVIS'), 'Skipping due to lack of DISPLAY on Travis')
 def test_rasterize_pillow_basic():
     im = Image.init_blank([11, 11], fill=0, n_channels=3)
     im.landmarks['test'] = centre
@@ -45,6 +50,7 @@ def test_rasterize_pillow_basic():
     assert_allclose(new_im.pixels[0, 3:6, 3:6], 255)
 
 
+@unittest.skipIf(os.environ.get('TRAVIS'), 'Skipping due to lack of DISPLAY on Travis')
 def test_rasterize_pillow_basic_line():
     im = Image.init_blank([11, 11], fill=0, n_channels=3)
     im.landmarks['test'] = line

--- a/menpo/image/test/rasterize_test.py
+++ b/menpo/image/test/rasterize_test.py
@@ -1,0 +1,59 @@
+import numpy as np
+from numpy.testing import assert_allclose
+from menpo.shape import PointCloud, PointUndirectedGraph
+from menpo.image import Image
+from menpo.image.rasterize import rasterize_landmarks_2d
+
+
+centre = PointCloud([[4.5, 4.5]])
+line = PointUndirectedGraph(np.array([[2, 4.5], [8, 4.5]]),
+                            adjacency_matrix=np.array([[0, 1], [1, 0]]))
+
+
+def test_rasterize_matplotlib_basic():
+    im = Image.init_blank([11, 11], fill=0, n_channels=1)
+    im.landmarks['test'] = centre
+    new_im = rasterize_landmarks_2d(im, group='test', render_lines=False,
+                                    marker_style='.', marker_face_colour='r',
+                                    marker_size=2, marker_edge_width=0,
+                                    backend='matplotlib')
+    assert new_im.n_channels == 3
+    assert_allclose(new_im.pixels[:, 5, 5], [255, 0, 0])
+
+
+def test_rasterize_matplotlib_basic_line():
+    im = Image.init_blank([11, 11], fill=0, n_channels=1)
+    im.landmarks['test'] = line
+    new_im = rasterize_landmarks_2d(im, group='test', render_lines=True,
+                                    marker_style='.', marker_face_colour='r',
+                                    marker_size=2, marker_edge_width=0,
+                                    backend='matplotlib')
+    assert new_im.n_channels == 3
+    assert_allclose(new_im.pixels[0, 3, 5], [255])
+    assert_allclose(new_im.pixels[0, 9, 5], [255])
+    assert_allclose(new_im.pixels[2, 5:8, 5], [255, 255, 255])
+
+
+def test_rasterize_pillow_basic():
+    im = Image.init_blank([11, 11], fill=0, n_channels=3)
+    im.landmarks['test'] = centre
+    new_im = rasterize_landmarks_2d(im, group='test', render_lines=False,
+                                    marker_style='s', marker_face_colour='r',
+                                    marker_size=1, marker_edge_width=0,
+                                    backend='pillow')
+    assert new_im.n_channels == 3
+    assert_allclose(new_im.pixels[0, 3:6, 3:6], 255)
+
+
+def test_rasterize_pillow_basic_line():
+    im = Image.init_blank([11, 11], fill=0, n_channels=3)
+    im.landmarks['test'] = line
+    new_im = rasterize_landmarks_2d(im, group='test', render_lines=True,
+                                    line_width=1, line_colour='b',
+                                    marker_style='s', marker_face_colour='r',
+                                    marker_size=1, marker_edge_width=0,
+                                    backend='pillow')
+    assert new_im.n_channels == 3
+    assert_allclose(new_im.pixels[0, 1:4, 3:6], 255)
+    assert_allclose(new_im.pixels[0, 7:-1, 3:6], 255)
+    assert_allclose(new_im.pixels[2, 4:7, 4], 255)


### PR DESCRIPTION
The matplotlib backend was causing errors in python 3. 
The following code crashed with `ValueError`: 
```
im = mio.import_builtin_asset.lenna_png()
im1 = rasterize_landmarks_2d(im, 'LJSON')
```
In my machine it works now  (python 2.7 and 3.4). 