### PR TITLE
LazyList init methods and are now Copyable

### DIFF
--- a/menpo/base.py
+++ b/menpo/base.py
@@ -488,6 +488,34 @@ class LazyList(collections.Sequence):
         return len(self._callables)
 
     @classmethod
+    def init_from_iterable(cls, iterable, f=None):
+        r"""
+        Create a lazy list from an existing iterable (think Python `list`) and
+        optionally a `callable` that expects a single parameter which will be
+        applied to each element of the list. This allows for simply
+        creating a `LazyList` from an existing list and if no `callable` is
+        provided the identity function is assumed.
+
+        Parameters
+        ----------
+        iterable : `iterable`
+            An iterable object such as a `list`.
+        f : `callable`, optional
+            Callable expecting a single parameter.
+
+        Returns
+        -------
+        lazy : `LazyList`
+            A LazyList where each element returns each item of the provided
+            iterable, optionally with `f` applied to it.
+        """
+        if f is None:
+            # The identity function
+            def f(i):
+                return i
+        return cls([partial(f, x) for x in iterable])
+
+    @classmethod
     def init_from_index_callable(cls, f, n_elements):
         r"""
         Create a lazy list from a `callable` that expects a single parameter,

--- a/menpo/base.py
+++ b/menpo/base.py
@@ -1,4 +1,5 @@
 import collections
+from itertools import chain
 from functools import partial, wraps
 import os.path
 import warnings
@@ -553,6 +554,32 @@ class LazyList(collections.Sequence):
         else:
             return self.__class__([partial(delayed, f, x)
                                    for x in self._callables])
+
+    def repeat(self, n):
+        r"""
+        Repeat each item of the underlying LazyList ``n`` times. Therefore,
+        if a list currently has ``D`` items, the returned list will contain
+        ``D * n`` items and will return immediately (method is lazy).
+
+        Parameters
+        ----------
+        n : `int`
+            The number of times to repeat each item.
+
+        Returns
+        -------
+        lazy : `LazyList`
+            A LazyList where each element returns each item of the provided
+            iterable, optionally with `f` applied to it.
+
+        Examples
+        --------
+        >>> from menpo.base import LazyList
+        >>> ll = LazyList.init_from_list([0, 1])
+        >>> repeated_ll = ll.repeat(2)  # Returns immediately
+        >>> items = list(repeated_ll)   # [0, 0, 1, 1]
+        """
+        return self.__class__(list(chain(*zip(*[self._callables] * n))))
 
     def __add__(self, other):
         r"""

--- a/menpo/base.py
+++ b/menpo/base.py
@@ -26,10 +26,8 @@ class Copyable(object):
 
         Returns
         -------
-
         ``type(self)``
             A copy of this object
-
         """
         new = self.__class__.__new__(self.__class__)
         for k, v in self.__dict__.items():
@@ -453,7 +451,7 @@ class doc_inherit(object):
         return func
 
 
-class LazyList(collections.Sequence):
+class LazyList(collections.Sequence, Copyable):
     r"""
     An immutable sequence that provides the ability to lazily access objects.
     In truth, this sequence simply wraps a list of callables which are then
@@ -608,6 +606,21 @@ class LazyList(collections.Sequence):
         >>> items = list(repeated_ll)   # [0, 0, 1, 1]
         """
         return self.__class__(list(chain(*zip(*[self._callables] * n))))
+
+    def copy(self):
+        r"""
+        Generate an efficient copy of this LazyList - copying the underlying
+        callables will be lazy and shallow (each callable will **not** be
+        called nor copied) but they will reside within in a new `list`.
+
+        Returns
+        -------
+        ``type(self)``
+            A copy of this LazyList.
+        """
+        new = super(LazyList, self).copy()
+        new._callables = list(self._callables)
+        return new
 
     def __add__(self, other):
         r"""

--- a/menpo/io/test/io_import_test.py
+++ b/menpo/io/test/io_import_test.py
@@ -330,11 +330,13 @@ def test_importing_PIL_P_no_normalize(is_file, mock_image):
 def test_importing_ffmpeg_GIF_normalize(is_file, video_infos_ffprobe, pipe):
     video_infos_ffprobe.return_value = {'duration': 2, 'width': 100,
                                         'height': 150, 'n_frames': 10, 'fps': 5}
-    pipe.return_value.stdout.read.return_value = np.ones(150 * 100 * 3,
-                                                         dtype=np.uint8).tostring()
+    empty_frame = np.zeros(150*100*3, dtype=np.uint8).tostring()
+    pipe.return_value.stdout.read.return_value = empty_frame
     is_file.return_value = True
 
     ll = mio.import_image('fake_image_being_mocked.gif', normalize=True)
+    assert ll.path.name == 'fake_image_being_mocked.gif'
+    assert ll.fps == 5
     assert len(ll) == 10
 
     im = ll[0]
@@ -349,11 +351,13 @@ def test_importing_ffmpeg_GIF_normalize(is_file, video_infos_ffprobe, pipe):
 def test_importing_ffmpeg_GIF_no_normalize(is_file, video_infos_ffprobe, pipe):
     video_infos_ffprobe.return_value = {'duration': 2, 'width': 100,
                                         'height': 150, 'n_frames': 10, 'fps': 5}
-    pipe.return_value.stdout.read.return_value = np.ones(150 * 100 * 3,
-                                                         dtype=np.uint8).tostring()
+    empty_frame = np.zeros(150*100*3, dtype=np.uint8).tostring()
+    pipe.return_value.stdout.read.return_value = empty_frame
     is_file.return_value = True
 
     ll = mio.import_image('fake_image_being_mocked.gif', normalize=False)
+    assert ll.path.name == 'fake_image_being_mocked.gif'
+    assert ll.fps == 5
     assert len(ll) == 10
 
     im = ll[0]
@@ -494,10 +498,14 @@ def test_importing_pickles_as_generator(is_file, glob, mock_open, mock_pickle):
 @patch('menpo.io.input.video.video_infos_ffprobe')
 @patch('menpo.io.input.base.Path.is_file')
 def test_importing_ffmpeg_avi_no_normalize(is_file, video_infos_ffprobe, pipe):
-    video_infos_ffprobe.return_value = {'duration': 2, 'width': 100, 'height': 150, 'n_frames': 10, 'fps': 5}
+    video_infos_ffprobe.return_value = {'duration': 2, 'width': 100,
+                                        'height': 150, 'n_frames': 10, 'fps': 5}
     is_file.return_value = True
-    pipe.return_value.stdout.read.return_value = np.zeros(150*100*3, dtype=np.uint8).tostring()
+    empty_frame = np.zeros(150*100*3, dtype=np.uint8).tostring()
+    pipe.return_value.stdout.read.return_value = empty_frame
     ll = mio.import_video('fake_image_being_mocked.avi', normalize=False)
+    assert ll.path.name == 'fake_image_being_mocked.avi'
+    assert ll.fps == 5
     assert len(ll) == 5*2
     image = ll[0]
     assert image.shape == ((150, 100))
@@ -509,13 +517,17 @@ def test_importing_ffmpeg_avi_no_normalize(is_file, video_infos_ffprobe, pipe):
 @patch('menpo.io.input.video.video_infos_ffprobe')
 @patch('menpo.io.input.base.Path.is_file')
 def test_importing_ffmpeg_avi_normalize(is_file, video_infos_ffprobe, pipe):
-    video_infos_ffprobe.return_value = {'duration': 2, 'width': 100, 'height': 150, 'n_frames': 10, 'fps': 5}
+    video_infos_ffprobe.return_value = {'duration': 2, 'width': 100,
+                                        'height': 150, 'n_frames': 10, 'fps': 5}
     is_file.return_value = True
-    pipe.return_value.stdout.read.return_value = np.zeros(150*100*3, dtype=np.uint8).tostring()
+    empty_frame = np.zeros(150*100*3, dtype=np.uint8).tostring()
+    pipe.return_value.stdout.read.return_value = empty_frame
     ll = mio.import_video('fake_image_being_mocked.avi', normalize=True)
+    assert ll.path.name == 'fake_image_being_mocked.avi'
+    assert ll.fps == 5
     assert len(ll) == 5*2
     image = ll[0]
-    assert image.shape == ((150, 100))
+    assert image.shape == (150, 100)
     assert image.n_channels == 3
     assert image.pixels.dtype == np.float
 

--- a/menpo/test/lazylist_test.py
+++ b/menpo/test/lazylist_test.py
@@ -57,6 +57,13 @@ def test_lazylist_multi_map_iterable_and_callable():
     assert 1
 
 
+def test_lazylist_repeat():
+    ll = LazyList.init_from_iterable([0, 1])
+    ll_repeated = ll.repeat(2)
+    assert len(ll_repeated) == 4
+    assert all([a == b for a, b in zip([0, 0, 1, 1], ll_repeated)])
+
+
 def test_lazylist_map():
     two_func = lambda: 2
     double_func = lambda x: x * 2

--- a/menpo/test/lazylist_test.py
+++ b/menpo/test/lazylist_test.py
@@ -92,6 +92,19 @@ def test_lazylist_map_no_call():
     mock_func.assert_not_called()
 
 
+def test_lazylist_init_from_iterable_identity():
+    ll = LazyList.init_from_iterable([0, 1])
+    assert ll[0] == 0
+    assert ll[1] == 1
+
+
+def test_lazylist_init_from_iterable_with_f():
+    double_func = lambda x: x * 2
+    ll = LazyList.init_from_iterable([0, 1], f=double_func)
+    assert ll[0] == 0
+    assert ll[1] == 2
+
+
 def test_lazylist_init_from_index_callable():
     identity_func = lambda x: x
     ll = LazyList.init_from_index_callable(identity_func, 5)

--- a/menpo/test/lazylist_test.py
+++ b/menpo/test/lazylist_test.py
@@ -14,6 +14,28 @@ def test_lazylist_get():
     assert ll[0] == 1
 
 
+def test_lazylist_copy_lazy():
+    mock_func = Mock()
+    mock_func.return_value = 1
+    ll = LazyList([mock_func] * 10)
+    copied_ll = ll.copy()
+    assert len(copied_ll) == 10
+    assert id(ll._callables) != id(copied_ll._callables)
+    mock_func.assert_not_called()
+
+
+def test_lazylist_copy_duck_typed():
+    mock_func = Mock()
+    mock_func.return_value = 1
+    ll = LazyList([mock_func] * 10)
+    ll.fps = 50
+    copied_ll = ll.copy()
+    assert len(copied_ll) == 10
+    assert id(ll._callables) != id(copied_ll._callables)
+    mock_func.assert_not_called()
+    assert copied_ll.fps == 50
+
+
 def test_lazylist_multiple_calls():
     mock_func = Mock()
     mock_func.return_value = 1

--- a/menpo/test/lazylist_test.py
+++ b/menpo/test/lazylist_test.py
@@ -1,3 +1,5 @@
+import collections
+
 from mock import Mock
 from nose.tools import raises
 
@@ -19,6 +21,40 @@ def test_lazylist_multiple_calls():
     ll[0]
     ll[0]
     assert mock_func.call_count == 2
+
+
+def test_lazylist_multi_map():
+    two_func = lambda: 2
+    double_func = [lambda x: x * 2] * 2
+    ll = LazyList([two_func] * 2)
+    ll_mapped = ll.map(double_func)
+    assert len(ll_mapped) == 2
+    assert id(ll) != id(ll_mapped)
+    assert all(x == 4 for x in ll_mapped)
+
+
+@raises(ValueError)
+def test_lazylist_multi_map_unequal_lengths():
+    two_func = lambda: 2
+    double_func = [lambda x: x * 2] * 2
+    ll = LazyList([two_func])
+    ll.map(double_func)
+
+
+@raises(ValueError)
+def test_lazylist_multi_map_iterable_and_callable():
+    class double_func(collections.Iterable):
+        def __call__(self, x, **kwargs):
+            return x * 2
+
+        def __iter__(self):
+            yield 1
+
+    f = double_func()
+    two_func = lambda: 2
+    ll = LazyList([two_func])
+    ll.map(f)
+    assert 1
 
 
 def test_lazylist_map():


### PR DESCRIPTION
Just a couple of small improvements:

  - `LazyList` is now copyable - helps propagate duck typed elements such as `path`
  - `init_from_iterable` for creating `LazyList`s from existing iterables
  - `map` now allows a list of callables
  - `repeat` for lazily expanding a `LazyList` to copy the elements - useful for SDM training
  - Fix lazy landmark importing to propagate `path` and `fps` properly now that `map` uses copying.