### PR TITLE
Minor change in documentation of pickle, contrain_landmarks in image.

### DIFF
--- a/menpo/image/base.py
+++ b/menpo/image/base.py
@@ -1352,15 +1352,6 @@ class Image(Vectorizable, Landmarkable, Viewable, LandmarkableViewable):
             constrain_to_boundary=constrain_to_boundary,
             return_transform=return_transform)
 
-    def _propagate_crop_to_inplace(self, cropped):
-        # helper method that sets self's state to the result of a crop call.
-        # only needed for the deprecation period of the inplace crop methods.
-        self.pixels = cropped.pixels
-        self.landmarks = cropped.landmarks
-        if hasattr(self, 'mask'):
-            self.mask = cropped.mask
-        return self
-
     def constrain_points_to_bounds(self, points):
         r"""
         Constrains the points provided to be within the bounds of this image.
@@ -2600,7 +2591,7 @@ class Image(Vectorizable, Landmarkable, Viewable, LandmarkableViewable):
         method. For example:
 
             >>> im.constrain_landmarks_to_bounds()  # Equivalent to below
-            >>> im.landmarks['test'] = im.landmarks['test'].lms.constrain_to_bounds(im.bounds)
+            >>> im.landmarks['test'] = im.landmarks['test'].lms.constrain_to_bounds(im.bounds())
         """
         warn('This method is no longer supported and will be removed in a '
              'future version of Menpo. '

--- a/menpo/io/output/base.py
+++ b/menpo/io/output/base.py
@@ -145,9 +145,9 @@ def export_pickle(obj, fp, overwrite=False, protocol=2):
     The ``fp`` argument can be either a `Path` or any Python type that acts like
     a file.
     If ``fp`` is a path, it must have the suffix `.pkl` or `.pkl.gz`. If
-    `.pkl`, the object will be pickled using Pickle protocol 2 without
-    compression. If `.pkl.gz` the object will be pickled using Pickle protocol
-    2 with gzip compression (at a fixed compression level of 3).
+    `.pkl`, the object will be pickled using the selected Pickle protocol.
+    If `.pkl.gz` the object will be pickled using the selected Pickle
+    protocol with gzip compression (at a fixed compression level of 3).
 
     Note that a special exception is made for `pathlib.Path` objects - they
     are pickled down as a `pathlib.PurePath` so that pickles can be easily


### PR DESCRIPTION
Additionally, delete the auxiliary function that was forgotten from crop_inplace methods.