### PR TITLE
Enable greyscale video to be exported.

### DIFF
--- a/menpo/io/output/base.py
+++ b/menpo/io/output/base.py
@@ -94,9 +94,11 @@ def export_image(image, fp, extension=None, overwrite=False):
 
 def export_video(images, filepath, overwrite=False, fps=30, **kwargs):
     r"""
-    Exports a given list of images as a video. The ``filepath`` argument is
-    a `Path` representing the path to save the video to. At this time,
-    it is not possible to export videos directly to a file buffer.
+    Exports a given list of images as a video. Ensure that all the images
+    have the same shape, otherwise you might get unexpected results from
+    the ffmpeg writer. The ``filepath`` argument is a `Path` representing
+    the path to save the video to. At this time, it is not possible
+    to export videos directly to a file buffer.
 
     Due to the mix of string and file types, an explicit overwrite argument is
     used which is ``False`` by default.

--- a/menpo/io/output/video.py
+++ b/menpo/io/output/video.py
@@ -1,5 +1,7 @@
 import os
 import subprocess as sp
+import warnings
+
 import numpy as np
 from pathlib import Path
 
@@ -49,9 +51,12 @@ def ffmpeg_video_exporter(images, out_path, fps=30, codec='libx264',
     # and is used under the terms of the MIT license which can be found at
     #   https://github.com/Zulko/moviepy/blob/master/LICENCE.txt
     first_image = images[0]
-    colour = 'rgb24' if images[0].n_channels == 3 else 'gray'
+    frame_shape = first_image.shape
+    # If the first image is gray then all the images will be assumed to be
+    # gray
+    colour = 'rgb24' if images[0].n_channels == 3 else 'gray8'
     cmd = [_FFMPEG_CMD(), '-y',
-           '-s', '{}x{}'.format(first_image.shape[1], first_image.shape[0]),
+           '-s', '{}x{}'.format(frame_shape[1], frame_shape[0]),
            '-r', str(fps),
            '-an',
            '-pix_fmt', colour,
@@ -71,9 +76,22 @@ def ffmpeg_video_exporter(images, out_path, fps=30, codec='libx264',
     # Pipe stdout to DEVNULL to ignore it
     with _call_subprocess(sp.Popen(cmd, stdin=sp.PIPE, stderr=sp.PIPE,
                                    stdout=DEVNULL)) as pipe:
-        for image in images:
+        for k, image in enumerate(images):
             try:
+                if image.n_channels != 1 and colour == 'gray8':
+                    warnings.warn('Frame {} is non-greyscale and the initial '
+                                  'frame was greyscale. This frame will be '
+                                  'corrupted.'.format(k))
+                if image.shape != frame_shape:  # Valid due to tuple/int
+                    warnings.warn('Frame {} is not the same shape as the '
+                                  'initial frame and therefore the output '
+                                  'may be corrupted.'.format(k))
+
                 i = image.pixels_with_channels_at_back(out_dtype=np.uint8)
+                # Handle the case of a greyscale image amidst colour images
+                if image.n_channels == 1 and colour == 'rgb24':
+                    # Repeat the channels axis 3 times
+                    i = i.reshape(i.shape + (1,)).repeat(3, axis=2)
                 pipe.stdin.write(i.tostring())
             except IOError:
                 error = ('FFMPEG encountered the following error while '

--- a/menpo/io/output/video.py
+++ b/menpo/io/output/video.py
@@ -49,11 +49,12 @@ def ffmpeg_video_exporter(images, out_path, fps=30, codec='libx264',
     # and is used under the terms of the MIT license which can be found at
     #   https://github.com/Zulko/moviepy/blob/master/LICENCE.txt
     first_image = images[0]
+    colour = 'rgb24' if images[0].n_channels == 3 else 'gray'
     cmd = [_FFMPEG_CMD(), '-y',
            '-s', '{}x{}'.format(first_image.shape[1], first_image.shape[0]),
            '-r', str(fps),
            '-an',
-           '-pix_fmt', 'rgb24',
+           '-pix_fmt', colour,
            '-c:v', 'rawvideo', '-f', 'rawvideo',
            '-i', '-']
     if codec:

--- a/menpo/io/test/io_export_test.py
+++ b/menpo/io/test/io_export_test.py
@@ -1,3 +1,5 @@
+import warnings
+
 import numpy as np
 import sys
 from numpy.testing import assert_allclose
@@ -19,6 +21,7 @@ test_lg = mio.import_landmark_file(mio.data_path_to('breakingbad.pts'))
 nan_lg = test_lg.copy()
 nan_lg.lms.points[0, :] = np.nan
 test_img = Image(np.random.random([100, 100]))
+colour_test_img = Image(np.random.random([3, 100, 100]))
 fake_path = '/tmp/test.fake'
 
 
@@ -244,11 +247,66 @@ def test_export_image_jpg(mock_open, exists, PILImage):
 
 @patch('subprocess.Popen')
 @patch('menpo.io.output.base.Path.exists')
-def test_export_video_avi(exists, pipe):
+def test_export_video_avi_gray(exists, pipe):
     exists.return_value = False
     fake_path = Path('/fake/fake.avi')
     mio.export_video([test_img, test_img], fake_path, extension='avi')
     assert pipe.return_value.stdin.write.call_count == 2
+    assert 'gray8' in pipe.call_args[0][0]
+
+
+@patch('subprocess.Popen')
+@patch('menpo.io.output.base.Path.exists')
+def test_export_video_avi_colour(exists, pipe):
+    exists.return_value = False
+    fake_path = Path('/fake/fake.avi')
+    mio.export_video([colour_test_img, colour_test_img], fake_path,
+                     extension='avi')
+    assert pipe.return_value.stdin.write.call_count == 2
+    assert 'rgb24' in pipe.call_args[0][0]
+
+
+@patch('subprocess.Popen')
+@patch('menpo.io.output.base.Path.exists')
+def test_export_video_avi_gray_first_mixed(exists, pipe):
+    exists.return_value = False
+    fake_path = Path('/fake/fake.avi')
+    with warnings.catch_warnings(record=True) as w:
+        warnings.simplefilter("always")
+        mio.export_video([test_img, colour_test_img], fake_path,
+                         extension='avi')
+        assert len(w) == 1
+    assert pipe.return_value.stdin.write.call_count == 2
+    assert 'gray8' in pipe.call_args[0][0]
+
+
+@patch('subprocess.Popen')
+@patch('menpo.io.output.base.Path.exists')
+def test_export_video_avi_colour_first_mixed(exists, pipe):
+    exists.return_value = False
+    fake_path = Path('/fake/fake.avi')
+    mio.export_video([colour_test_img, test_img], fake_path,
+                     extension='avi')
+    assert pipe.return_value.stdin.write.call_count == 2
+    recon_0 = pipe.return_value.stdin.write.mock_calls[0][1][0]
+    assert np.fromstring(recon_0, dtype=np.uint8).size == 30000
+    # Ensure that the second frame is converted to gray
+    recon_1 = pipe.return_value.stdin.write.mock_calls[1][1][0]
+    assert np.fromstring(recon_1, dtype=np.uint8).size == 30000
+    assert 'rgb24' in pipe.call_args[0][0]
+
+
+@patch('subprocess.Popen')
+@patch('menpo.io.output.base.Path.exists')
+def test_export_video_avi_shape_mismatch(exists, pipe):
+    exists.return_value = False
+    fake_path = Path('/fake/fake.avi')
+    with warnings.catch_warnings(record=True) as w:
+        warnings.simplefilter("always")
+        mio.export_video([test_img.resize([150, 100]), test_img], fake_path,
+                         extension='avi')
+        assert len(w) == 1
+    assert 'gray8' in pipe.call_args[0][0]
 
 
 @patch('subprocess.Popen')


### PR DESCRIPTION
There was a bug in the pixel format in the ffmpeg writer that only allowed RGB images to be exported. 

@patricksnape I tried to insert a related test, but your expertise would be required in case you want such a test.