### PR TITLE
Utilise the kwargs in exporting video with ffmpeg.

### DIFF
--- a/menpo/io/output/video.py
+++ b/menpo/io/output/video.py
@@ -41,10 +41,19 @@ def ffmpeg_video_exporter(images, out_path, fps=30, codec='libx264',
         defaults is 'msmpeg4' which is more commonly supported for windows.
     preset : `str`, optional
         The preset FFMPEG compression level.
+        Please check out the documentation for more information:
+        https://trac.ffmpeg.org/wiki/Encode/H.264#a2.Chooseapreset
     bitrate: `str`, optional
         The output video bitrate.
     verbose : `bool`, optional
         If ``True``, print a progress bar.
+    **kwargs : `dict`, optional
+        Extra parameters for advanced video exporting options.
+        They are passed through directly to FFMPEG and they should.
+        be organised in pairs of option/value in a dictionary.
+        For instance: {'crf' : '0'} # equivalent to -crf 0 in ffmpeg.
+        You can find further details in the documentation:
+        https://ffmpeg.org/ffmpeg.html#Options
     """
     # Some of the below was inspired by moviepy:
     #   https://github.com/Zulko/moviepy/blob/master/moviepy/video/io/ffmpeg_writer.py
@@ -68,6 +77,9 @@ def ffmpeg_video_exporter(images, out_path, fps=30, codec='libx264',
         cmd.extend(['-preset', preset])
     if bitrate:
         cmd.extend(['-b', str(bitrate)])
+    # add the optional kwargs for FFMPEG options.
+    for key, value in kwargs.items():
+        cmd.extend(['-{}'.format(key), value])
     cmd.append(str(out_path))
 
     images = (print_progress(images, prefix='Exporting frames') if verbose

--- a/menpo/io/output/video.py
+++ b/menpo/io/output/video.py
@@ -51,7 +51,7 @@ def ffmpeg_video_exporter(images, out_path, fps=30, codec='libx264',
         Extra parameters for advanced video exporting options.
         They are passed through directly to FFMPEG and they should.
         be organised in pairs of option/value in a dictionary.
-        For instance: {'crf' : '0'} # equivalent to -crf 0 in ffmpeg.
+        For instance: ``{'crf' : '0'} # equivalent to -crf 0 in ffmpeg.``
         You can find further details in the documentation:
         https://ffmpeg.org/ffmpeg.html#Options
     """

--- a/menpo/io/test/io_export_test.py
+++ b/menpo/io/test/io_export_test.py
@@ -318,6 +318,16 @@ def test_export_video_gif(exists, pipe):
     assert pipe.return_value.stdin.write.call_count == 2
 
 
+@patch('subprocess.Popen')
+@patch('menpo.io.output.base.Path.exists')
+def test_export_video_avi_kwargs(exists, pipe):
+    exists.return_value = False
+    fake_path = Path('/fake/fake.avi')
+    mio.export_video([test_img, test_img], fake_path, extension='avi', **{'crf' : '0'})
+    assert pipe.return_value.stdin.write.call_count == 2
+    assert '-crf' in pipe.call_args[0][0]
+
+
 @patch('menpo.io.output.pickle.pickle.dump')
 @patch('menpo.io.output.base.Path.exists')
 @patch('{}.open'.format(__name__), create=True)


### PR DESCRIPTION
Previously the kwargs were not used in ffmpeg_video_exporter(), thus several options  (e.g. compression) could not be changed. 