### PR TITLE
allow for forced inexact frame count in FFMpegVideoReader

### DIFF
--- a/menpo/image/test/image_test.py
+++ b/menpo/image/test/image_test.py
@@ -5,6 +5,11 @@ from nose.tools import raises
 from menpo.testing import is_same_array
 from menpo.image import BooleanImage, MaskedImage, Image
 
+# TODO: Remove when Pillow 3.3.0 release on all platforms
+import unittest
+from PIL import PILLOW_VERSION
+from distutils.version import LooseVersion
+
 
 @raises(ValueError)
 def test_create_1d_error():
@@ -702,10 +707,12 @@ def test_as_pil_image_float32():
                     (im.pixels * 255).astype(np.uint8))
 
 
-@raises(TypeError)
+@unittest.skipIf(LooseVersion(PILLOW_VERSION) < LooseVersion('3.3.0'), "requires pillow>=3.3.0")
 def test_as_pil_image_float32_uint16_out():
     im = Image(np.ones((1, 120, 120), dtype=np.float32), copy=False)
-    im.as_PILImage(out_dtype=np.uint16)
+    new_im = im.as_PILImage(out_dtype=np.uint16)
+    assert_allclose(np.asarray(new_im.getdata()).reshape(im.pixels.shape),
+                    (im.pixels * 65535).astype(np.uint16))
 
 
 def test_as_pil_image_bool():

--- a/menpo/image/test/rasterize_test.py
+++ b/menpo/image/test/rasterize_test.py
@@ -14,6 +14,8 @@ line = PointUndirectedGraph(np.array([[2, 4.5], [8, 4.5]]),
 
 @unittest.skipIf(os.environ.get('TRAVIS'), 'Skipping due to lack of DISPLAY on Travis')
 def test_rasterize_matplotlib_basic():
+    import matplotlib
+    matplotlib.use('agg')
     im = Image.init_blank([11, 11], fill=0, n_channels=1)
     im.landmarks['test'] = centre
     new_im = rasterize_landmarks_2d(im, group='test', render_lines=False,
@@ -27,6 +29,8 @@ def test_rasterize_matplotlib_basic():
 
 @unittest.skipIf(os.environ.get('TRAVIS'), 'Skipping due to lack of DISPLAY on Travis')
 def test_rasterize_matplotlib_basic_line():
+    import matplotlib
+    matplotlib.use('agg')
     im = Image.init_blank([11, 11], fill=0, n_channels=1)
     im.landmarks['test'] = line
     new_im = rasterize_landmarks_2d(im, group='test', render_lines=True,

--- a/menpo/io/input/base.py
+++ b/menpo/io/input/base.py
@@ -262,7 +262,8 @@ def import_image(filepath, landmark_resolver=same_name, normalize=None,
 
 
 def import_video(filepath, landmark_resolver=same_name_video, normalize=None,
-                 normalise=None, importer_method='ffmpeg', exact_frame_count=True):
+                 normalise=None, importer_method='ffmpeg',
+                 exact_frame_count=True):
     r"""Single video (and associated landmarks) importer.
 
     If a video file is found at `filepath`, returns an :map:`LazyList` wrapping
@@ -306,7 +307,7 @@ def import_video(filepath, landmark_resolver=same_name_video, normalize=None,
         A string representing the type of importer to use, by default ffmpeg
         is used.
     exact_frame_count: `bool`, optional
-        If True, the import fails if ffmprobe is not available
+        If ``True``, the import fails if ffprobe is not available
         (reading from ffmpeg's output returns inexact frame count)
 
     Returns

--- a/menpo/io/input/video.py
+++ b/menpo/io/input/video.py
@@ -16,7 +16,7 @@ _FFMPEG_CMD = lambda: str(Path(os.environ.get('MENPO_FFMPEG_CMD', 'ffmpeg')))
 _FFPROBE_CMD = lambda: str(Path(os.environ.get('MENPO_FFPROBE_CMD', 'ffprobe')))
 
 
-def ffmpeg_importer(filepath, normalize=True, exact_frame_count=False, **kwargs):
+def ffmpeg_importer(filepath, normalize=True, exact_frame_count=True, **kwargs):
     r"""
     Imports videos by streaming frames from a pipe using FFMPEG. Returns a
     :map:`LazyList` that gives lazy access to the video on a per-frame basis.
@@ -38,6 +38,9 @@ def ffmpeg_importer(filepath, normalize=True, exact_frame_count=False, **kwargs)
     normalize : `bool`, optional
         If ``True``, normalize between 0.0 and 1.0 and convert to float. If
         ``False`` just return whatever ffmpeg imports.
+    exact_frame_count: `bool`, optional
+        If ``True``, the import fails if ffprobe is not available
+        (reading from ffmpeg's output returns inexact frame count)
     \**kwargs : `dict`, optional
         Any other keyword arguments.
 

--- a/menpo/io/input/video.py
+++ b/menpo/io/input/video.py
@@ -94,9 +94,11 @@ class FFMpegVideoReader(object):
             try:
                 infos = video_infos_ffprobe(self.filepath)
             except:
-                raise ValueError('ffprobe not available, unable to get exact frame count.'
-                                 ' If you want to use an approximate frame number, set exact_frame_count to False'
-                                 ' and proceed at your own risks.')
+                raise ValueError('ffprobe not available, unable to get exact '
+                                 'frame count. If you want to use an '
+                                 'approximate frame number, set exact_frame_'
+                                 'count to False and proceed at your own '
+                                 'risk.')
         else:
             infos = video_infos_ffmpeg(self.filepath)
         self.duration = infos['duration']

--- a/menpo/io/input/video.py
+++ b/menpo/io/input/video.py
@@ -87,17 +87,15 @@ class FFMpegVideoReader(object):
         self.normalize = normalize
         self.exact_frame_count = exact_frame_count
         self._pipe = None
-        try:
-            infos = video_infos_ffprobe(self.filepath)
-        except:
-            if self.exact_frame_count:
+        if self.exact_frame_count:
+            try:
+                infos = video_infos_ffprobe(self.filepath)
+            except:
                 raise ValueError('ffprobe not available, unable to get exact frame count.'
                                  ' If you want to use an approximate frame number, set exact_frame_count to False'
                                  ' and proceed at your own risks.')
-            else:
-                # Eat the exception from above as we warn about it inside
-                # video_infos_ffmpeg
-                infos = video_infos_ffmpeg(self.filepath)
+        else:
+            infos = video_infos_ffmpeg(self.filepath)
         self.duration = infos['duration']
         self.width = infos['width']
         self.height = infos['height']

--- a/menpo/math/test/decomposition_base_test.py
+++ b/menpo/math/test/decomposition_base_test.py
@@ -108,7 +108,7 @@ def eigenvalue_decomposition_large_epsilon_test():
 
 
 def ipca_samples_yescentre_test():
-    n_a = large_samples_data_matrix.shape[0] / 2
+    n_a = large_samples_data_matrix.shape[0] // 2
     A = large_samples_data_matrix[:n_a, :]
     U_a, l_a, m_a = pca(A, centre=True)
 
@@ -123,7 +123,7 @@ def ipca_samples_yescentre_test():
 
 
 def ipca_samples_nocentre_test():
-    n_a = large_samples_data_matrix.shape[0] / 2
+    n_a = large_samples_data_matrix.shape[0] // 2
     A = large_samples_data_matrix[:n_a, :]
     U_a, l_a, m_a = pca(A, centre=False)
 
@@ -140,7 +140,7 @@ def ipca_samples_nocentre_test():
 def ipca_features_yescentre_test():
     C = np.vstack((large_samples_data_matrix.T, large_samples_data_matrix.T))
 
-    n_a = C.shape[0] / 2
+    n_a = C.shape[0] // 2
     A = C[:n_a, :]
     U_a, l_a, m_a = pca(A, centre=True)
 
@@ -157,7 +157,7 @@ def ipca_features_yescentre_test():
 def ipca_features_nocentre_test():
     C = np.vstack((large_samples_data_matrix.T, large_samples_data_matrix.T))
 
-    n_a = C.shape[0] / 2
+    n_a = C.shape[0] // 2
     A = C[:n_a, :]
     U_a, l_a, m_a = pca(A, centre=False)
 


### PR DESCRIPTION
Changes the behaviour of `exact_frame_count` in video importing so that if you set to `False` it just uses ffmpeg - this allows for much faster video ingestion. 