### PR TITLE
Support more types for normals

### DIFF
--- a/menpo/shape/mesh/base.py
+++ b/menpo/shape/mesh/base.py
@@ -5,7 +5,7 @@ from warnings import warn
 
 from .. import PointCloud
 from ..adjacency import mask_adjacency_array, reindex_adjacency_array
-from .normals import compute_normals
+from .normals import compute_vertex_normals, compute_face_normals
 
 
 Delaunay = None  # expensive, from scipy.spatial
@@ -360,7 +360,7 @@ class TriMesh(PointCloud):
         """
         if self.n_dims != 3:
             raise ValueError("Normals are only valid for 3D meshes")
-        return compute_normals(self.points, self.trilist)[0]
+        return compute_vertex_normals(self.points, self.trilist)
 
     def tri_normals(self):
         r"""
@@ -379,7 +379,7 @@ class TriMesh(PointCloud):
         """
         if self.n_dims != 3:
             raise ValueError("Normals are only valid for 3D meshes")
-        return compute_normals(self.points, self.trilist)[1]
+        return compute_face_normals(self.points, self.trilist)
 
     def tri_areas(self):
         r"""The area of each triangle face.

--- a/menpo/shape/mesh/normals.pyx
+++ b/menpo/shape/mesh/normals.pyx
@@ -2,101 +2,135 @@ import numpy as np
 import cython
 cimport numpy as np
 cimport cython
+from libc.math cimport sqrt
+from menpo.cy_utils cimport dtype_from_memoryview
 
-ctypedef np.float64_t FLOAT64_T
+
+ctypedef fused floats:
+    np.float32_t
+    np.float64_t
+
 ctypedef fused integrals:
+    np.int16_t
+    np.uint16_t
     np.uint32_t
     np.uint64_t
     np.int32_t
     np.int64_t
 
-cdef np.ndarray[FLOAT64_T, ndim=2] normalize(np.ndarray[FLOAT64_T, ndim=2] vec):
+
+cdef normalize(floats[:, :] vec):
     """
-    Normalize the given array of vectors.
+    Normalize the given array of vectors inplace.
 
     Parameters
     ----------
-    vec : (N, 3) c-contiguous double ndarray
+    vec : (N, 3) c-contiguous float32/float64 ndarray
         The array of vectors to normalize
-
-    Returns
-    -------
-    normalized : (N, 3) c-contiguous double ndarray
-        Normalized array of vectors.
     """
     # Avoid divisions by almost 0 numbers
     # np.spacing(1) is equivalent to Matlab's eps
-    cdef np.ndarray[FLOAT64_T, ndim=1] d = np.sqrt(np.sum(vec ** 2, axis=1))
-    d[d < np.spacing(1)] = 1.0
-    return vec / d[..., None]
+    cdef:
+        floats mag
+        Py_ssize_t n_elems = vec.shape[0], i = 0
+        floats eps = np.spacing(1)
+
+    for i in range(n_elems):
+        mag = sqrt(vec[i, 0] * vec[i, 0] +
+                   vec[i, 1] * vec[i, 1] +
+                   vec[i, 2] * vec[i, 2])
+        # Zero magnitude (or close to) causes massive values, so just set vector
+        # to zero.
+        if mag < eps:
+            vec[i, 0] = 0.0
+            vec[i, 1] = 0.0
+            vec[i, 2] = 0.0
+        else:
+            vec[i, 0] /= mag
+            vec[i, 1] /= mag
+            vec[i, 2] /= mag
 
 
-cdef inline np.ndarray[FLOAT64_T, ndim=2] cross(double[:, :] x,
-                                                double[:, :] y):
+cdef inline floats[:, :] triangle_cross(floats[:, :] vertex,
+                                        integrals[:, :] face):
     """
-    The N x 3 cross product (returns the vectors orthogonal
-    to ``x`` and ``y``). This performs the cross product on each (3, 1) vector
-    in the two arrays. Assumes ``x`` and ``y`` have the same shape.
+    The N x 3 cross product of the two sides of the triangles defined
+    by the face array.
 
     Parameters
     ----------
-    x : (N, 3) double memory view
+    x : (N, 3) float32/float64 memory view
         First array to perform cross product with.
-    y : (N, 3) double memory view
+    y : (N, 3) float32/float64 memory view
         Second array to perform cross product with.
 
     Returns
     -------
-    cross : (N, 3) c-contiguous double ndarray
+    cross : (N, 3) c-contiguous float32/float64 ndarray
         The array of vectors representing the cross product between each
         corresponding vector.
     """
+    vertex_dtype = dtype_from_memoryview(vertex)
     cdef:
-        np.ndarray[FLOAT64_T, ndim=2] z = np.empty_like(x)
-        Py_ssize_t n = x.shape[0], i = 0
-    for i in range(n):
-        z[i, 0] = x[i, 1] * y[i, 2] - x[i, 2] * y[i, 1]
-        z[i, 1] = x[i, 2] * y[i, 0] - x[i, 0] * y[i, 2]
-        z[i, 2] = x[i, 0] * y[i, 1] - x[i, 1] * y[i, 0]
+        Py_ssize_t n_vert = vertex.shape[0], n_face = face.shape[0]
+        Py_ssize_t i = 0, j = 0
+        floats[:, :] z = np.zeros([n_face, 3], dtype=vertex_dtype)
+        floats *v0
+        floats *v1
+        floats *v2
+        floats x[3]
+        floats y[3]
+
+    for i in range(n_face):
+        # This is dangerous since we just have a raw pointer, but since we know
+        # our vectors are always [n, 3] we hard coded the 3 loop below.
+        v0 = &vertex[face[i, 0], :][0]
+        v1 = &vertex[face[i, 1], :][0]
+        v2 = &vertex[face[i, 2], :][0]
+        # Calculate triangle edge vectors
+        for j in range(3):
+            x[j] = v1[j] - v0[j]
+            y[j] = v2[j] - v0[j]
+        # Cross Product
+        z[i, 0] = x[1] * y[2] - x[2] * y[1]
+        z[i, 1] = x[2] * y[0] - x[0] * y[2]
+        z[i, 2] = x[0] * y[1] - x[1] * y[0]
 
     return z
 
 
-cpdef compute_normals(np.ndarray[FLOAT64_T, ndim=2] vertex,
-                      np.ndarray[integrals, ndim=2] face):
+cpdef compute_vertex_normals(floats[:, :] vertex, integrals[:, :] face):
     """
-    Compute the per-vertex and per-face normal of the vertices given a list of
-    faces. Ensures that all the normals are pointing in a consistent direction
-    (to avoid 'inverted' normals).
+    Compute the per-vertex normals of the vertices given a list of
+    faces.
 
     Parameters
     ----------
-    vertex : (N, 3) c-contiguous double ndarray
+    vertex : (N, 3) c-contiguous float32/float64 ndarray
         The list of points to compute normals for.
-    face : (M, 3) c-contiguous double ndarray
+    face : (M, 3) c-contiguous int16/int32/int64 ndarray
         The list of faces (triangle list).
 
     Returns
     -------
-    vertex_normal : (N, 3) c-contiguous double ndarray
+    vertex_normal : (N, 3) c-contiguous float32/float64 ndarray
         The normal per vertex.
-    face_normal : (M, 3) c-contiguous double ndarray
-        The normal per face.
     :return:
     """
-    cdef int nface = face.shape[0]
-    cdef int nvert = vertex.shape[0]
+    cdef:
+        Py_ssize_t i = 0, j = 0
+        Py_ssize_t n_vert = vertex.shape[0]
+        Py_ssize_t n_face = face.shape[0]
+        floats[:, :] face_normal
+        floats[:, :] vertex_normal = np.zeros_like(vertex)
+        integrals f0, f1, f2
 
     # Calculate the cross product (per-face normal)
-    cdef np.ndarray[FLOAT64_T, ndim=2] face_normal = cross(
-        vertex[face[:, 1], :] - vertex[face[:, 0], :],
-        vertex[face[:, 2], :] - vertex[face[:, 0], :])
-    face_normal = normalize(face_normal)
+    face_normal = triangle_cross(vertex, face)
+    normalize(face_normal)
 
     # Calculate per-vertex normal
-    cdef np.ndarray[FLOAT64_T, ndim=2] vertex_normal = np.zeros([nvert, 3])
-    cdef integrals f0, f1, f2
-    for i in range(nface):
+    for i in range(n_face):
         f0 = face[i, 0]
         f1 = face[i, 1]
         f2 = face[i, 2]
@@ -104,8 +138,32 @@ cpdef compute_normals(np.ndarray[FLOAT64_T, ndim=2] vertex,
             vertex_normal[f0, j] += face_normal[i, j]
             vertex_normal[f1, j] += face_normal[i, j]
             vertex_normal[f2, j] += face_normal[i, j]
-
     # Normalize
-    vertex_normal = normalize(vertex_normal)
+    normalize(vertex_normal)
 
-    return vertex_normal, face_normal
+    return np.asarray(vertex_normal)
+
+
+cpdef compute_face_normals(floats[:, :] vertex, integrals[:, :] face):
+    """
+    Compute per-face normals of the vertices given a list of
+    faces.
+
+    Parameters
+    ----------
+    vertex : (N, 3) c-contiguous float32/float64 ndarray
+        The list of points to compute normals for.
+    face : (M, 3) c-contiguous int16/int32/int64 ndarray
+        The list of faces (triangle list).
+
+    Returns
+    -------
+    face_normal : (M, 3) c-contiguous float32/float64 ndarray
+        The normal per face.
+    :return:
+    """
+    # Calculate the cross product (per-face normal)
+    cdef floats[:, :] face_normal = triangle_cross(vertex, face)
+    normalize(face_normal)
+
+    return np.asarray(face_normal)

--- a/menpo/shape/mesh/test/trimish_test.py
+++ b/menpo/shape/mesh/test/trimish_test.py
@@ -299,6 +299,10 @@ def test_trimesh_face_normals():
     face_normals = trimesh.tri_normals()
     assert_allclose(face_normals, expected_normals)
 
+    trimesh.points = trimesh.points.astype(np.float32)
+    face_normals = trimesh.tri_normals()
+    assert_allclose(face_normals, expected_normals)
+
 
 def test_trimesh_vertex_normals():
     points = np.array([[0.0, 0.0, -1.0],
@@ -315,5 +319,9 @@ def test_trimesh_vertex_normals():
                                  [0, 0, 1],
                                  [-0.32505758,  -0.32505758, 0.88807383]])
     trimesh = TriMesh(points, trilist)
+    vertex_normals = trimesh.vertex_normals()
+    assert_allclose(vertex_normals, expected_normals)
+
+    trimesh.points = trimesh.points.astype(np.float32)
     vertex_normals = trimesh.vertex_normals()
     assert_allclose(vertex_normals, expected_normals)


### PR DESCRIPTION
This involved removing numpy specific typing from the Cython
and thus making the code more 'c'-like. However, this had an
advantage of making the code faster. While I was here I also
seperated the vertex and face calculation to make face normal
calculation from Python twice as fast.

This fixes #718.

The speedup is as follows:
```
OLD
100 loops, best of 3: 10.2 ms per loop
100 loops, best of 3: 9.53 ms per loop
```
```
NEW
100 loops, best of 3: 8.28 ms per loop
100 loops, best of 3: 4.93 ms per loop
```