### PR TITLE
Simplify the conda build

### DIFF
--- a/conda/bld.bat
+++ b/conda/bld.bat
@@ -1,5 +1,0 @@
-robocopy %RECIPE_DIR%\.. . /E /NFL /NDL
-
-"%PYTHON%" setup.py install --single-version-externally-managed --record=%TEMP%record.txt
-
-if errorlevel 1 exit 1

--- a/conda/build.sh
+++ b/conda/build.sh
@@ -1,5 +1,0 @@
-#!/bin/sh
-
-cp -r $RECIPE_DIR/../ .
-
-"$PYTHON" setup.py install --single-version-externally-managed --record=/tmp/record.txt

--- a/conda/meta.yaml
+++ b/conda/meta.yaml
@@ -2,6 +2,13 @@ package:
   name: menpo
   version: {{ environ['CONDACI_VERSION'] }}
 
+source:
+  path: ../
+
+build:
+  number: 0
+  script: python setup.py install --single-version-externally-managed --record=record.txt
+
 requirements:
   build:
     - python

--- a/setup.py
+++ b/setup.py
@@ -14,12 +14,14 @@ IS_WIN = 'windows' == SYS_PLATFORM
 
 
 # ---- C/C++ EXTENSIONS ---- #
-cython_modules = ['menpo/shape/mesh/normals.pyx',
-                  'menpo/transform/piecewiseaffine/fastpwa.pyx',
-                  'menpo/feature/windowiterator.pyx',
-                  'menpo/feature/gradient.pyx',
-                  'menpo/external/skimage/_warps_cy.pyx',
-                  'menpo/image/patches.pyx']
+cython_modules = [
+    'menpo/external/skimage/_warps_cy.pyx',
+    'menpo/transform/piecewiseaffine/fastpwa.pyx',
+    'menpo/feature/windowiterator.pyx',
+    'menpo/feature/gradient.pyx',
+    'menpo/image/patches.pyx',
+    'menpo/shape/mesh/normals.pyx'
+]
 
 cython_exts = cythonize(cython_modules, quiet=True)
 # Perform a small amount of gymnastics to improve the compilation output on
@@ -37,7 +39,7 @@ install_requires = ['numpy>=1.10,<2.0',
                     'scipy>=0.16,<1.0',
                     'matplotlib>=1.4,<2.0',
                     'pillow>=3.0,<4.0',
-                    'Cython>=0.23']
+                    'cython>=0.23']
 
 if sys.version_info.major == 2:
     install_requires.append('pathlib==1.0')
@@ -46,9 +48,8 @@ setup(name='menpo',
       version=versioneer.get_version(),
       cmdclass=versioneer.get_cmdclass(),
       description='A Python toolkit for handling annotated data',
-      author='James Booth',
-      author_email='james.booth08@imperial.ac.uk',
-      include_dirs=include_dirs,
+      author='The Menpo Team',
+      author_email='hello@menpo.org',
       ext_modules=cython_exts,
       packages=find_packages(),
       install_requires=install_requires,


### PR DESCRIPTION
Remove the copy and `build.sh`/`bld.bat` files in favour of the
`source: path` option and `build: script`. Hopefully this will also
fix the Jenkins issues with the copying of `.git` folders.