### PR TITLE
Docs fix: centred non-optional in PCAModel

### DIFF
--- a/menpo/model/pca.py
+++ b/menpo/model/pca.py
@@ -106,7 +106,7 @@ class PCAVectorModel(MeanLinearVectorModel):
             The mean vector.
         n_samples : `int`
             The number of samples used to generate the eigenvectors.
-        centred : `bool`, optional
+        centred : `bool`
             When ``True`` we assume that the data were centered before
             computing the eigenvectors.
         max_n_components : `int`, optional


### PR DESCRIPTION
I'm actually a little torn on this one. Current signature:
```py
    @classmethod
    def init_from_components(cls, components, eigenvalues, mean, n_samples,
                             centred, max_n_components=None):
```
but docs claim centred is optional.

Interestingly, centered is optional in other constructors for `PCAModel`/`PCAVectorModel` - maybe the right fix here is to move this to be a keyword argument? This would be a change of signature though...

- [ ] Apply decided fix to both `PCAModel` and `PCAVectorModel`