### PR TITLE
Pin setuptools to 23.x

### DIFF
--- a/conda/meta.yaml
+++ b/conda/meta.yaml
@@ -12,7 +12,7 @@ build:
 requirements:
   build:
     - python
-    - setuptools
+    - setuptools 23.*
     - numpy >=1.10,<2.0
     - cython >=0.23
 


### PR DESCRIPTION
This is needed to avoid bugs with setuptools 25.x:
https://github.com/pypa/setuptools/issues/728