### PR TITLE
Change LandmarkGroup dict to OrderedDict

### DIFF
--- a/menpo/landmark/base.py
+++ b/menpo/landmark/base.py
@@ -240,7 +240,7 @@ class LandmarkManager(MutableMapping, Transformable):
     @property
     def group_labels(self):
         """
-        All the labels for the landmark set.
+        All the labels for the landmark set sorted alphabetically.
 
         :type: `list` of `str`
         """

--- a/menpo/landmark/base.py
+++ b/menpo/landmark/base.py
@@ -221,7 +221,7 @@ class LandmarkManager(MutableMapping, Transformable):
 
     def __setstate__(self, state):
         # consistency with older versions imported.
-        if ~isinstance(state['_landmark_groups'], OrderedDict):
+        if not isinstance(state['_landmark_groups'], OrderedDict):
             state['_landmark_groups'] = OrderedDict(state['_landmark_groups'])
 
         self.__dict__ = state

--- a/menpo/landmark/base.py
+++ b/menpo/landmark/base.py
@@ -246,7 +246,7 @@ class LandmarkManager(MutableMapping, Transformable):
         """
         # Convert to list so that we can index immediately, as keys()
         # is a generator in Python 3
-        return list(self._landmark_groups.keys())
+        return sorted(list(self._landmark_groups.keys()))
 
     def keys_matching(self, glob_pattern):
         r"""

--- a/menpo/landmark/base.py
+++ b/menpo/landmark/base.py
@@ -219,6 +219,13 @@ class LandmarkManager(MutableMapping, Transformable):
     def __len__(self):
         return len(self._landmark_groups)
 
+    def __setstate__(self, state):
+        # consistency with older versions imported.
+        if ~isinstance(state['_landmark_groups'], OrderedDict):
+            state['_landmark_groups'] = OrderedDict(state['_landmark_groups'])
+
+        self.__dict__ = state
+
     @property
     def n_groups(self):
         """

--- a/menpo/landmark/base.py
+++ b/menpo/landmark/base.py
@@ -92,7 +92,6 @@ class LandmarkManager(MutableMapping, Transformable):
     :map:`LandmarkManager` - in this case ``None`` can be used as a key to
     access the sole group.
 
-
     Note that all landmarks stored on a :map:`Landmarkable` in it's attached
     :map:`LandmarkManager` are automatically transformed and copied with their
     parent object.
@@ -247,7 +246,7 @@ class LandmarkManager(MutableMapping, Transformable):
     @property
     def group_labels(self):
         """
-        All the labels for the landmark set sorted alphabetically.
+        All the labels for the landmark set sorted by insertion order.
 
         :type: `list` of `str`
         """

--- a/menpo/landmark/base.py
+++ b/menpo/landmark/base.py
@@ -80,7 +80,7 @@ class Landmarkable(Copyable):
 
 
 class LandmarkManager(MutableMapping, Transformable):
-    """Store for :map:`LandmarkGroup` instances associated with an object
+    """Store for :map:`LandmarkGroup` instances associated with an object.
 
     Every :map:`Landmarkable` instance has an instance of this class available
     at the ``.landmarks`` property.  It is through this class that all access
@@ -99,7 +99,7 @@ class LandmarkManager(MutableMapping, Transformable):
     """
     def __init__(self):
         super(LandmarkManager, self).__init__()
-        self._landmark_groups = {}
+        self._landmark_groups = OrderedDict()
 
     @property
     def n_dims(self):
@@ -133,7 +133,7 @@ class LandmarkManager(MutableMapping, Transformable):
 
     def __iter__(self):
         """
-        Iterate over the internal landmark group dictionary
+        Iterate over the internal landmark group dictionary.
         """
         return iter(self._landmark_groups)
 
@@ -246,7 +246,7 @@ class LandmarkManager(MutableMapping, Transformable):
         """
         # Convert to list so that we can index immediately, as keys()
         # is a generator in Python 3
-        return sorted(list(self._landmark_groups.keys()))
+        return list(self._landmark_groups.keys())
 
     def keys_matching(self, glob_pattern):
         r"""

--- a/menpo/landmark/test/landmark_test.py
+++ b/menpo/landmark/test/landmark_test.py
@@ -179,11 +179,11 @@ def test_LandmarkManager_group_order():
     man['test_set'] = pcloud.copy()
     man['abc'] = pcloud.copy()
     man['def'] = pcloud.copy()
-    assert_equal(man._landmark_groups.keys(), ['test_set', 'abc', 'def'])
+    assert_equal(list(man._landmark_groups.keys()), ['test_set', 'abc', 'def'])
     # check that after deleting and inserting the order will remain the same.
     del man['test_set']
     man['tt'] = pcloud.copy()
-    assert_equal(man._landmark_groups.keys(), ['abc', 'def', 'tt'])
+    assert_equal(list(man._landmark_groups.keys()), ['abc', 'def', 'tt'])
 
 
 def test_LandmarkManager_in():

--- a/menpo/landmark/test/landmark_test.py
+++ b/menpo/landmark/test/landmark_test.py
@@ -170,6 +170,22 @@ def test_LandmarkManager_del():
     assert_equal(man.n_groups, 0)
 
 
+def test_LandmarkManager_group_order():
+    points = np.ones((10, 3))
+    pcloud = PointCloud(points, copy=False)
+    target = PointCloud(points)
+
+    man = LandmarkManager()
+    man['test_set'] = pcloud.copy()
+    man['abc'] = pcloud.copy()
+    man['def'] = pcloud.copy()
+    assert_equal(man._landmark_groups.keys(), ['test_set', 'abc', 'def'])
+    # check that after deleting and inserting the order will remain the same.
+    del man['test_set']
+    man['tt'] = pcloud.copy()
+    assert_equal(man._landmark_groups.keys(), ['abc', 'def', 'tt'])
+
+
 def test_LandmarkManager_in():
     points = np.ones((10, 3))
     pcloud = PointCloud(points, copy=False)


### PR DESCRIPTION
This is a tiny practical change. 

It is particularly  valuable for detection/tracking when there are multiple bounding boxes/landmarks returned. Usually, those are sorted based on confidence, so it makes sense to have them sorted based on the detectors' confidence. 
For instance, calling  `im.landmarks.group_labels[0]` should return the most confident detection. 

While this can be done when calling it in the user code, I believe it is a sensible change in the group_labels. 