### PR TITLE
Automatically add channels axis at back for init_from_channels_at_back

### DIFF
--- a/menpo/image/base.py
+++ b/menpo/image/base.py
@@ -331,7 +331,17 @@ class Image(Vectorizable, Landmarkable, Viewable, LandmarkableViewable):
         image : :map:`Image`
             A new image from the given pixels, with the FIRST axis as the
             channels.
+
+        Raises
+        ------
+        ValueError
+            If image is not at least 2D, i.e. has at least 2 dimensions plus
+            the channels in the end.
         """
+        if pixels.ndim <= 2:
+            m = ('The image should have more than 2 dimensions plus one more '
+                 'for \nthe channels. Currently provided {} dimensions.')
+            raise ValueError(m.format(pixels.ndim))
         return cls(np.rollaxis(pixels, -1))
 
     @classmethod

--- a/menpo/image/base.py
+++ b/menpo/image/base.py
@@ -206,11 +206,8 @@ def channels_to_front(pixels):
     """
     if not isinstance(pixels, np.ndarray):
         pixels = np.array(pixels)
-    # Channels to axis 0
-    if pixels.ndim == 3:
-        pixels = np.require(np.rollaxis(pixels, -1), dtype=pixels.dtype,
-                            requirements=['C'])
-    return pixels
+    return np.require(np.rollaxis(pixels, -1), dtype=pixels.dtype,
+                      requirements=['C'])
 
 
 class Image(Vectorizable, Landmarkable, Viewable, LandmarkableViewable):
@@ -309,7 +306,7 @@ class Image(Vectorizable, Landmarkable, Viewable, LandmarkableViewable):
              'Use .init_from_channels_at_back instead.',
              MenpoDeprecationWarning)
 
-        return cls(np.rollaxis(pixels, -1))
+        return cls.init_from_channels_at_back(pixels)
 
     @classmethod
     def init_from_channels_at_back(cls, pixels):
@@ -338,11 +335,17 @@ class Image(Vectorizable, Landmarkable, Viewable, LandmarkableViewable):
             If image is not at least 2D, i.e. has at least 2 dimensions plus
             the channels in the end.
         """
-        if pixels.ndim <= 2:
-            m = ('The image should have more than 2 dimensions plus one more '
-                 'for \nthe channels. Currently provided {} dimensions.')
-            raise ValueError(m.format(pixels.ndim))
-        return cls(np.rollaxis(pixels, -1))
+        if pixels.ndim == 2:
+            pixels = pixels[..., None]
+
+        if pixels.ndim < 2:
+            raise ValueError(
+                "Pixel array has to be 2D "
+                "(2D shape, implicitly 1 channel) "
+                "or 3D+ (2D+ shape, n_channels) "
+                " - a {}D array "
+                "was provided".format(pixels.ndim))
+        return cls(channels_to_front(pixels))
 
     @classmethod
     def init_from_pointcloud(cls, pointcloud, group=None, boundary=0,

--- a/menpo/image/boolean.py
+++ b/menpo/image/boolean.py
@@ -143,6 +143,24 @@ class BooleanImage(Image):
         return cls(mask, copy=False)
 
     @classmethod
+    def init_from_channels_at_back(cls, pixels):
+        r"""
+        This method is not required for ``BooleanImage`` types as boolean images
+        do not expect a channel axis for construction.
+
+        Parameters
+        ----------
+        pixels : ``(M, N ..., Q)`` `ndarray`
+            Array representing the image pixels, with NO channel axis.
+
+        Returns
+        -------
+        image : :map:`BooleanImage`
+            A new image from the given boolean pixels.
+        """
+        return cls(pixels)
+
+    @classmethod
     def init_from_pointcloud(cls, pointcloud, group=None, boundary=0,
                              constrain=True, fill=True):
         r"""

--- a/menpo/image/masked.py
+++ b/menpo/image/masked.py
@@ -149,7 +149,10 @@ class MaskedImage(Image):
             A new image from the given pixels, with the FIRST axis as the
             channels.
         """
-        return cls(np.rollaxis(pixels, -1), mask=mask)
+        im = Image.init_from_channels_at_back(pixels)
+        if mask is not None:
+            mask = mask.copy()
+        return MaskedImage(im.pixels, mask=mask, copy=False)
 
     @classmethod
     def init_from_pointcloud(cls, pointcloud, group=None, boundary=0,

--- a/menpo/image/test/image_basics_test.py
+++ b/menpo/image/test/image_basics_test.py
@@ -90,10 +90,13 @@ def test_init_from_rolled_channels():
     assert im.height == 50
     assert im.width == 60
 
-@raises(ValueError)
+
 def test_init_from_channels_at_back_less_dimensions():
     p = np.empty([50, 60])
     im = Image.init_from_channels_at_back(p)
+    assert im.n_channels == 1
+    assert im.height == 50
+    assert im.width == 60
 
 
 def test_init_from_pointcloud():

--- a/menpo/image/test/image_basics_test.py
+++ b/menpo/image/test/image_basics_test.py
@@ -90,6 +90,11 @@ def test_init_from_rolled_channels():
     assert im.height == 50
     assert im.width == 60
 
+@raises(ValueError)
+def test_init_from_channels_at_back_less_dimensions():
+    p = np.empty([50, 60])
+    im = Image.init_from_channels_at_back(p)
+
 
 def test_init_from_pointcloud():
     pc = PointCloud.init_2d_grid((10, 10))

--- a/menpo/io/input/image.py
+++ b/menpo/io/input/image.py
@@ -10,7 +10,7 @@ from menpo.image.base import normalize_pixels_range, channels_to_front
 
 def _pil_to_numpy(pil_image, normalize, convert=None):
     p = pil_image.convert(convert) if convert else pil_image
-    p = channels_to_front(p)
+    p = np.asarray(p)
     if normalize:
         return normalize_pixels_range(p)
     else:
@@ -63,22 +63,28 @@ def pillow_importer(filepath, asset=None, normalize=True, **kwargs):
         if normalize:
             alpha = np.array(pil_image)[..., 3].astype(np.bool)
             image_pixels = _pil_to_numpy(pil_image, True, convert='RGB')
-            image = MaskedImage(image_pixels, mask=alpha, copy=False)
+            image = MaskedImage.init_from_channels_at_back(image_pixels,
+                                                           mask=alpha)
         else:
             # With no normalisation we just return the pixels
-            image = Image(_pil_to_numpy(pil_image, False), copy=False)
+            image = Image.init_from_channels_at_back(
+                _pil_to_numpy(pil_image, False))
     elif mode in ['L', 'I', 'RGB']:
         # Greyscale, Integer and RGB images
-        image = Image(_pil_to_numpy(pil_image, normalize), copy=False)
+        image = Image.init_from_channels_at_back(
+            _pil_to_numpy(pil_image, normalize))
     elif mode == '1':
         # Can't normalize a binary image
-        image = BooleanImage(_pil_to_numpy(pil_image, False), copy=False)
+        image = BooleanImage.init_from_channels_at_back(
+            _pil_to_numpy(pil_image, False))
     elif mode == 'P':
         # Convert pallete images to RGB
-        image = Image(_pil_to_numpy(pil_image, normalize, convert='RGB'))
+        image = Image.init_from_channels_at_back(
+            _pil_to_numpy(pil_image, normalize, convert='RGB'))
     elif mode == 'F':  # Floating point images
         # Don't normalize as we don't know the scale
-        image = Image(_pil_to_numpy(pil_image, False), copy=False)
+        image = Image.init_from_channels_at_back(
+            _pil_to_numpy(pil_image, False))
     else:
         raise ValueError('Unexpected mode for PIL: {}'.format(mode))
     return image

--- a/menpo/io/test/io_import_test.py
+++ b/menpo/io/test/io_import_test.py
@@ -172,11 +172,11 @@ def test_import_landmark_files_wrong_path_raises_value_error():
 @patch('PIL.Image.open')
 @patch('menpo.io.input.base.Path.is_file')
 def test_importing_PIL_no_normalize(is_file, mock_image):
-    mock_image.return_value = PILImage.new('RGBA', (10, 10))
+    mock_image.return_value = PILImage.new('RGBA', (10, 15))
     is_file.return_value = True
 
     im = mio.import_image('fake_image_being_mocked.png', normalize=False)
-    assert im.shape == (10, 10)
+    assert im.shape == (15, 10)
     assert im.n_channels == 4
     assert im.pixels.dtype == np.uint8
 
@@ -186,11 +186,11 @@ def test_importing_PIL_no_normalize(is_file, mock_image):
 def test_importing_pil_RGBA_normalize(is_file, mock_image):
     from menpo.image import MaskedImage
 
-    mock_image.return_value = PILImage.new('RGBA', (10, 10))
+    mock_image.return_value = PILImage.new('RGBA', (10, 15))
     is_file.return_value = True
 
     im = mio.import_image('fake_image_being_mocked.png', normalize=True)
-    assert im.shape == (10, 10)
+    assert im.shape == (15, 10)
     assert im.n_channels == 3
     assert im.pixels.dtype == np.float
     assert type(im) == MaskedImage
@@ -201,11 +201,11 @@ def test_importing_pil_RGBA_normalize(is_file, mock_image):
 def test_importing_PIL_RGBA_normalize(is_file, mock_image):
     from menpo.image import MaskedImage
 
-    mock_image.return_value = PILImage.new('RGBA', (10, 10))
+    mock_image.return_value = PILImage.new('RGBA', (10, 15))
     is_file.return_value = True
 
     im = mio.import_image('fake_image_being_mocked.ppm', normalize=True)
-    assert im.shape == (10, 10)
+    assert im.shape == (15, 10)
     assert im.n_channels == 3
     assert im.pixels.dtype == np.float
     assert type(im) == MaskedImage
@@ -215,11 +215,11 @@ def test_importing_PIL_RGBA_normalize(is_file, mock_image):
 @patch('menpo.io.input.base.Path.is_file')
 def test_importing_PIL_RGBA_no_normalize(is_file, mock_image):
 
-    mock_image.return_value = PILImage.new('RGBA', (10, 10))
+    mock_image.return_value = PILImage.new('RGBA', (10, 15))
     is_file.return_value = True
 
     im = mio.import_image('fake_image_being_mocked.ppm', normalize=False)
-    assert im.shape == (10, 10)
+    assert im.shape == (15, 10)
     assert im.n_channels == 4
     assert im.pixels.dtype == np.uint8
 
@@ -227,11 +227,11 @@ def test_importing_PIL_RGBA_no_normalize(is_file, mock_image):
 @patch('PIL.Image.open')
 @patch('menpo.io.input.base.Path.is_file')
 def test_importing_PIL_L_no_normalize(is_file, mock_image):
-    mock_image.return_value = PILImage.new('L', (10, 10))
+    mock_image.return_value = PILImage.new('L', (10, 15))
     is_file.return_value = True
 
     im = mio.import_image('fake_image_being_mocked.ppm', normalize=False)
-    assert im.shape == (10, 10)
+    assert im.shape == (15, 10)
     assert im.n_channels == 1
     assert im.pixels.dtype == np.uint8
 
@@ -239,11 +239,11 @@ def test_importing_PIL_L_no_normalize(is_file, mock_image):
 @patch('PIL.Image.open')
 @patch('menpo.io.input.base.Path.is_file')
 def test_importing_PIL_L_normalize(is_file, mock_image):
-    mock_image.return_value = PILImage.new('L', (10, 10))
+    mock_image.return_value = PILImage.new('L', (10, 15))
     is_file.return_value = True
 
     im = mio.import_image('fake_image_being_mocked.ppm', normalize=True)
-    assert im.shape == (10, 10)
+    assert im.shape == (15, 10)
     assert im.n_channels == 1
     assert im.pixels.dtype == np.float
 
@@ -252,20 +252,20 @@ def test_importing_PIL_L_normalize(is_file, mock_image):
 @patch('menpo.io.input.base.Path.is_file')
 @raises
 def test_importing_PIL_I_normalize(is_file, mock_image):
-    mock_image.return_value = PILImage.new('I', (10, 10))
+    mock_image.return_value = PILImage.new('I', (10, 15))
     is_file.return_value = True
 
-    im = mio.import_image('fake_image_being_mocked.ppm', normalize=True)
+    mio.import_image('fake_image_being_mocked.ppm', normalize=True)
 
 
 @patch('PIL.Image.open')
 @patch('menpo.io.input.base.Path.is_file')
 def test_importing_PIL_I_no_normalize(is_file, mock_image):
-    mock_image.return_value = PILImage.new('I', (10, 10))
+    mock_image.return_value = PILImage.new('I', (10, 15))
     is_file.return_value = True
 
     im = mio.import_image('fake_image_being_mocked.ppm', normalize=False)
-    assert im.shape == (10, 10)
+    assert im.shape == (15, 10)
     assert im.n_channels == 1
     assert im.pixels.dtype == np.int32
 
@@ -275,11 +275,11 @@ def test_importing_PIL_I_no_normalize(is_file, mock_image):
 def test_importing_PIL_1_normalize(is_file, mock_image):
     from menpo.image import BooleanImage
 
-    mock_image.return_value = PILImage.new('1', (10, 10))
+    mock_image.return_value = PILImage.new('1', (10, 15))
     is_file.return_value = True
 
     im = mio.import_image('fake_image_being_mocked.ppm', normalize=True)
-    assert im.shape == (10, 10)
+    assert im.shape == (15, 10)
     assert im.n_channels == 1
     assert im.pixels.dtype == np.bool
     assert type(im) == BooleanImage
@@ -290,11 +290,11 @@ def test_importing_PIL_1_normalize(is_file, mock_image):
 def test_importing_PIL_1_no_normalize(is_file, mock_image):
     from menpo.image import BooleanImage
 
-    mock_image.return_value = PILImage.new('1', (10, 10))
+    mock_image.return_value = PILImage.new('1', (10, 15))
     is_file.return_value = True
 
     im = mio.import_image('fake_image_being_mocked.ppm', normalize=False)
-    assert im.shape == (10, 10)
+    assert im.shape == (15, 10)
     assert im.n_channels == 1
     assert im.pixels.dtype == np.bool
     assert type(im) == BooleanImage
@@ -315,11 +315,11 @@ def test_importing_PIL_P_normalize(is_file, mock_image):
 @patch('PIL.Image.open')
 @patch('menpo.io.input.base.Path.is_file')
 def test_importing_PIL_P_no_normalize(is_file, mock_image):
-    mock_image.return_value = PILImage.new('P', (10, 10))
+    mock_image.return_value = PILImage.new('P', (10, 15))
     is_file.return_value = True
 
     im = mio.import_image('fake_image_being_mocked.ppm', normalize=False)
-    assert im.shape == (10, 10)
+    assert im.shape == (15, 10)
     assert im.n_channels == 3
     assert im.pixels.dtype == np.uint8
 


### PR DESCRIPTION
Small change in init_from_channels_at_back() in Image class. 

Currently if less dimensions are provided it does not raise any error or warning, e.g. :

Image.init_from_channels_at_back(np.random.rand(20, 40)).shape
