### PR TITLE
Fix bug in Boolean Image import_image.

### DIFF
--- a/menpo/io/input/image.py
+++ b/menpo/io/input/image.py
@@ -71,6 +71,9 @@ def pillow_importer(filepath, asset=None, normalize=True, **kwargs):
         # Greyscale, Integer and RGB images
         image = Image(_pil_to_numpy(pil_image, normalize), copy=False)
     elif mode == '1':
+        # convert first to 'L' type, see here:
+        # http://stackoverflow.com/a/4114122/1716869
+        pil_image = pil_image.convert('L')
         # Can't normalize a binary image
         image = BooleanImage(_pil_to_numpy(pil_image, False), copy=False)
     elif mode == 'P':

--- a/menpo/io/input/image.py
+++ b/menpo/io/input/image.py
@@ -71,11 +71,10 @@ def pillow_importer(filepath, asset=None, normalize=True, **kwargs):
         # Greyscale, Integer and RGB images
         image = Image(_pil_to_numpy(pil_image, normalize), copy=False)
     elif mode == '1':
-        # convert first to 'L' type, see here:
-        # http://stackoverflow.com/a/4114122/1716869
-        pil_image = pil_image.convert('L')
+        # Convert to 'L' type (http://stackoverflow.com/a/4114122/1716869).
         # Can't normalize a binary image
-        image = BooleanImage(_pil_to_numpy(pil_image, False), copy=False)
+        image = BooleanImage(_pil_to_numpy(pil_image, False, convert='L'),
+                             copy=True)
     elif mode == 'P':
         # Convert pallete images to RGB
         image = Image(_pil_to_numpy(pil_image, normalize, convert='RGB'))

--- a/menpo/io/test/io_import_test.py
+++ b/menpo/io/test/io_import_test.py
@@ -302,6 +302,24 @@ def test_importing_PIL_1_no_normalize(is_file, mock_image):
 
 @patch('PIL.Image.open')
 @patch('menpo.io.input.base.Path.is_file')
+def test_importing_PIL_1_proper_conversion(is_file, mock_image):
+    from menpo.image import BooleanImage
+ 
+    arr = np.zeros((10, 10), dtype=np.uint8)
+    arr[4, 4] = 255
+    mock_image.return_value = PILImage.fromarray(arr).convert('1')
+    is_file.return_value = True
+
+    im = mio.import_image('fake_image_being_mocked.ppm', normalize=False)
+    assert im.shape == (10, 10)
+    assert im.n_channels == 1
+    assert im.pixels.dtype == np.bool
+    assert type(im) == BooleanImage
+    assert np.all(im.pixels == arr.astype(np.bool))
+
+
+@patch('PIL.Image.open')
+@patch('menpo.io.input.base.Path.is_file')
 def test_importing_PIL_P_normalize(is_file, mock_image):
     mock_image.return_value = PILImage.new('P', (10, 10))
     is_file.return_value = True


### PR DESCRIPTION
There is a bug in converting PIL image of mode '1' to numpy arrays. 

E.g. sample code: 
```
im = mio.import_image('path_sample_below.png')
im.view()
```

Actual image:
![actual_image](https://cloud.githubusercontent.com/assets/2621492/18129508/532c48fa-6f8b-11e6-8856-52b97a85aa81.png)

However the one from the code above as parsed with menpo:
![view_current_menpo](https://cloud.githubusercontent.com/assets/2621492/18129523/63f0ccf6-6f8b-11e6-8073-dcab89a1592d.png)

