### PR TITLE
Documentation change in image gradient for int pixels dtype.

### DIFF
--- a/menpo/feature/features.py
+++ b/menpo/feature/features.py
@@ -55,6 +55,8 @@ def gradient(pixels):
         Either the image object itself or an array where the first dimension
         is interpreted as channels. This means an N-dimensional image is
         represented by an N+1 dimensional array.
+        If the image is 2-dimensional the pixels should be of type
+        float/double (int is not supported).
 
     Returns
     -------

--- a/menpo/image/base.py
+++ b/menpo/image/base.py
@@ -2162,7 +2162,7 @@ class Image(Vectorizable, Landmarkable, Viewable, LandmarkableViewable):
             ``scale < 1.0`` denotes zooming out. The image will be padded
             by the value of ``cval``.
         cval : ``float``, optional
-            The value to be set outside the rotated image boundaries.
+            The value to be set outside the zoomed image boundaries.
         return_transform : `bool`, optional
             If ``True``, then the :map:`Transform` object that was used to
             perform the zooming is also returned.


### PR DESCRIPTION
Small clarification, because the gradient crashes if dtype is int/uint in the cython file.