### PR TITLE
Copy landmarks and path

### DIFF
--- a/menpo/base.py
+++ b/menpo/base.py
@@ -680,3 +680,11 @@ def partial_doc(func, *args, **kwargs):
     p = partial(func, *args, **kwargs)
     p.__doc__ = func.__doc__
     return p
+
+
+def copy_landmarks_and_path(orig, new):
+    if orig.has_landmarks:
+        new.landmarks = orig.landmarks
+    if hasattr(orig, 'path'):
+        new.path = orig.path
+    return new

--- a/menpo/base.py
+++ b/menpo/base.py
@@ -682,9 +682,25 @@ def partial_doc(func, *args, **kwargs):
     return p
 
 
-def copy_landmarks_and_path(orig, new):
-    if orig.has_landmarks:
-        new.landmarks = orig.landmarks
-    if hasattr(orig, 'path'):
-        new.path = orig.path
-    return new
+def copy_landmarks_and_path(source, target):
+    r"""
+    Transfers over the landmarks and path, if any, from one object to another.
+    This should be called in conversion and copy functions.
+
+    Parameters
+    ----------
+    source : :map:`Landmarkable`
+        The object who's landmarks and path, if any, will be copied
+    target : :map:`Landmarkable`
+        The object who will have landmarks and path set on
+
+    Returns
+    -------
+    target : :map:`Landmarkable`
+        The updated target.
+    """
+    if source.has_landmarks:
+        target.landmarks = source.landmarks
+    if hasattr(source, 'path'):
+        target.path = source.path
+    return target

--- a/menpo/base.py
+++ b/menpo/base.py
@@ -687,6 +687,8 @@ def copy_landmarks_and_path(source, target):
     Transfers over the landmarks and path, if any, from one object to another.
     This should be called in conversion and copy functions.
 
+    See `.as_masked()` on :map:`Image` as an example of usage.
+
     Parameters
     ----------
     source : :map:`Landmarkable`

--- a/menpo/image/base.py
+++ b/menpo/image/base.py
@@ -6,7 +6,8 @@ import numpy as np
 import PIL.Image as PILImage
 
 from menpo.compatibility import basestring
-from menpo.base import Vectorizable, MenpoDeprecationWarning
+from menpo.base import (Vectorizable, MenpoDeprecationWarning,
+                        copy_landmarks_and_path)
 from menpo.shape import PointCloud, bounding_box
 from menpo.landmark import Landmarkable
 from menpo.transform import (Translation, NonUniformScale, Rotation,
@@ -428,11 +429,9 @@ class Image(Vectorizable, Landmarkable, Viewable, LandmarkableViewable):
             a mask.
         """
         from menpo.image import MaskedImage
-        img = MaskedImage(self.pixels, mask=mask, copy=copy)
-        img.landmarks = self.landmarks
-        if hasattr(self, 'path'):
-            img.path = self.path
-        return img
+        return copy_landmarks_and_path(self,
+                                       MaskedImage(self.pixels,
+                                                   mask=mask, copy=copy))
 
     @property
     def n_dims(self):

--- a/menpo/image/masked.py
+++ b/menpo/image/masked.py
@@ -5,7 +5,7 @@ import numpy as np
 binary_erosion = None  # expensive, from scipy.ndimage
 binary_dilation = None  # expensive, from scipy.ndimage
 
-from menpo.base import MenpoDeprecationWarning
+from menpo.base import MenpoDeprecationWarning, copy_landmarks_and_path
 from menpo.transform import Translation
 from menpo.visualize.base import ImageViewer
 
@@ -245,12 +245,7 @@ class MaskedImage(Image):
             if not np.isscalar(fill):
                 fill = np.array(fill).reshape(self.n_channels, -1)
             img.pixels[..., ~self.mask.mask] = fill
-
-        if self.has_landmarks:
-            img.landmarks = self.landmarks
-        if hasattr(self, 'path'):
-            img.path = self.path
-        return img
+        return copy_landmarks_and_path(self, img)
 
     def n_true_pixels(self):
         r"""

--- a/menpo/test/copy_landmarks_and_path_test.py
+++ b/menpo/test/copy_landmarks_and_path_test.py
@@ -1,0 +1,30 @@
+import menpo.io as mio
+from menpo.base import copy_landmarks_and_path
+from menpo.image import Image
+
+
+def test_copy_landmarks_and_path():
+    img = mio.import_builtin_asset.lenna_png()
+    new_img = Image.init_blank(img.shape)
+    copy_landmarks_and_path(img, new_img)
+
+    assert new_img.path == img.path
+    assert new_img.landmarks.keys() == img.landmarks.keys()
+    assert new_img.landmarks is not img.landmarks
+
+
+def test_copy_landmarks_and_path_returns_target():
+    img = mio.import_builtin_asset.lenna_png()
+    new_img = Image.init_blank(img.shape)
+    new_img_ret = copy_landmarks_and_path(img, new_img)
+    assert new_img_ret is new_img
+
+
+def test_copy_landmarks_and_path_with_no_lms_path():
+    img = Image.init_blank((5, 5))
+    new_img = Image.init_blank((5, 5))
+    copy_landmarks_and_path(img, new_img)
+    assert not hasattr(img, 'path')
+    assert not hasattr(new_img, 'path')
+    assert not img.has_landmarks
+    assert not new_img.has_landmarks


### PR DESCRIPTION
Provides a single function that copies over landmarks and a path if any from a source to a target.

Useful in conversion methods - this PR includes changing the conversion methods on image to use it. 