### PR TITLE
Restrict the video channels in exports

### DIFF
--- a/menpo/io/output/video.py
+++ b/menpo/io/output/video.py
@@ -61,9 +61,14 @@ def ffmpeg_video_exporter(images, out_path, fps=30, codec='libx264',
     #   https://github.com/Zulko/moviepy/blob/master/LICENCE.txt
     first_image = images[0]
     frame_shape = first_image.shape
+    im = images[0]
+    if im.n_channels != 3 and im.n_channels != 1:
+        m = ('Currently only images of 1 or 3 channels are expected, '
+             'while {} channels were found in the first frame.')
+        raise ValueError(m.format(im.n_channels))
     # If the first image is gray then all the images will be assumed to be
     # gray
-    colour = 'rgb24' if images[0].n_channels == 3 else 'gray8'
+    colour = 'rgb24' if im.n_channels == 3 else 'gray8'
     cmd = [_FFMPEG_CMD(), '-y',
            '-s', '{}x{}'.format(frame_shape[1], frame_shape[0]),
            '-r', str(fps),

--- a/menpo/io/output/video.py
+++ b/menpo/io/output/video.py
@@ -59,9 +59,8 @@ def ffmpeg_video_exporter(images, out_path, fps=30, codec='libx264',
     #   https://github.com/Zulko/moviepy/blob/master/moviepy/video/io/ffmpeg_writer.py
     # and is used under the terms of the MIT license which can be found at
     #   https://github.com/Zulko/moviepy/blob/master/LICENCE.txt
-    first_image = images[0]
-    frame_shape = first_image.shape
     im = images[0]
+    frame_shape = im.shape
     if im.n_channels != 3 and im.n_channels != 1:
         m = ('Currently only images of 1 or 3 channels are expected, '
              'while {} channels were found in the first frame.')


### PR DESCRIPTION
The existing system works fine for 1 or 3 channels lists of images, however it outputs noise when provided with a different setting, e.g. 4 channel images. 
For instance, if matplotlib is used, then the images exported have alpha channel as well, resulting in a video with non-sense content. 

Code snippet to reproduce an instance: 

```
import menpo.io as mio
import matplotlib.pyplot as plt

im = mio.import_builtin_asset.lenna_png()

plt.figure()
plt.subplot(131)
renderer = im.view()

plt.subplot(132)
renderer = im.view(new_figure=False)
plt.subplot(133)
renderer = im.view(new_figure=False)
renderer.save_figure('/tmp/lenna.png', overwrite=True)
im = mio.import_image('/tmp/lenna.png', normalize=False)
print(im.n_channels)
mio.export_video([im, im, im, im, im], '/tmp/lenna.mp4', overwrite=True, fps=2)
```

Alternative solutions could be provided, e.g. if we export the 3 first channels it should work, but this is the explicit solution, so that the user has the choice.