### PR TITLE
fix ndarray slicing of lazylist, cleaner __add__ implementation

### DIFF
--- a/menpo/base.py
+++ b/menpo/base.py
@@ -472,12 +472,14 @@ class LazyList(collections.Sequence, Copyable):
         self._callables = callables
 
     def __getitem__(self, slice_):
-        if isinstance(slice_, int) or hasattr(slice_, '__index__'):
-            # PEP 357 and single integer index access - returns element
-            return self._callables[slice_]()
-        elif isinstance(slice_, collections.Iterable):
+        # note that we have to check for iterable *before* __index__ as ndarray
+        # has both (but we expect the iteration behavior when slicing)
+        if isinstance(slice_, collections.Iterable):
             # An iterable object is passed - return a new LazyList
             return LazyList([self._callables[s] for s in slice_])
+        elif isinstance(slice_, int) or hasattr(slice_, '__index__'):
+            # PEP 357 and single integer index access - returns element
+            return self._callables[slice_]()
         else:
             # A slice or unknown type is passed - let List handle it
             return LazyList(self._callables[slice_])

--- a/menpo/base.py
+++ b/menpo/base.py
@@ -647,16 +647,20 @@ class LazyList(collections.Sequence, Copyable):
         lazy : `LazyList`
             A new LazyList formed of the concatenation of this list and
             the ``other`` list.
+
+        Raises
+        ------
+        ValueError
+            If other is not a LazyList or an Iterable
         """
-        new = self.copy()
-        # If the passed Sequence was not lazy then fake it being lazy by
-        # wrapping it in a function that just returns the value.
-        if not isinstance(other, LazyList):
-            new_callables = LazyList.init_from_iterable(other)._callables
+        if isinstance(other, LazyList):
+            return LazyList(self._callables + other._callables)
+        elif isinstance(other, collections.Iterable):
+            return self + LazyList.init_from_iterable(other)
         else:
-            new_callables = other._callables
-        new._callables = new._callables + new_callables
-        return new
+            raise ValueError(
+                'Can only add another LazyList or an Iterable to a LazyList '
+                '- {} is neither'.format(type(other)))
 
 
 def partial_doc(func, *args, **kwargs):

--- a/menpo/test/lazylist_test.py
+++ b/menpo/test/lazylist_test.py
@@ -1,5 +1,5 @@
 import collections
-
+import numpy as np
 from mock import Mock
 from nose.tools import raises
 
@@ -161,3 +161,10 @@ def test_lazylist_add_list():
     assert new_ll._callables[0] is a
     assert new_ll._callables[1] is not b
     assert new_ll[1] is b
+
+
+def test_lazylist_slice_with_ndarray():
+    index = np.array([1, 0, 3], dtype=np.int)
+    l = LazyList.init_from_iterable(['a', 'b', 'c', 'd', 'e'])
+    l_indexed = l[index]
+    assert list(l_indexed) == ['b', 'a', 'd']

--- a/menpo/test/lazylist_test.py
+++ b/menpo/test/lazylist_test.py
@@ -163,6 +163,11 @@ def test_lazylist_add_list():
     assert new_ll[1] is b
 
 
+@raises(ValueError)
+def test_lazylist_add_non_iterable_non_lazy_list_rases_value_error():
+    LazyList([1]) + None
+
+
 def test_lazylist_slice_with_ndarray():
     index = np.array([1, 0, 3], dtype=np.int)
     l = LazyList.init_from_iterable(['a', 'b', 'c', 'd', 'e'])


### PR DESCRIPTION
Trying to slice a LazyList with an ndarrray raised the following:
```py
  File "/Users/jab08/pythondev/menpo/menpo/base.py", line 477, in __getitem__
    return self._callables[slice_]()
TypeError: only integer arrays with one element can be converted to an index
```
This was because ndarray has both `__index__` and is Iterable, but our test was for `__index__` first. This PR flips the check and adds a test for ndarray slicing.

It also gives a cleaner `__add__` implementation that properly raises a `ValueError` when trying to add an illegal type to the end of the list.