### PR TITLE
don't print_dynamic size report in as_matrix

### DIFF
--- a/menpo/math/linalg.py
+++ b/menpo/math/linalg.py
@@ -132,8 +132,8 @@ def as_matrix(vectorizables, length=None, return_template=False, verbose=False):
 
     data = np.zeros((length, n_features), dtype=template_vector.dtype)
     if verbose:
-        print_dynamic('Allocated data matrix of size {} '
-                      '({} samples)'.format(bytes_str(data.nbytes), length))
+        print('Allocated data matrix of size {} '
+              '({} samples)'.format(bytes_str(data.nbytes), length))
 
     # now we can fill in the first element from the template
     data[0] = template_vector


### PR DESCRIPTION
Currently this is a `print_dynamic` which is immediately overridden by the progress bar as the `as_matrix` is constructed.