### PR TITLE
Bounding cuboid

### DIFF
--- a/docs/source/api/shape/bounding_cuboid.rst
+++ b/docs/source/api/shape/bounding_cuboid.rst
@@ -1,0 +1,7 @@
+.. _menpo-shape-bounding_cuboid:
+
+.. currentmodule:: menpo.shape
+
+bounding_cuboid
+===============
+.. autofunction:: bounding_cuboid

--- a/docs/source/api/shape/index.rst
+++ b/docs/source/api/shape/index.rst
@@ -87,3 +87,4 @@ Shape Building
   :maxdepth: 2
 
   bounding_box
+  bounding_cuboid

--- a/menpo/shape/__init__.py
+++ b/menpo/shape/__init__.py
@@ -1,4 +1,4 @@
-from .pointcloud import PointCloud, bounding_box
+from .pointcloud import PointCloud, bounding_box, bounding_cuboid
 from .mesh import TriMesh, ColouredTriMesh, TexturedTriMesh
 from .groupops import mean_pointcloud
 from .graph import (UndirectedGraph, DirectedGraph, Tree, PointUndirectedGraph,

--- a/menpo/shape/pointcloud.py
+++ b/menpo/shape/pointcloud.py
@@ -64,6 +64,54 @@ def bounding_box(closest_to_origin, opposite_corner):
     return PointDirectedGraph(box, adjacency_matrix, copy=False)
 
 
+def bounding_cuboid(near_closest_to_origin, far_opposite_corner):
+    r"""
+    Return a bounding cuboid from the near closest and far opposite
+    corners as a directed graph.
+
+    Parameters
+    ----------
+    near_closest_to_origin : (`float`, `float`, `float`)
+        Three floats representing the coordinates of the near corner closest to
+        the origin.
+    far_opposite_corner  : (`float`, `float`, `float`)
+        Three floats representing the coordinates of the far opposite corner
+        compared to near_closest_to_origin.
+
+    Returns
+    -------
+    bounding_box : :map:`PointDirectedGraph`
+        The axis aligned bounding cuboid from the two given corners.
+    """
+    from .graph import PointDirectedGraph
+
+    if len(near_closest_to_origin) != 3 or len(far_opposite_corner) != 3:
+        raise ValueError('Only 3D bounding cuboids can be created.')
+
+    adjacency_matrix = csr_matrix(
+        ([1] * 12,
+         ([0, 1, 2, 3, 0, 1, 2, 3, 4, 5, 6, 7],
+          [1, 2, 3, 0, 4, 5, 6, 7, 5, 6, 7, 4])), shape=(8, 8))
+    cuboid = np.array(
+        [near_closest_to_origin, [far_opposite_corner[0],
+                                  near_closest_to_origin[1],
+                                  near_closest_to_origin[2]],
+         [far_opposite_corner[0],
+          far_opposite_corner[1],
+          near_closest_to_origin[2]], [near_closest_to_origin[0],
+                                       far_opposite_corner[1],
+                                       near_closest_to_origin[2]],
+         [near_closest_to_origin[0],
+          near_closest_to_origin[1],
+          far_opposite_corner[2]], [far_opposite_corner[0],
+                                    near_closest_to_origin[1],
+                                    far_opposite_corner[2]],
+         far_opposite_corner, [near_closest_to_origin[0],
+                               far_opposite_corner[1],
+                               far_opposite_corner[2]]], dtype=np.float)
+    return PointDirectedGraph(cuboid, adjacency_matrix, copy=False)
+
+
 class PointCloud(Shape):
     r"""
     An N-dimensional point cloud. This is internally represented as an `ndarray`
@@ -315,8 +363,8 @@ class PointCloud(Shape):
     def bounding_box(self):
         r"""
         Return a bounding box from two corner points as a directed graph.
-        The the first point (0) should be nearest the origin.
-        In the case of an image, this ordering would appear as:
+        In the case of a 2D pointcloud, first point (0) should be nearest the
+        origin. In the case of an image, this ordering would appear as:
 
         ::
 
@@ -336,16 +384,23 @@ class PointCloud(Shape):
             v   |
             0-->1
 
+        In the case of a 3D pointcloud, the first point (0) should be the
+        near closest to the origin and the second point is the far opposite
+        corner.
+
         Returns
         -------
         bounding_box : :map:`PointDirectedGraph`
             The axis aligned bounding box of the PointCloud.
         """
-        if self.n_dims != 2:
-            raise ValueError('Bounding boxes are only supported for 2D '
+        if self.n_dims != 2 and self.n_dims != 3:
+            raise ValueError('Bounding boxes are only supported for 2D or 3D '
                              'pointclouds.')
         min_p, max_p = self.bounds()
-        return bounding_box(min_p, max_p)
+        if self.n_dims == 2:
+            return bounding_box(min_p, max_p)
+        elif self.n_dims == 3:
+            return bounding_cuboid(min_p, max_p)
 
     def _view_2d(self, figure_id=None, new_figure=False, image_view=True,
                  render_markers=True, marker_style='o', marker_size=5,

--- a/menpo/shape/test/pointcloud_test.py
+++ b/menpo/shape/test/pointcloud_test.py
@@ -185,12 +185,14 @@ def test_pointcloud_bounding_box():
     assert_allclose(bb_bounds[1], [1., 2.])
 
 
-@raises(ValueError)
-def test_pointcloud_bounding_box_3d_fail():
-    points = np.array([[0, 0, 0],
-                       [1, 1, 1]])
+def test_pointcloud_bounding_box_3d():
+    points = np.array([[1., 2., 3.],
+                       [3., 2., 1.]])
     pc = PointCloud(points)
-    pc.bounding_box()
+    bb = pc.bounding_box()
+    bb_bounds = bb.bounds()
+    assert_allclose(bb_bounds[0], [1., 2., 1.])
+    assert_allclose(bb_bounds[1], [3., 2., 3.])
 
 
 def test_bounding_box_creation():


### PR DESCRIPTION
This PR adds a `bounding_cuboid()` method similar to the `bounding_box()` one, which returns the bounding cuboid of a 3D `PointCloud`. 

It also updates the `.bounding_box()` method of a `PointCloud` (and its subclasses `TriMesh` etc.) in order to call `menpo.shape.pointcloud.bounding_cuboid()` or `menpo.shape.pointcloud.bounding_bbox()` based on the `n_dims` of the object.

### Example
```
%matplotlib qt
import menpo3d.io as mio

mesh = mio.import_builtin_asset.james_obj()

mesh.view()
mesh.bounding_box().view(new_figure=False, line_colour=(0, 0, 1), render_markers=False)
```


![screenshot from 2016-11-23 16-39-02](https://cloud.githubusercontent.com/assets/4224739/20570440/8358a6ca-b19b-11e6-8bc9-ba5eefaf9ce0.png)
