### PR TITLE
Add clip_pixels to Image and automatically clip RGB visualisations

### DIFF
--- a/menpo/image/base.py
+++ b/menpo/image/base.py
@@ -2808,7 +2808,7 @@ class Image(Vectorizable, Landmarkable, Viewable, LandmarkableViewable):
     def rescale_pixels(self, minimum, maximum, per_channel=True):
         r"""A copy of this image with pixels linearly rescaled to fit a range.
 
-        Note that the only pixels that will considered and rescaled are those
+        Note that the only pixels that will be considered and rescaled are those
         that feature in the vectorized form of this image. If you want to use
         this routine on all the pixels in a :map:`MaskedImage`, consider
         using `as_unmasked()` prior to this call.
@@ -2837,6 +2837,42 @@ class Image(Vectorizable, Landmarkable, Viewable, LandmarkableViewable):
         sf = ((maximum - minimum) * 1.0) / (max_ - min_)
         v_new = ((v - min_) * sf) + minimum
         return self.from_vector(v_new.T.ravel())
+
+    def clip_pixels(self, minimum=None, maximum=None):
+        r"""A copy of this image with pixels linearly clipped to fit a range.
+
+        Parameters
+        ----------
+        minimum: `float`, optional
+            The minimal value of the clipped pixels. If None is provided, the
+            default value will be 0.
+        maximum: `float`, optional
+            The maximal value of the clipped pixels. If None is provided, the
+            default value will depend on the dtype.
+
+        Returns
+        -------
+        rescaled_image: ``type(self)``
+            A copy of this image with pixels linearly rescaled to fit in the
+            range provided.
+        """
+        if minimum is None:
+            minimum = 0
+        if maximum is None:
+            dtype = self.pixels.dtype
+            if dtype == np.uint8:
+                maximum = 255
+            elif dtype == np.uint16:
+                maximum = 65535
+            elif dtype in [np.float32, np.float64]:
+                maximum = 1.0
+            else:
+                m1 = 'Could not recognise the dtype ({}) to set the maximum.'
+                raise ValueError(m1.format(dtype))
+
+        copy = self.copy()
+        copy.pixels = copy.pixels.clip(min=minimum, max=maximum)
+        return copy
 
     def rasterize_landmarks(self, group=None, render_lines=True, line_style='-',
                             line_colour='b', line_width=1, render_markers=True,

--- a/menpo/image/test/image_test.py
+++ b/menpo/image/test/image_test.py
@@ -146,6 +146,40 @@ def test_image_from_vector_custom_channels_no_copy():
     assert(is_same_array(image2.pixels, pixels2))
 
 
+def test_image_clip_pixels_no_args():
+    pixels = np.random.rand(3, 10, 20)
+    # add the noise of increased values
+    pixels *= 2.0
+    pixels[0, 0, 0] = 3.0
+    pixels[0, 0, 1] = - 0.1
+    image = Image(pixels, copy=False)
+    assert(image.pixels.max() > 1.0)
+    image2 = image.clip_pixels()
+    assert(image2.pixels.max() <= 1.0)
+    assert(image2.pixels.min() >= 0.0)
+
+
+def test_image_clip_pixels_cutom_max():
+    pixels = np.random.rand(3, 10, 20)
+    # add the noise of increased values
+    pixels *= 2.0
+    pixels[0, 0, 0] = 3.0
+    pixels[0, 0, 1] = - 0.1
+    image = Image(pixels, copy=False)
+    assert(image.pixels.max() > 1.0)
+    image2 = image.clip_pixels(maximum=0.9)
+    assert(image2.pixels.max() <= 0.9)
+    assert(image2.pixels.min() >= 0.0)
+
+
+def test_image_clip_pixels_cutom_max_uint():
+    pixels = (np.random.rand(3, 10, 20) * 255).astype(np.uint8)
+    # add the noise of increased values
+    pixels[0, 0, 0] = 255
+    image = Image(pixels, copy=False)
+    image2 = image.clip_pixels(maximum=200)
+    assert(image2.pixels.max() <= 200)
+
 @raises(ValueError)
 def test_boolean_image_wrong_round():
     BooleanImage.init_blank((12, 12), round='ads')

--- a/menpo/visualize/base.py
+++ b/menpo/visualize/base.py
@@ -228,7 +228,14 @@ class ImageViewer(object):
 
     def __init__(self, figure_id, new_figure, dimensions, pixels,
                  channels=None, mask=None):
-        pixels = pixels.copy()
+        if len(pixels.shape) == 3 and pixels.shape[0] == 3:
+            # then probably an RGB image, so ensure the clipped pixels.
+            from menpo.image import Image
+            image = Image(pixels, copy=False)
+            image_clipped = image.clip_pixels()
+            pixels = image_clipped.pixels
+        else:
+            pixels = pixels.copy()
         self.figure_id = figure_id
         self.new_figure = new_figure
         self.dimensions = dimensions


### PR DESCRIPTION
Till now if the image is out of range, then the visualisation is weird. Such a case might appear in filtering or even with value scaling, e.g. 

```
import menpo.io as mio
im = mio.import_builtin_asset.lenna_png()
im.pixels *= 1.2
im.view()
```

This proposes one optional variable in the .view() methods to allow the clipping inside the image viewer (the original values are untouched).