### PR TITLE
3D Visualization Upgrade

### DIFF
--- a/menpo/landmark/base.py
+++ b/menpo/landmark/base.py
@@ -939,7 +939,7 @@ class LandmarkGroup(MutableMapping, Copyable, Viewable):
             axes_y_limits=axes_y_limits, axes_x_ticks=axes_x_ticks,
             axes_y_ticks=axes_y_ticks, figure_size=figure_size)
 
-    def _view_3d(self, figure_id=None, new_figure=False, **kwargs):
+    def _view_3d(self, figure_id=None, new_figure=True, **kwargs):
         try:
             from menpo3d.visualize import LandmarkViewer3d
             return LandmarkViewer3d(figure_id, new_figure,

--- a/menpo/landmark/base.py
+++ b/menpo/landmark/base.py
@@ -944,6 +944,84 @@ class LandmarkGroup(MutableMapping, Copyable, Viewable):
                  line_colour=None, line_width=4, render_markers=True,
                  marker_style='sphere', marker_size=None, marker_colour=None,
                  marker_resolution=8, step=None, alpha=1.0):
+        """
+        Visualize the landmark group in 3D.
+
+        Parameters
+        ----------
+        with_labels : ``None`` or `str` or `list` of `str`, optional
+            If not ``None``, only show the given label(s). Should **not** be
+            used with the ``without_labels`` kwarg.
+        without_labels : ``None`` or `str` or `list` of `str`, optional
+            If not ``None``, show all except the given label(s). Should **not**
+            be used with the ``with_labels`` kwarg.
+        group : `str` or `None`, optional
+            The landmark group to be visualized. If ``None`` and there are more
+            than one landmark groups, an error is raised.
+        figure_id : `object`, optional
+            The id of the figure to be used.
+        new_figure : `bool`, optional
+            If ``True``, a new figure is created.
+        render_lines : `bool`, optional
+            If ``True``, then the lines will be rendered.
+        line_colour : See Below, optional
+            The colour of the lines. If ``None``, a different colour will be
+            automatically selected for each label.
+            Example options ::
+
+                {r, g, b, c, m, k, w}
+                or
+                (3, ) ndarray
+                or
+                None
+
+        line_width : `float`, optional
+            The width of the lines.
+        render_markers : `bool`, optional
+            If ``True``, then the markers will be rendered.
+        marker_style : `str`, optional
+            The style of the markers.
+            Example options ::
+
+                {2darrow, 2dcircle, 2dcross, 2ddash, 2ddiamond, 2dhooked_arrow,
+                 2dsquare, 2dthick_arrow, 2dthick_cross, 2dtriangle, 2dvertex,
+                 arrow, axes, cone, cube, cylinder, point, sphere}
+
+        marker_size : `float` or ``None``, optional
+            The size of the markers. This size can be seen as a scale factor
+            applied to the size markers, which is by default calculated from
+            the inter-marker spacing. If ``None``, then an optimal marker size
+            value will be set automatically.
+        marker_colour : See Below, optional
+            The colour of the markers. If ``None``, a different colour will be
+            automatically selected for each label.
+            Example options ::
+
+                {r, g, b, c, m, k, w}
+                or
+                (3, ) ndarray
+                or
+                None
+
+        marker_resolution : `int`, optional
+            The resolution of the markers. For spheres, for instance, this is
+            the number of divisions along theta and phi.
+        step : `int` or ``None``, optional
+            If `int`, then one every `step` vertexes will be rendered.
+            If ``None``, then all vertexes will be rendered.
+        alpha : `float`, optional
+            Defines the transparency (opacity) of the object.
+
+        Returns
+        -------
+        renderer : `menpo3d.visualize.LandmarkViewer3d`
+            The Menpo3D rendering object.
+
+        Raises
+        ------
+        ValueError
+            If both ``with_labels`` and ``without_labels`` are passed.
+        """
         try:
             from menpo3d.visualize import LandmarkViewer3d
             if with_labels is not None and without_labels is not None:

--- a/menpo/landmark/base.py
+++ b/menpo/landmark/base.py
@@ -939,11 +939,31 @@ class LandmarkGroup(MutableMapping, Copyable, Viewable):
             axes_y_limits=axes_y_limits, axes_x_ticks=axes_x_ticks,
             axes_y_ticks=axes_y_ticks, figure_size=figure_size)
 
-    def _view_3d(self, figure_id=None, new_figure=True, **kwargs):
+    def _view_3d(self, with_labels=None, without_labels=None, group='group',
+                 figure_id=None, new_figure=False, render_lines=True,
+                 line_colour=None, line_width=4, render_markers=True,
+                 marker_style='sphere', marker_size=None, marker_colour=None,
+                 marker_resolution=8, step=None, alpha=1.0):
         try:
             from menpo3d.visualize import LandmarkViewer3d
-            return LandmarkViewer3d(figure_id, new_figure,
-                                    self._pointcloud, self).render(**kwargs)
+            if with_labels is not None and without_labels is not None:
+                raise ValueError('You may only pass one of `with_labels` or '
+                                 '`without_labels`.')
+            elif with_labels is not None:
+                lmark_group = self.with_labels(with_labels)
+            elif without_labels is not None:
+                lmark_group = self.without_labels(without_labels)
+            else:
+                lmark_group = self  # Fall through
+            landmark_viewer = LandmarkViewer3d(figure_id, new_figure,
+                                               group, lmark_group._pointcloud,
+                                               lmark_group._labels_to_masks)
+            return landmark_viewer.render(
+                render_lines=render_lines, line_colour=line_colour,
+                line_width=line_width, render_markers=render_markers,
+                marker_style=marker_style, marker_size=marker_size,
+                marker_colour=marker_colour,
+                marker_resolution=marker_resolution, step=step, alpha=alpha)
         except ImportError:
             from menpo.visualize import Menpo3dMissingError
             raise Menpo3dMissingError()

--- a/menpo/landmark/base.py
+++ b/menpo/landmark/base.py
@@ -943,7 +943,8 @@ class LandmarkGroup(MutableMapping, Copyable, Viewable):
                  figure_id=None, new_figure=True, render_lines=True,
                  line_colour=None, line_width=4, render_markers=True,
                  marker_style='sphere', marker_size=None, marker_colour=None,
-                 marker_resolution=8, step=None, alpha=1.0):
+                 marker_resolution=8, step=None, alpha=1.0,
+                 render_numbering=False, numbers_colour='k', numbers_size=None):
         """
         Visualize the landmark group in 3D.
 
@@ -1011,6 +1012,21 @@ class LandmarkGroup(MutableMapping, Copyable, Viewable):
             If ``None``, then all vertexes will be rendered.
         alpha : `float`, optional
             Defines the transparency (opacity) of the object.
+        render_numbering : `bool`, optional
+            If ``True``, the points will be numbered.
+        numbers_colour : See Below, optional
+            The colour of the numbers.
+            Example options ::
+
+                {r, g, b, c, m, k, w}
+                or
+                (3, ) ndarray
+
+        numbers_size : `float` or ``None``, optional
+            The size of the numbers. This size can be seen as a scale factor
+            applied to the numbers, which is by default calculated from
+            the inter-marker spacing. If ``None``, then an optimal numbers size
+            value will be set automatically.
 
         Returns
         -------
@@ -1041,7 +1057,9 @@ class LandmarkGroup(MutableMapping, Copyable, Viewable):
                 line_width=line_width, render_markers=render_markers,
                 marker_style=marker_style, marker_size=marker_size,
                 marker_colour=marker_colour,
-                marker_resolution=marker_resolution, step=step, alpha=alpha)
+                marker_resolution=marker_resolution, step=step, alpha=alpha,
+                render_numbering=render_numbering,
+                numbers_colour=numbers_colour, numbers_size=numbers_size)
         except ImportError:
             from menpo.visualize import Menpo3dMissingError
             raise Menpo3dMissingError()

--- a/menpo/landmark/base.py
+++ b/menpo/landmark/base.py
@@ -940,7 +940,7 @@ class LandmarkGroup(MutableMapping, Copyable, Viewable):
             axes_y_ticks=axes_y_ticks, figure_size=figure_size)
 
     def _view_3d(self, with_labels=None, without_labels=None, group='group',
-                 figure_id=None, new_figure=False, render_lines=True,
+                 figure_id=None, new_figure=True, render_lines=True,
                  line_colour=None, line_width=4, render_markers=True,
                  marker_style='sphere', marker_size=None, marker_colour=None,
                  marker_resolution=8, step=None, alpha=1.0):

--- a/menpo/shape/graph.py
+++ b/menpo/shape/graph.py
@@ -1948,7 +1948,11 @@ class PointGraph(Graph, PointCloud):
             figure_size=figure_size, label=label)
         return renderer
 
-    def _view_3d(self, figure_id=None, new_figure=False):
+    def _view_3d(self, figure_id=None, new_figure=True, render_lines=True,
+                 line_colour=(1, 0, 0), line_width=4, render_markers=True,
+                 marker_style='sphere', marker_size=None,
+                 marker_colour=(1, 0, 0), marker_resolution=8, step=None,
+                 alpha=1.0):
         r"""
         Visualization of the PointGraph in 3D.
 
@@ -1958,16 +1962,52 @@ class PointGraph(Graph, PointCloud):
             The id of the figure to be used.
         new_figure : `bool`, optional
             If ``True``, a new figure is created.
+        render_lines : `bool`, optional
+            If ``True``, then the lines will be rendered.
+        line_colour : `(float, float, float)`, optional
+            The colour of the lines as a tuple of RGB values.
+        line_width : `float`, optional
+            The width of the lines.
+        render_markers : `bool`, optional
+            If ``True``, then the markers will be rendered.
+        marker_style : `str`, optional
+            The style of the markers.
+            Example options ::
+
+                {2darrow, 2dcircle, 2dcross, 2ddash, 2ddiamond, 2dhooked_arrow,
+                 2dsquare, 2dthick_arrow, 2dthick_cross, 2dtriangle, 2dvertex,
+                 arrow, axes, cone, cube, cylinder, point, sphere}
+
+        marker_size : `float` or ``None``, optional
+            The size of the markers. This size can be seen as a scale factor
+            applied to the size markers, which is by default calculated from
+            the inter-marker spacing. If ``None``, then an optimal marker size
+            value will be set automatically.
+        marker_colour : `(float, float, float)`, optional
+            The colour of the markers as a tuple of RGB values.
+        marker_resolution : `int`, optional
+            The resolution of the markers. For spheres, for instance, this is
+            the number of divisions along theta and phi.
+        step : `int` or ``None``, optional
+            If `int`, then one every `step` vertexes will be rendered.
+            If ``None``, then all vertexes will be rendered.
+        alpha : `float`, optional
+            Defines the transparency (opacity) of the object.
 
         Returns
         -------
-        viewer : PointGraphViewer3d
-            The Menpo3D viewer object.
+        renderer : `menpo3d.visualize.PointGraphViewer3d`
+            The Menpo3D rendering object.
         """
         try:
             from menpo3d.visualize import PointGraphViewer3d
             return PointGraphViewer3d(figure_id, new_figure, self.points,
-                                      self.edges).render()
+                                      self.edges).render(
+                render_lines=render_lines, line_colour=line_colour,
+                line_width=line_width, render_markers=render_markers,
+                marker_style=marker_style, marker_size=marker_size,
+                marker_colour=marker_colour, step=step,
+                marker_resolution=marker_resolution, alpha=alpha)
         except ImportError:
             from menpo.visualize import Menpo3dMissingError
             raise Menpo3dMissingError()
@@ -2945,7 +2985,7 @@ def _isolated_vertices(adjacency_matrix):
 
 def _convert_edges_to_adjacency_matrix(edges, n_vertices):
     r"""
-    Converts an edges array to and adjacency matrix.
+    Converts an edges array to an adjacency matrix.
 
     Parameters
     ----------
@@ -2976,7 +3016,7 @@ def _convert_edges_to_adjacency_matrix(edges, n_vertices):
 
 def _convert_edges_to_symmetric_adjacency_matrix(edges, n_vertices):
     r"""
-    Converts an edges array to and adjacency matrix.
+    Converts an edges array to an adjacency matrix.
 
     Parameters
     ----------

--- a/menpo/shape/graph.py
+++ b/menpo/shape/graph.py
@@ -1949,10 +1949,9 @@ class PointGraph(Graph, PointCloud):
         return renderer
 
     def _view_3d(self, figure_id=None, new_figure=True, render_lines=True,
-                 line_colour=(1, 0, 0), line_width=4, render_markers=True,
-                 marker_style='sphere', marker_size=None,
-                 marker_colour=(1, 0, 0), marker_resolution=8, step=None,
-                 alpha=1.0):
+                 line_colour='r', line_width=4, render_markers=True,
+                 marker_style='sphere', marker_size=None, marker_colour='k',
+                 marker_resolution=8, step=None, alpha=1.0):
         r"""
         Visualization of the PointGraph in 3D.
 
@@ -1964,8 +1963,14 @@ class PointGraph(Graph, PointCloud):
             If ``True``, a new figure is created.
         render_lines : `bool`, optional
             If ``True``, then the lines will be rendered.
-        line_colour : `(float, float, float)`, optional
-            The colour of the lines as a tuple of RGB values.
+        line_colour : See Below, optional
+            The colour of the lines.
+            Example options ::
+
+                {r, g, b, c, m, k, w}
+                or
+                (3, ) ndarray
+
         line_width : `float`, optional
             The width of the lines.
         render_markers : `bool`, optional
@@ -1983,8 +1988,14 @@ class PointGraph(Graph, PointCloud):
             applied to the size markers, which is by default calculated from
             the inter-marker spacing. If ``None``, then an optimal marker size
             value will be set automatically.
-        marker_colour : `(float, float, float)`, optional
-            The colour of the markers as a tuple of RGB values.
+        marker_colour : See Below, optional
+            The colour of the markers.
+            Example options ::
+
+                {r, g, b, c, m, k, w}
+                or
+                (3, ) ndarray
+
         marker_resolution : `int`, optional
             The resolution of the markers. For spheres, for instance, this is
             the number of divisions along theta and phi.
@@ -2001,13 +2012,15 @@ class PointGraph(Graph, PointCloud):
         """
         try:
             from menpo3d.visualize import PointGraphViewer3d
-            return PointGraphViewer3d(figure_id, new_figure, self.points,
-                                      self.edges).render(
+            renderer = PointGraphViewer3d(figure_id, new_figure,
+                                          self.points, self.edges)
+            renderer.render(
                 render_lines=render_lines, line_colour=line_colour,
                 line_width=line_width, render_markers=render_markers,
                 marker_style=marker_style, marker_size=marker_size,
-                marker_colour=marker_colour, step=step,
-                marker_resolution=marker_resolution, alpha=alpha)
+                marker_colour=marker_colour,
+                marker_resolution=marker_resolution, step=step, alpha=alpha)
+            return renderer
         except ImportError:
             from menpo.visualize import Menpo3dMissingError
             raise Menpo3dMissingError()

--- a/menpo/shape/graph.py
+++ b/menpo/shape/graph.py
@@ -1951,7 +1951,8 @@ class PointGraph(Graph, PointCloud):
     def _view_3d(self, figure_id=None, new_figure=True, render_lines=True,
                  line_colour='r', line_width=4, render_markers=True,
                  marker_style='sphere', marker_size=None, marker_colour='k',
-                 marker_resolution=8, step=None, alpha=1.0):
+                 marker_resolution=8, step=None, alpha=1.0,
+                 render_numbering=False, numbers_colour='k', numbers_size=None):
         r"""
         Visualization of the PointGraph in 3D.
 
@@ -2004,6 +2005,21 @@ class PointGraph(Graph, PointCloud):
             If ``None``, then all vertexes will be rendered.
         alpha : `float`, optional
             Defines the transparency (opacity) of the object.
+        render_numbering : `bool`, optional
+            If ``True``, the points will be numbered.
+        numbers_colour : See Below, optional
+            The colour of the numbers.
+            Example options ::
+
+                {r, g, b, c, m, k, w}
+                or
+                (3, ) ndarray
+
+        numbers_size : `float` or ``None``, optional
+            The size of the numbers. This size can be seen as a scale factor
+            applied to the numbers, which is by default calculated from
+            the inter-marker spacing. If ``None``, then an optimal numbers size
+            value will be set automatically.
 
         Returns
         -------
@@ -2019,7 +2035,9 @@ class PointGraph(Graph, PointCloud):
                 line_width=line_width, render_markers=render_markers,
                 marker_style=marker_style, marker_size=marker_size,
                 marker_colour=marker_colour,
-                marker_resolution=marker_resolution, step=step, alpha=alpha)
+                marker_resolution=marker_resolution, step=step, alpha=alpha,
+                render_numbering=render_numbering,
+                numbers_colour=numbers_colour, numbers_size=numbers_size)
             return renderer
         except ImportError:
             from menpo.visualize import Menpo3dMissingError

--- a/menpo/shape/mesh/base.py
+++ b/menpo/shape/mesh/base.py
@@ -740,7 +740,12 @@ class TriMesh(PointCloud):
                 axes_y_limits=axes_y_limits, axes_x_ticks=axes_x_ticks,
                 axes_y_ticks=axes_y_ticks, figure_size=figure_size, label=label)
 
-    def _view_3d(self, figure_id=None, new_figure=False, **kwargs):
+    def _view_3d(self, figure_id=None, new_figure=True, mesh_type='wireframe',
+                 line_width=2, colour=(1, 0, 0), marker_style='sphere',
+                 marker_size=0.05, marker_resolution=8, normals=None,
+                 normals_colour=(0, 0, 0), normals_line_width=2,
+                 normals_marker_style='2darrow', normals_marker_resolution=8,
+                 normals_marker_size=0.05, step=None, alpha=1.0):
         r"""
         Visualization of the TriMesh in 3D.
 
@@ -750,16 +755,86 @@ class TriMesh(PointCloud):
             The id of the figure to be used.
         new_figure : `bool`, optional
             If ``True``, a new figure is created.
+        mesh_type : `str`, optional
+            The representation type to be used for the mesh.
+            Example options ::
+
+                {surface, wireframe, points, mesh, fancymesh}
+
+        line_width : `float`, optional
+            The width of the lines, if there are any.
+        colour : `(float, float, float)`, optional
+            The colour of the mesh as a tuple of RGB values.
+        marker_style : `str`, optional
+            The style of the markers.
+            Example options ::
+
+                {2darrow, 2dcircle, 2dcross, 2ddash, 2ddiamond, 2dhooked_arrow,
+                 2dsquare, 2dthick_arrow, 2dthick_cross, 2dtriangle, 2dvertex,
+                 arrow, axes, cone, cube, cylinder, point, sphere}
+
+        marker_size : `float` or ``None``, optional
+            The size of the markers. This size can be seen as a scale factor
+            applied to the size markers, which is by default calculated from
+            the inter-marker spacing. If ``None``, then an optimal marker size
+            value will be set automatically. It only applies for the
+            'fancymesh'.
+        marker_resolution : `int`, optional
+            The resolution of the markers. For spheres, for instance, this is
+            the number of divisions along theta and phi. It only applies for
+            the 'fancymesh'.
+        normals : ``(n_points, 3)`` `ndarray` or ``None``, optional
+            If ``None``, then the normals will not be rendered. If `ndarray`,
+            then the provided normals will be rendered as well. Note that a
+            normal must be provided for each point in the TriMesh.
+        normals_colour : `(float, float, float)`, optional
+            The colour of the normals as a tuple of RGB values. It only applies
+            if `normals` is not ``None``.
+        normals_line_width : `float`, optional
+            The width of the lines of the normals. It only applies if `normals`
+            is not ``None``.
+        normals_marker_style : `str`, optional
+            The style of the markers of the normals. It only applies if `normals`
+            is not ``None``.
+            Example options ::
+
+                {2darrow, 2dcircle, 2dcross, 2ddash, 2ddiamond, 2dhooked_arrow,
+                 2dsquare, 2dthick_arrow, 2dthick_cross, 2dtriangle, 2dvertex,
+                 arrow, axes, cone, cube, cylinder, point, sphere}
+
+        normals_marker_resolution : `int`, optional
+            The resolution of the markers of the normals. For spheres, for
+            instance, this is the number of divisions along theta and phi. It
+            only applies if `normals` is not ``None``.
+        normals_marker_size : `float`, optional
+            The size of the markers. This size can be seen as a scale factor
+            applied to the size markers, which is by default calculated from
+            the inter-marker spacing. It only applies if `normals` is not
+            ``None``.
+        step : `int` or ``None``, optional
+            If `int`, then one every `step` markers will be rendered.
+            If ``None``, then all vertexes will be rendered. It only applies for
+            the 'fancymesh' and if `normals` is not ``None``.
+        alpha : `float`, optional
+            Defines the transparency (opacity) of the object.
 
         Returns
         -------
-        viewer : TriMeshViewer3D
-            The Menpo3D viewer object.
+        renderer : `menpo3d.visualize.TriMeshViewer3D`
+            The Menpo3D rendering object.
         """
         try:
             from menpo3d.visualize import TriMeshViewer3d
             return TriMeshViewer3d(figure_id, new_figure,
-                                   self.points, self.trilist).render(**kwargs)
+                                   self.points, self.trilist).render(
+                mesh_type=mesh_type, line_width=line_width, colour=colour,
+                marker_size=marker_size, marker_resolution=marker_resolution,
+                marker_style=marker_style, normals=normals,
+                normals_colour=normals_colour,
+                normals_line_width=normals_line_width,
+                normals_marker_style=normals_marker_style,
+                normals_marker_resolution=normals_marker_resolution,
+                normals_marker_size=normals_marker_size, step=step, alpha=alpha)
         except ImportError:
             from menpo.visualize import Menpo3dMissingError
             raise Menpo3dMissingError()

--- a/menpo/shape/mesh/base.py
+++ b/menpo/shape/mesh/base.py
@@ -817,10 +817,11 @@ class TriMesh(PointCloud):
             The resolution of the markers of the normals. For spheres, for
             instance, this is the number of divisions along theta and phi. It
             only applies if `normals` is not ``None``.
-        normals_marker_size : `float`, optional
+        normals_marker_size : `float` or ``None``, optional
             The size of the markers. This size can be seen as a scale factor
             applied to the size markers, which is by default calculated from
-            the inter-marker spacing. It only applies if `normals` is not
+            the inter-marker spacing. If ``None``, then an optimal marker size
+            value will be set automatically. It only applies if `normals` is not
             ``None``.
         step : `int` or ``None``, optional
             If `int`, then one every `step` markers will be rendered.

--- a/menpo/shape/mesh/base.py
+++ b/menpo/shape/mesh/base.py
@@ -741,11 +741,11 @@ class TriMesh(PointCloud):
                 axes_y_ticks=axes_y_ticks, figure_size=figure_size, label=label)
 
     def _view_3d(self, figure_id=None, new_figure=True, mesh_type='wireframe',
-                 line_width=2, colour=(1, 0, 0), marker_style='sphere',
-                 marker_size=0.05, marker_resolution=8, normals=None,
-                 normals_colour=(0, 0, 0), normals_line_width=2,
+                 line_width=2, colour='r', marker_style='sphere',
+                 marker_size=None, marker_resolution=8, normals=None,
+                 normals_colour='k', normals_line_width=2,
                  normals_marker_style='2darrow', normals_marker_resolution=8,
-                 normals_marker_size=0.05, step=None, alpha=1.0):
+                 normals_marker_size=None, step=None, alpha=1.0):
         r"""
         Visualization of the TriMesh in 3D.
 
@@ -763,8 +763,14 @@ class TriMesh(PointCloud):
 
         line_width : `float`, optional
             The width of the lines, if there are any.
-        colour : `(float, float, float)`, optional
-            The colour of the mesh as a tuple of RGB values.
+        colour : See Below, optional
+            The colour of the markers.
+            Example options ::
+
+                {r, g, b, c, m, k, w}
+                or
+                (3, ) ndarray
+
         marker_style : `str`, optional
             The style of the markers.
             Example options ::
@@ -787,9 +793,14 @@ class TriMesh(PointCloud):
             If ``None``, then the normals will not be rendered. If `ndarray`,
             then the provided normals will be rendered as well. Note that a
             normal must be provided for each point in the TriMesh.
-        normals_colour : `(float, float, float)`, optional
-            The colour of the normals as a tuple of RGB values. It only applies
-            if `normals` is not ``None``.
+        normals_colour : See Below, optional
+            The colour of the normals.
+            Example options ::
+
+                {r, g, b, c, m, k, w}
+                or
+                (3, ) ndarray
+
         normals_line_width : `float`, optional
             The width of the lines of the normals. It only applies if `normals`
             is not ``None``.
@@ -825,16 +836,18 @@ class TriMesh(PointCloud):
         """
         try:
             from menpo3d.visualize import TriMeshViewer3d
-            return TriMeshViewer3d(figure_id, new_figure,
-                                   self.points, self.trilist).render(
+            renderer = TriMeshViewer3d(figure_id, new_figure, self.points,
+                                       self.trilist)
+            renderer.render(
                 mesh_type=mesh_type, line_width=line_width, colour=colour,
-                marker_size=marker_size, marker_resolution=marker_resolution,
-                marker_style=marker_style, normals=normals,
+                marker_style=marker_style, marker_size=marker_size,
+                marker_resolution=marker_resolution, normals=normals,
                 normals_colour=normals_colour,
                 normals_line_width=normals_line_width,
                 normals_marker_style=normals_marker_style,
                 normals_marker_resolution=normals_marker_resolution,
                 normals_marker_size=normals_marker_size, step=step, alpha=alpha)
+            return renderer
         except ImportError:
             from menpo.visualize import Menpo3dMissingError
             raise Menpo3dMissingError()

--- a/menpo/shape/mesh/coloured.py
+++ b/menpo/shape/mesh/coloured.py
@@ -219,12 +219,12 @@ class ColouredTriMesh(TriMesh):
         instance.colours = ((colours - min_) * sf) + minimum
         return instance
 
-    def _view_3d(self, figure_id=None, new_figure=True, coloured=True,
-                 mesh_type='surface', mesh_colour=(1, 0, 0), line_width=2,
-                 ambient_light=0.0, specular_light=0.0, normals=None,
-                 normals_colour=(0, 0, 0), normals_line_width=2,
-                 normals_marker_style='2darrow', normals_marker_resolution=8,
-                 normals_marker_size=0.05, step=None, alpha=1.0):
+    def _view_3d(self, figure_id=None, new_figure=True, render_texture=True,
+                 mesh_type='surface', ambient_light=0.0, specular_light=0.0,
+                 colour='r', line_width=2, normals=None, normals_colour='k',
+                 normals_line_width=2, normals_marker_style='2darrow',
+                 normals_marker_resolution=8, normals_marker_size=None,
+                 step=None, alpha=1.0):
         r"""
         Visualize the Coloured TriMesh in 3D.
 
@@ -234,27 +234,37 @@ class ColouredTriMesh(TriMesh):
             The id of the figure to be used.
         new_figure : `bool`, optional
             If ``True``, a new figure is created.
-        coloured : `bool`, optional
-            If ``True``, then the colour per vertex is rendered. If ``False``,
-            then only the TriMesh is rendered with the specified `colour`.
+        render_texture : `bool`, optional
+            If ``True``, then the texture is rendered. If ``False``, then only
+            the TriMesh is rendered with the specified `colour`.
         mesh_type : ``{'surface', 'wireframe'}``, optional
             The representation type to be used for the mesh.
-        mesh_colour : `(float, float, float)`, optional
-            The colour of the mesh as a tuple of RGB values. It only applies if
-            `coloured` is ``False``.
-        line_width : `float`, optional
-            The width of the lines, if there are any.
         ambient_light : `float`, optional
             The ambient light intensity. It must be in range ``[0., 1.]``.
         specular_light : `float`, optional
             The specular light intensity. It must be in range ``[0., 1.]``.
+        colour : See Below, optional
+            The colour of the mesh if `render_texture` is ``False``.
+            Example options ::
+
+                {r, g, b, c, m, k, w}
+                or
+                (3, ) ndarray
+
+        line_width : `float`, optional
+            The width of the lines, if there are any.
         normals : ``(n_points, 3)`` `ndarray` or ``None``, optional
             If ``None``, then the normals will not be rendered. If `ndarray`,
             then the provided normals will be rendered as well. Note that a
             normal must be provided for each point in the TriMesh.
-        normals_colour : `(float, float, float)`, optional
-            The colour of the normals as a tuple of RGB values. It only applies
-            if `normals` is not ``None``.
+        normals_colour : See Below, optional
+            The colour of the normals.
+            Example options ::
+
+                {r, g, b, c, m, k, w}
+                or
+                (3, ) ndarray
+
         normals_line_width : `float`, optional
             The width of the lines of the normals. It only applies if `normals`
             is not ``None``.
@@ -271,10 +281,11 @@ class ColouredTriMesh(TriMesh):
             The resolution of the markers of the normals. For spheres, for
             instance, this is the number of divisions along theta and phi. It
             only applies if `normals` is not ``None``.
-        normals_marker_size : `float`, optional
+        normals_marker_size : `float` or ``None``, optional
             The size of the markers. This size can be seen as a scale factor
             applied to the size markers, which is by default calculated from
-            the inter-marker spacing. It only applies if `normals` is not
+            the inter-marker spacing. If ``None``, then an optimal marker size
+            value will be set automatically. It only applies if `normals` is not
             ``None``.
         step : `int` or ``None``, optional
             If `int`, then one every `step` normals will be rendered.
@@ -288,12 +299,13 @@ class ColouredTriMesh(TriMesh):
         renderer : `menpo3d.visualize.ColouredTriMeshViewer3D`
             The Menpo3D rendering object.
         """
-        if coloured:
+        if render_texture:
             try:
                 from menpo3d.visualize import ColouredTriMeshViewer3d
-                return ColouredTriMeshViewer3d(figure_id, new_figure,
-                                               self.points, self.trilist,
-                                               self.colours).render(
+                renderer = ColouredTriMeshViewer3d(figure_id, new_figure,
+                                                   self.points, self.trilist,
+                                                   self.colours)
+                renderer.render(
                     mesh_type=mesh_type, ambient_light=ambient_light,
                     specular_light=specular_light, normals=normals,
                     normals_colour=normals_colour,
@@ -306,15 +318,22 @@ class ColouredTriMesh(TriMesh):
                 from menpo.visualize import Menpo3dMissingError
                 raise Menpo3dMissingError()
         else:
-            from menpo3d.visualize import TriMeshViewer3d
-            return TriMeshViewer3d(figure_id, new_figure,
-                                   self.points, self.trilist).render(
-                mesh_type=mesh_type, line_width=line_width, colour=mesh_colour,
-                normals=normals, normals_colour=normals_colour,
-                normals_line_width=normals_line_width,
-                normals_marker_style=normals_marker_style,
-                normals_marker_resolution=normals_marker_resolution,
-                normals_marker_size=normals_marker_size, step=step, alpha=alpha)
+            try:
+                from menpo3d.visualize import TriMeshViewer3d
+                renderer = TriMeshViewer3d(figure_id, new_figure, self.points,
+                                           self.trilist)
+                renderer.render(
+                    mesh_type=mesh_type, line_width=line_width, colour=colour,
+                    normals=normals, normals_colour=normals_colour,
+                    normals_line_width=normals_line_width,
+                    normals_marker_style=normals_marker_style,
+                    normals_marker_resolution=normals_marker_resolution,
+                    normals_marker_size=normals_marker_size, step=step,
+                    alpha=alpha)
+                return renderer
+            except ImportError:
+                from menpo.visualize import Menpo3dMissingError
+                raise Menpo3dMissingError()
 
     def _view_2d(self, figure_id=None, new_figure=False, image_view=True,
                  render_lines=True, line_colour='r', line_style='-',

--- a/menpo/shape/mesh/coloured.py
+++ b/menpo/shape/mesh/coloured.py
@@ -215,7 +215,7 @@ class ColouredTriMesh(TriMesh):
             min_, max_ = colours.min(axis=0), colours.max(axis=0)
         else:
             min_, max_ = colours.min(), colours.max()
-        sf = ((maximum - minimum) * 1.0) / (max_ - min_)
+        sf = (maximum - minimum) / (max_ - min_)
         instance.colours = ((colours - min_) * sf) + minimum
         return instance
 

--- a/menpo/shape/mesh/coloured.py
+++ b/menpo/shape/mesh/coloured.py
@@ -171,7 +171,7 @@ class ColouredTriMesh(TriMesh):
             ctm.colours = ctm.colours[isolated_mask, :]
             return ctm
 
-    def with_clipped_texture(self, range=(0., 1.)):
+    def clip_texture(self, range=(0., 1.)):
         """
         Method that returns a copy of the object with the coloured values
         clipped in range ``(0, 1)``.
@@ -190,8 +190,9 @@ class ColouredTriMesh(TriMesh):
         instance.colours = np.clip(self.colours, *range)
         return instance
 
-    def with_rescaled_texture(self, minimum, maximum, per_channel=True):
-        r"""A copy of this mesh with colours linearly rescaled to fit a range.
+    def rescale_texture(self, minimum, maximum, per_channel=True):
+        r"""
+        A copy of this mesh with colours linearly rescaled to fit a range.
 
         Parameters
         ----------

--- a/menpo/shape/mesh/coloured.py
+++ b/menpo/shape/mesh/coloured.py
@@ -314,6 +314,7 @@ class ColouredTriMesh(TriMesh):
                     normals_marker_resolution=normals_marker_resolution,
                     normals_marker_size=normals_marker_size, step=step,
                     alpha=alpha)
+                return renderer
             except ImportError:
                 from menpo.visualize import Menpo3dMissingError
                 raise Menpo3dMissingError()

--- a/menpo/shape/mesh/textured.py
+++ b/menpo/shape/mesh/textured.py
@@ -38,6 +38,15 @@ class TexturedTriMesh(TriMesh):
         else:
             self.texture = texture.copy()
 
+    @property
+    def n_channels(self):
+        r"""
+        The number of channels of colour used (e.g. 3 for RGB).
+
+        :type: `int`
+        """
+        return self.texture.n_channels
+
     @classmethod
     def init_2d_grid(cls, shape, spacing=None, tcoords=None, texture=None):
         r"""
@@ -218,10 +227,33 @@ class TexturedTriMesh(TriMesh):
             ttm.tcoords.points = ttm.tcoords.points[isolated_mask, :]
             return ttm
 
-    def _view_3d(self, figure_id=None, new_figure=False, textured=True,
-                 **kwargs):
+    def with_clipped_texture(self, range=(0., 1.)):
+        """
+        Method that returns a copy of the object with the texture values
+        clipped in range ``(0, 1)``.
+
+        Parameters
+        ----------
+        range : ``(float, float)``, optional
+            The clipping range.
+
+        Returns
+        -------
+        self : :map:`ColouredTriMesh`
+            A copy of self with its texture clipped.
+        """
+        instance = self.copy()
+        instance.texture.pixels = np.clip(self.texture.pixels, *range)
+        return instance
+
+    def _view_3d(self, figure_id=None, new_figure=True, textured=True,
+                 mesh_type='surface', mesh_colour=(1, 0, 0), line_width=2,
+                 ambient_light=0.0, specular_light=0.0, normals=None,
+                 normals_colour=(0, 0, 0), normals_line_width=2,
+                 normals_marker_style='2darrow', normals_marker_resolution=8,
+                 normals_marker_size=0.05, step=None, alpha=1.0):
         r"""
-        Visualize the :map:`TexturedTriMesh` in 3D.
+        Visualize the Textured TriMesh in 3D.
 
         Parameters
         ----------
@@ -230,27 +262,87 @@ class TexturedTriMesh(TriMesh):
         new_figure : `bool`, optional
             If ``True``, a new figure is created.
         textured : `bool`, optional
-            If `True`, render the texture.
+            If ``True``, then the texture is rendered. If ``False``, then only
+            the TriMesh is rendered with the specified `colour`.
+        mesh_type : ``{'surface', 'wireframe'}``, optional
+            The representation type to be used for the mesh.
+        mesh_colour : `(float, float, float)`, optional
+            The colour of the mesh as a tuple of RGB values. It only applies if
+            `textured` is ``False``.
+        line_width : `float`, optional
+            The width of the lines, if there are any.
+        ambient_light : `float`, optional
+            The ambient light intensity. It must be in range ``[0., 1.]``.
+        specular_light : `float`, optional
+            The specular light intensity. It must be in range ``[0., 1.]``.
+        normals : ``(n_points, 3)`` `ndarray` or ``None``, optional
+            If ``None``, then the normals will not be rendered. If `ndarray`,
+            then the provided normals will be rendered as well. Note that a
+            normal must be provided for each point in the TriMesh.
+        normals_colour : `(float, float, float)`, optional
+            The colour of the normals as a tuple of RGB values. It only applies
+            if `normals` is not ``None``.
+        normals_line_width : `float`, optional
+            The width of the lines of the normals. It only applies if `normals`
+            is not ``None``.
+        normals_marker_style : `str`, optional
+            The style of the markers of the normals. It only applies if `normals`
+            is not ``None``.
+            Example options ::
+
+                {2darrow, 2dcircle, 2dcross, 2ddash, 2ddiamond, 2dhooked_arrow,
+                 2dsquare, 2dthick_arrow, 2dthick_cross, 2dtriangle, 2dvertex,
+                 arrow, axes, cone, cube, cylinder, point, sphere}
+
+        normals_marker_resolution : `int`, optional
+            The resolution of the markers of the normals. For spheres, for
+            instance, this is the number of divisions along theta and phi. It
+            only applies if `normals` is not ``None``.
+        normals_marker_size : `float`, optional
+            The size of the markers. This size can be seen as a scale factor
+            applied to the size markers, which is by default calculated from
+            the inter-marker spacing. It only applies if `normals` is not
+            ``None``.
+        step : `int` or ``None``, optional
+            If `int`, then one every `step` normals will be rendered.
+            If ``None``, then all vertexes will be rendered. It only applies if
+            `normals` is not ``None``.
+        alpha : `float`, optional
+            Defines the transparency (opacity) of the object.
 
         Returns
         -------
-        viewer : :map:`Renderer`
-            The viewer object.
+        renderer : `menpo3d.visualize.TexturedTriMeshViewer3D`
+            The Menpo3D rendering object.
         """
         if textured:
             try:
                 from menpo3d.visualize import TexturedTriMeshViewer3d
-                return TexturedTriMeshViewer3d(
-                    figure_id, new_figure, self.points,
-                    self.trilist, self.texture,
-                    self.tcoords.points).render(**kwargs)
+                return TexturedTriMeshViewer3d(figure_id, new_figure,
+                                               self.points, self.trilist,
+                                               self.texture,
+                                               self.tcoords.points).render(
+                    mesh_type=mesh_type, ambient_light=ambient_light,
+                    specular_light=specular_light, normals=normals,
+                    normals_colour=normals_colour,
+                    normals_line_width=normals_line_width,
+                    normals_marker_style=normals_marker_style,
+                    normals_marker_resolution=normals_marker_resolution,
+                    normals_marker_size=normals_marker_size, step=step,
+                    alpha=alpha)
             except ImportError:
                 from menpo.visualize import Menpo3dMissingError
                 raise Menpo3dMissingError()
         else:
-            return super(TexturedTriMesh, self).view(figure_id=figure_id,
-                                                     new_figure=new_figure,
-                                                     **kwargs)
+            from menpo3d.visualize import TriMeshViewer3d
+            return TriMeshViewer3d(figure_id, new_figure,
+                                   self.points, self.trilist).render(
+                mesh_type=mesh_type, line_width=line_width, colour=mesh_colour,
+                normals=normals, normals_colour=normals_colour,
+                normals_line_width=normals_line_width,
+                normals_marker_style=normals_marker_style,
+                normals_marker_resolution=normals_marker_resolution,
+                normals_marker_size=normals_marker_size, step=step, alpha=alpha)
 
     def _view_2d(self, figure_id=None, new_figure=False, image_view=True,
                  render_lines=True, line_colour='r', line_style='-',

--- a/menpo/shape/mesh/textured.py
+++ b/menpo/shape/mesh/textured.py
@@ -227,7 +227,7 @@ class TexturedTriMesh(TriMesh):
             ttm.tcoords.points = ttm.tcoords.points[isolated_mask, :]
             return ttm
 
-    def with_clipped_texture(self, range=(0., 1.)):
+    def clip_texture(self, range=(0., 1.)):
         """
         Method that returns a copy of the object with the texture values
         clipped in range ``(0, 1)``.
@@ -244,6 +244,31 @@ class TexturedTriMesh(TriMesh):
         """
         instance = self.copy()
         instance.texture.pixels = np.clip(self.texture.pixels, *range)
+        return instance
+
+    def rescale_texture(self, minimum, maximum, per_channel=True):
+        r"""
+        A copy of this mesh with texture linearly rescaled to fit a range.
+
+        Parameters
+        ----------
+        minimum: `float`
+            The minimal value of the rescaled colours
+        maximum: `float`
+            The maximal value of the rescaled colours
+        per_channel: `boolean`, optional
+            If ``True``, each channel will be rescaled independently. If
+            ``False``, the scaling will be over all channels.
+
+        Returns
+        -------
+        textured_mesh : ``type(self)``
+            A copy of this mesh with texture linearly rescaled to fit in the
+            range provided.
+        """
+        instance = self.copy()
+        instance.texture = instance.texture.rescale_pixels(
+            minimum, maximum, per_channel=per_channel)
         return instance
 
     def _view_3d(self, figure_id=None, new_figure=True, render_texture=True,

--- a/menpo/shape/pointcloud.py
+++ b/menpo/shape/pointcloud.py
@@ -475,8 +475,7 @@ class PointCloud(Shape):
         from menpo.visualize.base import PointGraphViewer2d
         adjacency_array = np.empty(0)
         renderer = PointGraphViewer2d(figure_id, new_figure,
-                                      self.points,
-                                      adjacency_array)
+                                      self.points, adjacency_array)
         renderer.render(
             image_view=image_view, render_lines=False, line_colour='b',
             line_style='-', line_width=1., render_markers=render_markers,
@@ -767,9 +766,9 @@ class PointCloud(Shape):
 
         return landmark_view
 
-    def _view_3d(self, figure_id=None, new_figure=True, marker_style='sphere',
-                 marker_size=None, marker_colour=(1, 0, 0), marker_resolution=8,
-                 step=None, alpha=1.0):
+    def _view_3d(self, figure_id=None, new_figure=True, render_markers=True,
+                 marker_style='sphere', marker_size=None, marker_colour='r',
+                 marker_resolution=8, step=None, alpha=1.0, **kwargs):
         r"""
         Visualization of the PointCloud in 3D.
 
@@ -779,6 +778,8 @@ class PointCloud(Shape):
             The id of the figure to be used.
         new_figure : `bool`, optional
             If ``True``, a new figure is created.
+        render_markers : `bool`, optional
+            If ``True``, the markers will be rendered.
         marker_style : `str`, optional
             The style of the markers.
             Example options ::
@@ -792,8 +793,14 @@ class PointCloud(Shape):
             applied to the size markers, which is by default calculated from
             the inter-marker spacing. If ``None``, then an optimal marker size
             value will be set automatically.
-        marker_colour : `(float, float, float)`, optional
-            The colour of the markers as a tuple of RGB values.
+        marker_colour : See Below, optional
+            The colour of the markers.
+            Example options ::
+
+                {r, g, b, c, m, k, w}
+                or
+                (3, ) ndarray
+
         marker_resolution : `int`, optional
             The resolution of the markers. For spheres, for instance, this is
             the number of divisions along theta and phi.
@@ -805,16 +812,20 @@ class PointCloud(Shape):
 
         Returns
         -------
-        renderer : `menpo3d.visualize.PointCloudViewer3d`
+        renderer : `menpo3d.visualize.PointGraphViewer3d`
             The Menpo3D rendering object.
         """
         try:
-            from menpo3d.visualize import PointCloudViewer3d
-            return PointCloudViewer3d(figure_id, new_figure,
-                                      self.points).render(
-                marker_style=marker_style, marker_size=marker_size,
-                marker_colour=marker_colour,
+            from menpo3d.visualize import PointGraphViewer3d
+            edges = np.empty(0)
+            renderer = PointGraphViewer3d(figure_id, new_figure,
+                                          self.points, edges)
+            renderer.render(
+                render_lines=False, line_colour='r', line_width=4,
+                render_markers=render_markers, marker_style=marker_style,
+                marker_size=marker_size, marker_colour=marker_colour,
                 marker_resolution=marker_resolution, step=step, alpha=alpha)
+            return renderer
         except ImportError:
             from menpo.visualize import Menpo3dMissingError
             raise Menpo3dMissingError()

--- a/menpo/shape/pointcloud.py
+++ b/menpo/shape/pointcloud.py
@@ -830,35 +830,100 @@ class PointCloud(Shape):
             from menpo.visualize import Menpo3dMissingError
             raise Menpo3dMissingError()
 
-    def _view_landmarks_3d(self, figure_id=None, new_figure=False,
-                           group=None):
+    def _view_landmarks_3d(self, group=None, with_labels=None,
+                           without_labels=None, figure_id=None,
+                           new_figure=False, render_lines=True,
+                           line_colour=None, line_width=4, render_markers=True,
+                           marker_style='sphere', marker_size=None,
+                           marker_colour=None, marker_resolution=8,
+                           step=None, alpha=1.0):
         r"""
         Visualization of the PointCloud landmarks in 3D.
 
         Parameters
         ----------
+        with_labels : ``None`` or `str` or `list` of `str`, optional
+            If not ``None``, only show the given label(s). Should **not** be
+            used with the ``without_labels`` kwarg.
+        without_labels : ``None`` or `str` or `list` of `str`, optional
+            If not ``None``, show all except the given label(s). Should **not**
+            be used with the ``with_labels`` kwarg.
+        group : `str` or `None`, optional
+            The landmark group to be visualized. If ``None`` and there are more
+            than one landmark groups, an error is raised.
         figure_id : `object`, optional
             The id of the figure to be used.
         new_figure : `bool`, optional
             If ``True``, a new figure is created.
-        group : `str`
-            The landmark group to visualize. If ``None`` is passed, the first
-            and only landmark group on the object will be visualized.
+        render_lines : `bool`, optional
+            If ``True``, then the lines will be rendered.
+        line_colour : See Below, optional
+            The colour of the lines. If ``None``, a different colour will be
+            automatically selected for each label.
+            Example options ::
+
+                {r, g, b, c, m, k, w}
+                or
+                (3, ) ndarray
+                or
+                None
+
+        line_width : `float`, optional
+            The width of the lines.
+        render_markers : `bool`, optional
+            If ``True``, then the markers will be rendered.
+        marker_style : `str`, optional
+            The style of the markers.
+            Example options ::
+
+                {2darrow, 2dcircle, 2dcross, 2ddash, 2ddiamond, 2dhooked_arrow,
+                 2dsquare, 2dthick_arrow, 2dthick_cross, 2dtriangle, 2dvertex,
+                 arrow, axes, cone, cube, cylinder, point, sphere}
+
+        marker_size : `float` or ``None``, optional
+            The size of the markers. This size can be seen as a scale factor
+            applied to the size markers, which is by default calculated from
+            the inter-marker spacing. If ``None``, then an optimal marker size
+            value will be set automatically.
+        marker_colour : See Below, optional
+            The colour of the markers. If ``None``, a different colour will be
+            automatically selected for each label.
+            Example options ::
+
+                {r, g, b, c, m, k, w}
+                or
+                (3, ) ndarray
+                or
+                None
+
+        marker_resolution : `int`, optional
+            The resolution of the markers. For spheres, for instance, this is
+            the number of divisions along theta and phi.
+        step : `int` or ``None``, optional
+            If `int`, then one every `step` vertexes will be rendered.
+            If ``None``, then all vertexes will be rendered.
+        alpha : `float`, optional
+            Defines the transparency (opacity) of the object.
 
         Returns
         -------
-        viewer : LandmarkViewer3d
-            The Menpo3D viewer object.
+        renderer : `menpo3d.visualize.LandmarkViewer3d`
+            The Menpo3D rendering object.
         """
-        try:
-            from menpo3d.visualize import LandmarkViewer3d
-            self_renderer = self.view(figure_id=figure_id,
-                                      new_figure=new_figure)
-            return LandmarkViewer3d(self_renderer.figure, False,  self,
-                                    self.landmarks[group]).render()
-        except ImportError:
-            from menpo.visualize import Menpo3dMissingError
-            raise Menpo3dMissingError()
+        if not self.has_landmarks:
+            raise ValueError('PointCloud does not have landmarks attached, '
+                             'unable to view landmarks.')
+        self_view = self.view(figure_id=figure_id, new_figure=new_figure)
+        landmark_view = self.landmarks[group].view(
+            with_labels=with_labels, without_labels=without_labels,
+            figure_id=self_view.figure_id, new_figure=False,
+            render_lines=render_lines, line_colour=line_colour,
+            line_width=line_width, render_markers=render_markers,
+            marker_style=marker_style, marker_size=marker_size,
+            marker_colour=marker_colour, marker_resolution=marker_resolution,
+            step=step, alpha=alpha)
+
+        return landmark_view
 
     def view_widget(self, browser_style='buttons', figure_size=(10, 8),
                     style='coloured'):

--- a/menpo/shape/pointcloud.py
+++ b/menpo/shape/pointcloud.py
@@ -832,7 +832,7 @@ class PointCloud(Shape):
 
     def _view_landmarks_3d(self, group=None, with_labels=None,
                            without_labels=None, figure_id=None,
-                           new_figure=False, render_lines=True,
+                           new_figure=True, render_lines=True,
                            line_colour=None, line_width=4, render_markers=True,
                            marker_style='sphere', marker_size=None,
                            marker_colour=None, marker_resolution=8,

--- a/menpo/shape/pointcloud.py
+++ b/menpo/shape/pointcloud.py
@@ -767,7 +767,9 @@ class PointCloud(Shape):
 
         return landmark_view
 
-    def _view_3d(self, figure_id=None, new_figure=False):
+    def _view_3d(self, figure_id=None, new_figure=True, marker_style='sphere',
+                 marker_size=None, marker_colour=(1, 0, 0), marker_resolution=8,
+                 step=None, alpha=1.0):
         r"""
         Visualization of the PointCloud in 3D.
 
@@ -777,16 +779,42 @@ class PointCloud(Shape):
             The id of the figure to be used.
         new_figure : `bool`, optional
             If ``True``, a new figure is created.
+        marker_style : `str`, optional
+            The style of the markers.
+            Example options ::
+
+                {2darrow, 2dcircle, 2dcross, 2ddash, 2ddiamond, 2dhooked_arrow,
+                 2dsquare, 2dthick_arrow, 2dthick_cross, 2dtriangle, 2dvertex,
+                 arrow, axes, cone, cube, cylinder, point, sphere}
+
+        marker_size : `float` or ``None``, optional
+            The size of the markers. This size can be seen as a scale factor
+            applied to the size markers, which is by default calculated from
+            the inter-marker spacing. If ``None``, then an optimal marker size
+            value will be set automatically.
+        marker_colour : `(float, float, float)`, optional
+            The colour of the markers as a tuple of RGB values.
+        marker_resolution : `int`, optional
+            The resolution of the markers. For spheres, for instance, this is
+            the number of divisions along theta and phi.
+        step : `int` or ``None``, optional
+            If `int`, then one every `step` vertexes will be rendered.
+            If ``None``, then all vertexes will be rendered.
+        alpha : `float`, optional
+            Defines the transparency (opacity) of the object.
 
         Returns
         -------
-        viewer : PointCloudViewer3d
-            The Menpo3D viewer object.
+        renderer : `menpo3d.visualize.PointCloudViewer3d`
+            The Menpo3D rendering object.
         """
         try:
             from menpo3d.visualize import PointCloudViewer3d
             return PointCloudViewer3d(figure_id, new_figure,
-                                      self.points).render()
+                                      self.points).render(
+                marker_style=marker_style, marker_size=marker_size,
+                marker_colour=marker_colour,
+                marker_resolution=marker_resolution, step=step, alpha=alpha)
         except ImportError:
             from menpo.visualize import Menpo3dMissingError
             raise Menpo3dMissingError()

--- a/menpo/shape/pointcloud.py
+++ b/menpo/shape/pointcloud.py
@@ -855,7 +855,8 @@ class PointCloud(Shape):
                            line_colour=None, line_width=4, render_markers=True,
                            marker_style='sphere', marker_size=None,
                            marker_colour=None, marker_resolution=8,
-                           step=None, alpha=1.0):
+                           step=None, alpha=1.0, render_numbering=False,
+                           numbers_colour='k', numbers_size=None):
         r"""
         Visualization of the PointCloud landmarks in 3D.
 
@@ -923,6 +924,21 @@ class PointCloud(Shape):
             If ``None``, then all vertexes will be rendered.
         alpha : `float`, optional
             Defines the transparency (opacity) of the object.
+        render_numbering : `bool`, optional
+            If ``True``, the points will be numbered.
+        numbers_colour : See Below, optional
+            The colour of the numbers.
+            Example options ::
+
+                {r, g, b, c, m, k, w}
+                or
+                (3, ) ndarray
+
+        numbers_size : `float` or ``None``, optional
+            The size of the numbers. This size can be seen as a scale factor
+            applied to the numbers, which is by default calculated from
+            the inter-marker spacing. If ``None``, then an optimal numbers size
+            value will be set automatically.
 
         Returns
         -------
@@ -940,7 +956,8 @@ class PointCloud(Shape):
             line_width=line_width, render_markers=render_markers,
             marker_style=marker_style, marker_size=marker_size,
             marker_colour=marker_colour, marker_resolution=marker_resolution,
-            step=step, alpha=alpha)
+            step=step, alpha=alpha, render_numbering=render_numbering,
+            numbers_colour=numbers_colour, numbers_size=numbers_size)
 
         return landmark_view
 

--- a/menpo/shape/pointcloud.py
+++ b/menpo/shape/pointcloud.py
@@ -768,7 +768,9 @@ class PointCloud(Shape):
 
     def _view_3d(self, figure_id=None, new_figure=True, render_markers=True,
                  marker_style='sphere', marker_size=None, marker_colour='r',
-                 marker_resolution=8, step=None, alpha=1.0, **kwargs):
+                 marker_resolution=8, step=None, alpha=1.0,
+                 render_numbering=False, numbers_colour='k', numbers_size=None,
+                 **kwargs):
         r"""
         Visualization of the PointCloud in 3D.
 
@@ -809,6 +811,21 @@ class PointCloud(Shape):
             If ``None``, then all vertexes will be rendered.
         alpha : `float`, optional
             Defines the transparency (opacity) of the object.
+        render_numbering : `bool`, optional
+            If ``True``, the points will be numbered.
+        numbers_colour : See Below, optional
+            The colour of the numbers.
+            Example options ::
+
+                {r, g, b, c, m, k, w}
+                or
+                (3, ) ndarray
+
+        numbers_size : `float` or ``None``, optional
+            The size of the numbers. This size can be seen as a scale factor
+            applied to the numbers, which is by default calculated from
+            the inter-marker spacing. If ``None``, then an optimal numbers size
+            value will be set automatically.
 
         Returns
         -------
@@ -824,7 +841,9 @@ class PointCloud(Shape):
                 render_lines=False, line_colour='r', line_width=4,
                 render_markers=render_markers, marker_style=marker_style,
                 marker_size=marker_size, marker_colour=marker_colour,
-                marker_resolution=marker_resolution, step=step, alpha=alpha)
+                marker_resolution=marker_resolution, step=step, alpha=alpha,
+                render_numbering=render_numbering,
+                numbers_colour=numbers_colour, numbers_size=numbers_size)
             return renderer
         except ImportError:
             from menpo.visualize import Menpo3dMissingError

--- a/menpo/shape/pointcloud.py
+++ b/menpo/shape/pointcloud.py
@@ -838,11 +838,10 @@ class PointCloud(Shape):
             renderer = PointGraphViewer3d(figure_id, new_figure,
                                           self.points, edges)
             renderer.render(
-                render_lines=False, line_colour='r', line_width=4,
-                render_markers=render_markers, marker_style=marker_style,
-                marker_size=marker_size, marker_colour=marker_colour,
-                marker_resolution=marker_resolution, step=step, alpha=alpha,
-                render_numbering=render_numbering,
+                render_lines=False, render_markers=render_markers,
+                marker_style=marker_style, marker_size=marker_size,
+                marker_colour=marker_colour, marker_resolution=marker_resolution,
+                step=step, alpha=alpha, render_numbering=render_numbering,
                 numbers_colour=numbers_colour, numbers_size=numbers_size)
             return renderer
         except ImportError:

--- a/menpo/visualize/base.py
+++ b/menpo/visualize/base.py
@@ -102,6 +102,18 @@ class Renderer(object):
         """
         pass
 
+    def clear_figure(self):
+        r"""
+        Abstract method for clearing the current figure.
+        """
+        pass
+
+    def force_draw(self):
+        r"""
+        Abstract method for forcing the current figure to render.
+        """
+        pass
+
 
 class viewwrapper(object):
     r"""

--- a/menpo/visualize/viewmatplotlib.py
+++ b/menpo/visualize/viewmatplotlib.py
@@ -27,7 +27,8 @@ class MatplotlibRenderer(Renderer):
         # Create the extensions map, have to add . in front of the extensions
         # and map every extension to the savefig method
         n_ext = len(self._supported_ext)
-        func_list = [lambda obj, fp, **kwargs: self.figure.savefig(fp, **obj)] * n_ext
+        func_list = [lambda obj, fp, **kwargs:
+                     self.figure.savefig(fp, **obj)] * n_ext
         self._extensions_map = dict(zip(['.' + s for s in self._supported_ext],
                                     func_list))
 
@@ -129,6 +130,20 @@ class MatplotlibRenderer(Renderer):
         """
         from menpowidgets import save_matplotlib_figure
         save_matplotlib_figure(self)
+
+    def clear_figure(self):
+        r"""
+        Method for clearing the current figure.
+        """
+        self.figure.clf()
+
+    def force_draw(self):
+        r"""
+        Method for forcing the current figure to render. This is useful for
+        the widgets animation.
+        """
+        import matplotlib.pyplot as plt
+        plt.show()
 
 
 class MatplotlibSubplots(object):


### PR DESCRIPTION
This PR exposes various rendering options in the `_view_3d()` and `_view_landmarks_3d()` methods of Menpo's objects. 3D visualization is now equally powerful to 2D and follows the same logic.

This PR depends on https://github.com/menpo/menpo3d/pull/36 .

Note that the only major difference to the 2D case is the fact that the default value of `new_figure` argument is set to ``True``.