### PR TITLE
Fix NUMPY_INC_PATH detection for multiple dirs found

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -14,12 +14,16 @@ IS_WIN = 'windows' == SYS_PLATFORM
 NUMPY_INC_PATHS = [os.path.join(r, 'numpy', 'core', 'include') 
                    for r in site.getsitepackages() if 
                    os.path.isdir(os.path.join(r, 'numpy', 'core', 'include'))]
-if len(NUMPY_INC_PATHS) != 1:
-    print("Warning expected a single numpy include dir and found "
-          "{}: {}".format(len(NUMPY_INC_PATHS), ', '.join(NUMPY_INC_PATHS)))
-    NUMPY_INC_PATH = ''
-else:
-    NUMPY_INC_PATH = NUMPY_INC_PATHS[0]
+if len(NUMPY_INC_PATHS) == 0:
+    raise ValueError("Could not find numpy include dir - cannot proceed with "
+                     "compilation of cython modules.")
+elif len(NUMPY_INC_PATHS) > 1:
+    print("Found {} numpy include dirs: "
+          "{}".format(len(NUMPY_INC_PATHS), ', '.join(NUMPY_INC_PATHS)))
+    print("Taking first (highest precedence on path): {}".format(
+        NUMPY_INC_PATHS[0]))
+NUMPY_INC_PATH = NUMPY_INC_PATHS[0]
+
 
 # ---- C/C++ EXTENSIONS ---- #
 # Stolen (and modified) from the Cython documentation:


### PR DESCRIPTION
The newly added in `v0.7.5` `NUMPY_INC_PATH` detection code would fail in the case of multiple numpy include dirs found. This shouldn't be the case - we should just select the first of the directories found, which being the first on the include path, is the highest precedence.