### PR TITLE
Fix pip install by properly including source files

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,3 +1,7 @@
 include LICENSE.txt
 include AUTHORS.txt
 include versioneer.py
+include menpo *.h
+include menpo *.cpp
+include menpo *.pyx
+include menpo *.pxd

--- a/setup.py
+++ b/setup.py
@@ -10,6 +10,7 @@ SYS_PLATFORM = platform.system().lower()
 IS_LINUX = 'linux' in SYS_PLATFORM
 IS_OSX = 'darwin' == SYS_PLATFORM
 IS_WIN = 'windows' == SYS_PLATFORM
+
 # Get Numpy include path without importing it
 NUMPY_INC_PATHS = [os.path.join(r, 'numpy', 'core', 'include') 
                    for r in site.getsitepackages() if 
@@ -105,7 +106,6 @@ setup(name='menpo',
       ext_modules=cython_exts,
       packages=find_packages(),
       install_requires=install_requires,
-      package_data={'menpo': ['data/*'],
-                    '': ['*.pxd', '*.pyx', '*.h', '*.cpp']},
+      package_data={'menpo': ['data/*']},
       tests_require=['nose', 'mock']
 )


### PR DESCRIPTION
I misunderstood how the packaging worked and naively used
the package-data key to add the header and cpp files to the menpo
install directories. However, this only works for cpp and header
files are that inside **packages**. So it doesn't include, for
example, headers in places such as the cpp/ folders we use.
Thus, we revert back to using the MANIFEST.in and remove
the package-data as we never need to rebuild menpo when
installed in site-packages directly.