### PR TITLE
Allow Pillow 4.x

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,3 +1,7 @@
 include LICENSE.txt
 include AUTHORS.txt
 include versioneer.py
+include menpo *.h
+include menpo *.cpp
+include menpo *.pyx
+include menpo *.pxd

--- a/conda/meta.yaml
+++ b/conda/meta.yaml
@@ -23,7 +23,7 @@ requirements:
     # Scientific Python Stack
     - numpy >=1.10,<2.0
     - scipy >=0.16,<1.0
-    - pillow >=3.0,<4.0
+    - pillow >=3.0,<5.0
     - ffmpeg >=2.7,<3.0
 
     # Features

--- a/setup.py
+++ b/setup.py
@@ -92,7 +92,7 @@ cython_exts = cythonize(cython_modules, quiet=True)
 install_requires = ['numpy>=1.10,<2.0',
                     'scipy>=0.16,<1.0',
                     'matplotlib>=1.4,<2.0',
-                    'pillow>=3.0,<4.0']
+                    'pillow>=3.0,<5.0']
 
 if sys.version_info.major == 2:
     install_requires.append('pathlib==1.0')

--- a/setup.py
+++ b/setup.py
@@ -10,6 +10,7 @@ SYS_PLATFORM = platform.system().lower()
 IS_LINUX = 'linux' in SYS_PLATFORM
 IS_OSX = 'darwin' == SYS_PLATFORM
 IS_WIN = 'windows' == SYS_PLATFORM
+
 # Get Numpy include path without importing it
 NUMPY_INC_PATHS = [os.path.join(r, 'numpy', 'core', 'include') 
                    for r in site.getsitepackages() if 
@@ -105,7 +106,6 @@ setup(name='menpo',
       ext_modules=cython_exts,
       packages=find_packages(),
       install_requires=install_requires,
-      package_data={'menpo': ['data/*'],
-                    '': ['*.pxd', '*.pyx', '*.h', '*.cpp']},
+      package_data={'menpo': ['data/*']},
       tests_require=['nose', 'mock']
 )


### PR DESCRIPTION
Looking at the release notes, the major version bump was due to dropping support for Python 2.6 and 3.2, which we don't support either. So I feel safe in doing this.

To be merged after #774.