### PR TITLE
Manifest includes should be recursive

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,7 +1,7 @@
 include LICENSE.txt
 include AUTHORS.txt
 include versioneer.py
-include menpo *.h
-include menpo *.cpp
-include menpo *.pyx
-include menpo *.pxd
+recursive-include menpo *.h
+recursive-include menpo *.cpp
+recursive-include menpo *.pyx
+recursive-include menpo *.pxd

--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -13,10 +13,12 @@ Github Pull Requests
 - `#767`_ Minor fixes (@patricksnape)
 - `#774`_ Fix pip install by properly including source files (@patricksnape)
 - `#775`_ Allow Pillow 4.x  (@patricksnape)
+- `#776`_ Manifest includes should be recursive (@jabooth)
 
 .. _#767: https://github.com/menpo/menpo/pull/767
 .. _#774: https://github.com/menpo/menpo/pull/774
 .. _#775: https://github.com/menpo/menpo/pull/775
+.. _#776: https://github.com/menpo/menpo/pull/776
 
 0.7.6 (2016/12/10)
 ------------------


### PR DESCRIPTION
Further fix on top of #774 - we need to recursively include headers etc to ensure they are included.