### PR TITLE
Print an informative message for Procrustes when failing to converge.

### DIFF
--- a/menpo/transform/groupalign/procrustes.py
+++ b/menpo/transform/groupalign/procrustes.py
@@ -46,6 +46,8 @@ class GeneralizedProcrustesAnalysis(MultipleAlignment):
         self.converged = self._recursive_procrustes()
         if target is not None:
             self.target = initial_target
+        if not self.converged:
+            print(self)
 
     def _recursive_procrustes(self):
         r"""


### PR DESCRIPTION
It took a while to realise in a framework that procrustes had failed, maily because it does not print any informative message when it fails. 

Maybe you would like a different message to be printed, however it takes a while to figure it out without any message (it was required to check out the raw code). 