### PR TITLE
add support for ipython tab complete landmarks

### DIFF
--- a/menpo/landmark/base.py
+++ b/menpo/landmark/base.py
@@ -219,6 +219,11 @@ class LandmarkManager(MutableMapping, Transformable):
 
         self.__dict__ = state
 
+    def _ipython_key_completions_(self):
+        # Opt in to IPython tab completion - see
+        # https://github.com/ipython/ipython/blob/5.2.2/docs/source/config/integrating.rst
+        return list(self)
+
     @property
     def n_groups(self):
         """


### PR DESCRIPTION
With IPython it's now possible to customise what keys appear in tab completion for an object.

With this PR, typing `landmarks[<TAB>` gives:
<img width="771" alt="screenshot 2017-02-07 19 10 30" src="https://cloud.githubusercontent.com/assets/1312873/22731327/23480bf8-ede2-11e6-9b16-5e93e97ce560.png">

(Notice this file only has one landmark group, `'LJSON'`, and it's handily near the top of the list).

If you start typing more of a key name and hit tab then:
<img width="751" alt="screenshot 2017-02-07 19 11 22" src="https://cloud.githubusercontent.com/assets/1312873/22731464/ac7e729a-ede2-11e6-9ab5-dfa0c96285c7.png">

You unfortunately currently get a mixture of all globals (`LookupError`), local paths `Library/` in this case) and the valid keys.

Still, this is a way better experience that what we currently have, and it's a trivial addition to menpo to support it.