### PR TITLE
__repr__ return __str__ for all Copyable objects

### DIFF
--- a/menpo/base.py
+++ b/menpo/base.py
@@ -37,6 +37,14 @@ class Copyable(object):
                 new.__dict__[k] = v
         return new
 
+    def __repr__(self):
+        # Most classes in Menpo derive from Copyable, so it's a handy place
+        # to implement Menpo-wide behavior. For use in the notebook, we find
+        # __repr__ representations not of very much use, so we default to
+        # showing the string representation for this case. See
+        # https://github.com/menpo/menpo/issues/752 for discussion.
+        return self.__str__()
+
 
 class Vectorizable(Copyable):
     """


### PR DESCRIPTION
See #752 for discussion.

This maps `__repr__` to return `__str__` for all `Copyable` objects (i.e. neigh on everything in Menpo).

It's a strange mixture of concerns, but for a two line addition it actually makes a profound difference to discoverability and usability in the notebook.

Before:
<img width="728" alt="screenshot 2017-02-08 09 54 39" src="https://cloud.githubusercontent.com/assets/1312873/22732037/a8629964-ede4-11e6-9129-ee6da2a36a22.png">

After:
<img width="722" alt="screenshot 2017-02-08 09 54 22" src="https://cloud.githubusercontent.com/assets/1312873/22732046/ae3572c6-ede4-11e6-9e9b-eb86c30a1f34.png">