### PR TITLE
3D LabelledPointUndirectedGraph visualization

### DIFF
--- a/menpo/landmark/base.py
+++ b/menpo/landmark/base.py
@@ -143,7 +143,7 @@ class LandmarkManager(MutableMapping, Transformable):
     def __setitem__(self, group, value):
         """
         Sets a new landmark group for the given label. This can be set using
-        an any :map`PointCloud` subclass. Existing landmark groups will be
+        any :map`PointCloud` subclass. Existing landmark groups will be
         replaced.
 
         Parameters

--- a/menpo/shape/graph.py
+++ b/menpo/shape/graph.py
@@ -2273,7 +2273,7 @@ class PointGraph(Graph, PointCloud):
         return landmark_view
 
     def _view_3d(self, figure_id=None, new_figure=True, render_lines=True,
-                 line_colour='r', line_width=4, render_markers=True,
+                 line_colour='r', line_width=2, render_markers=True,
                  marker_style='sphere', marker_size=None, marker_colour='k',
                  marker_resolution=8, step=None, alpha=1.0,
                  render_numbering=False, numbers_colour='k', numbers_size=None):

--- a/menpo/shape/labelled.py
+++ b/menpo/shape/labelled.py
@@ -739,11 +739,32 @@ class LabelledPointUndirectedGraph(PointUndirectedGraph):
             axes_y_limits=axes_y_limits, axes_x_ticks=axes_x_ticks,
             axes_y_ticks=axes_y_ticks, figure_size=figure_size)
 
-    def _view_3d(self, figure_id=None, new_figure=False, **kwargs):
+    def _view_3d(self, with_labels=None, without_labels=None, group='group',
+                 figure_id=None, new_figure=False, render_lines=True,
+                 line_colour=None, line_width=2, render_markers=True,
+                 marker_style='sphere', marker_size=None, marker_colour=None,
+                 marker_resolution=8, step=None, alpha=1.0,
+                 render_numbering=False, numbers_colour='k', numbers_size=None):
         try:
             from menpo3d.visualize import LandmarkViewer3d
-            return LandmarkViewer3d(
-                figure_id, new_figure, self).render(**kwargs)
+            if with_labels is not None and without_labels is not None:
+                raise ValueError('You may only pass one of `with_labels` or '
+                                 '`without_labels`.')
+            elif with_labels is not None:
+                lmark_group = self.with_labels(with_labels)
+            elif without_labels is not None:
+                lmark_group = self.without_labels(without_labels)
+            else:
+                lmark_group = self  # Fall through
+            landmark_viewer = LandmarkViewer3d(figure_id, new_figure,
+                                               group, lmark_group)
+            return landmark_viewer.render(
+                render_lines=render_lines, line_colour=line_colour,
+                line_width=line_width, render_markers=render_markers,
+                marker_style=marker_style, marker_size=marker_size,
+                marker_colour=marker_colour, marker_resolution=marker_resolution,
+                step=step, alpha=alpha, render_numbering=render_numbering,
+                numbers_colour=numbers_colour, numbers_size=numbers_size)
         except ImportError:
             from menpo.visualize import Menpo3dMissingError
             raise Menpo3dMissingError()


### PR DESCRIPTION
This PR fixes the visualization of a 3D LabelledPointUndirectedGraph which was broken. It is part of the 3D widgets in `menpowidgets` and should be merged with https://github.com/menpo/menpo3d/pull/48.