### PR TITLE
Fallback to querying numpy for inc dir

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -12,12 +12,19 @@ IS_OSX = 'darwin' == SYS_PLATFORM
 IS_WIN = 'windows' == SYS_PLATFORM
 
 # Get Numpy include path without importing it
-NUMPY_INC_PATHS = [os.path.join(r, 'numpy', 'core', 'include') 
-                   for r in site.getsitepackages() if 
+NUMPY_INC_PATHS = [os.path.join(r, 'numpy', 'core', 'include')
+                   for r in site.getsitepackages() if
                    os.path.isdir(os.path.join(r, 'numpy', 'core', 'include'))]
 if len(NUMPY_INC_PATHS) == 0:
-    raise ValueError("Could not find numpy include dir - cannot proceed with "
-                     "compilation of cython modules.")
+    try:
+        import numpy as np
+    except ImportError:
+        raise ValueError("Could not find numpy include dir and numpy not installed before build - "
+                         "cannot proceed with compilation of cython modules.")
+    else:
+        # just ask numpy for it's include dir
+        NUMPY_INC_PATHS = [np.get_include()]
+
 elif len(NUMPY_INC_PATHS) > 1:
     print("Found {} numpy include dirs: "
           "{}".format(len(NUMPY_INC_PATHS), ', '.join(NUMPY_INC_PATHS)))


### PR DESCRIPTION
We changed to use `site.getsitepackages()` to find numpy's incude dir to avoid having to import `numpy` at `setup.py` invocation. That's great, but in some environments that means we will not find `numpy` correctly.

This doesn't change initial behavior, but at the point where we used to give up and fail to install it will now attempt to `import numpy` to find the include path. If `numpy` fails to import then we back out as before.