### PR TITLE
Fix edge_vectors() when dim!=2

### DIFF
--- a/menpo/shape/mesh/base.py
+++ b/menpo/shape/mesh/base.py
@@ -495,7 +495,7 @@ class TriMesh(PointCloud):
         t = self.points[self.trilist]
         return np.hstack(
             (t[:, 1] - t[:, 0], t[:, 2] - t[:, 1], t[:, 2] - t[:, 0])
-        ).reshape(-1, 2)
+        ).reshape(-1, self.n_dims)
 
     def edge_indices(self):
         r"""An unordered index into points that rebuilds the edges of this


### PR DESCRIPTION
As reported in #868 - the hardcoded 2 applies to the dimension
axis and thus is currently hardcoded to 2D only pointclouds.